### PR TITLE
Add store nudge and Claude Code auto-extract hook

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -432,6 +432,8 @@ enum InitMode {
     Cli,
     /// Claude Code slash commands /recall and /remember
     Skill,
+    /// Claude Code PostToolUse hook (auto-extract context)
+    Hook,
     /// All integration modes
     All,
 }
@@ -820,6 +822,7 @@ fn cmd_init(mode: InitMode) -> Result<()> {
     let do_mcp = matches!(mode, InitMode::Mcp | InitMode::All);
     let do_cli = matches!(mode, InitMode::Cli | InitMode::All);
     let do_skill = matches!(mode, InitMode::Skill | InitMode::All);
+    let do_hook = matches!(mode, InitMode::Hook | InitMode::All);
 
     // --- MCP mode: configure MCP servers for all detected tools ---
     if do_mcp {
@@ -1034,6 +1037,32 @@ After completing significant work, store a summary:
         )?;
     }
 
+    // --- Hook mode: install Claude Code PostToolUse hook ---
+    if do_hook {
+        let claude_settings_path = PathBuf::from(&home).join(".claude/settings.json");
+        let hook_dir = PathBuf::from(&home).join(".claude/hooks");
+        std::fs::create_dir_all(&hook_dir).ok();
+
+        // Write the hook script
+        let hook_script_path = hook_dir.join("icm-post-tool.sh");
+        let hook_script = include_str!("../../../scripts/hooks/icm-post-tool.sh");
+        if hook_script_path.exists() {
+            println!("[hook] icm-post-tool.sh already exists, updating.");
+        }
+        std::fs::write(&hook_script_path, hook_script).context("cannot write hook script")?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&hook_script_path, std::fs::Permissions::from_mode(0o755))
+                .ok();
+        }
+
+        // Inject into settings.json
+        let hook_cmd = hook_script_path.to_string_lossy().to_string();
+        let status = inject_claude_hook(&claude_settings_path, &hook_cmd)?;
+        println!("[hook] Claude Code PostToolUse: {status}");
+    }
+
     println!();
     println!("  binary: {icm_bin_str}");
     println!("  db:     {}", default_db_path().display());
@@ -1041,6 +1070,68 @@ After completing significant work, store a summary:
     println!("Restart your AI tool to activate.");
 
     Ok(())
+}
+
+/// Inject ICM PostToolUse hook into Claude Code settings.json
+fn inject_claude_hook(settings_path: &PathBuf, hook_command: &str) -> Result<String> {
+    let mut config: Value = if settings_path.exists() {
+        let content = std::fs::read_to_string(settings_path)
+            .with_context(|| format!("cannot read {}", settings_path.display()))?;
+        serde_json::from_str(&content)
+            .with_context(|| format!("cannot parse {}", settings_path.display()))?
+    } else {
+        serde_json::json!({})
+    };
+
+    let hooks = config
+        .as_object_mut()
+        .context("settings is not a JSON object")?
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}));
+
+    let post_tool = hooks
+        .as_object_mut()
+        .context("hooks is not a JSON object")?
+        .entry("PostToolUse")
+        .or_insert_with(|| serde_json::json!([]));
+
+    let post_tool_arr = post_tool
+        .as_array_mut()
+        .context("PostToolUse is not an array")?;
+
+    // Check if ICM hook already exists
+    let already = post_tool_arr.iter().any(|entry| {
+        entry
+            .get("hooks")
+            .and_then(|h| h.as_array())
+            .map(|hooks| {
+                hooks.iter().any(|h| {
+                    h.get("command")
+                        .and_then(|c| c.as_str())
+                        .map(|c| c.contains("icm-post-tool"))
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false)
+    });
+
+    if already {
+        return Ok("already configured".into());
+    }
+
+    // Add ICM hook entry (matches all tools except ICM's own)
+    post_tool_arr.push(serde_json::json!({
+        "hooks": [{
+            "type": "command",
+            "command": hook_command
+        }]
+    }));
+
+    let output = serde_json::to_string_pretty(&config)?;
+    std::fs::write(settings_path, output)
+        .with_context(|| format!("cannot write {}", settings_path.display()))?;
+
+    Ok("configured".into())
 }
 
 /// Install a skill/rule file if it doesn't exist yet.

--- a/crates/icm-mcp/src/protocol.rs
+++ b/crates/icm-mcp/src/protocol.rs
@@ -93,4 +93,11 @@ impl ToolResult {
             is_error: true,
         }
     }
+
+    /// Append a hint to the last text content block.
+    pub fn append_hint(&mut self, hint: &str) {
+        if let Some(last) = self.content.last_mut() {
+            last.text.push_str(hint);
+        }
+    }
 }

--- a/crates/icm-mcp/src/server.rs
+++ b/crates/icm-mcp/src/server.rs
@@ -13,6 +13,9 @@ const SERVER_NAME: &str = "icm";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const PROTOCOL_VERSION: &str = "2024-11-05";
 
+/// Number of non-store tool calls before we nudge the agent to store.
+const STORE_NUDGE_THRESHOLD: u32 = 10;
+
 /// Run the MCP server on stdio. Blocks until stdin is closed.
 pub fn run_server(
     store: &SqliteStore,
@@ -21,6 +24,7 @@ pub fn run_server(
 ) -> anyhow::Result<()> {
     let stdin = io::stdin();
     let mut stdout = io::stdout();
+    let mut calls_since_store: u32 = 0;
 
     for line in stdin.lock().lines() {
         let line = match line {
@@ -60,7 +64,14 @@ pub fn run_server(
             "initialize" => handle_initialize(id),
             "ping" => JsonRpcResponse::ok(id, json!({})),
             "tools/list" => handle_tools_list(id, embedder.is_some()),
-            "tools/call" => handle_tools_call(id, &msg.params, store, embedder, compact),
+            "tools/call" => handle_tools_call(
+                id,
+                &msg.params,
+                store,
+                embedder,
+                compact,
+                &mut calls_since_store,
+            ),
             other => JsonRpcResponse::method_not_found(id, other),
         };
 
@@ -106,6 +117,14 @@ STORE (icm_memory_store): Automatically store important information:\n\
 - User preferences discovered in session → topic: \"preferences\"\n\
 - Project context after significant work → topic: \"context-{project}\"\n\
 \n\
+IMPORTANT — Store frequently. Your context window will be compacted without warning, and \
+any unstored information will be lost forever. Store after:\n\
+- Resolving a bug or error\n\
+- Making an architecture or design decision\n\
+- Discovering a user preference\n\
+- Completing a significant piece of work\n\
+If ICM reminds you to store, do it immediately.\n\
+\n\
 Do NOT store: trivial details, information already in CLAUDE.md, ephemeral state.\n\
 \n\
 Importance levels: critical (never forgotten), high (slow decay), medium (normal), low (fast decay).";
@@ -120,6 +139,7 @@ fn handle_tools_call(
     store: &SqliteStore,
     embedder: Option<&dyn Embedder>,
     compact: bool,
+    calls_since_store: &mut u32,
 ) -> JsonRpcResponse {
     let params = match params {
         Some(p) => p,
@@ -137,6 +157,23 @@ fn handle_tools_call(
 
     let args = params.get("arguments").cloned().unwrap_or(json!({}));
 
-    let result = tools::call_tool(store, embedder, tool_name, &args, compact);
+    // Track store calls to nudge the agent
+    if tool_name == "icm_memory_store" {
+        *calls_since_store = 0;
+    } else {
+        *calls_since_store += 1;
+    }
+
+    let mut result = tools::call_tool(store, embedder, tool_name, &args, compact);
+
+    // Nudge: append a store reminder if too many calls without storing
+    if *calls_since_store >= STORE_NUDGE_THRESHOLD && tool_name != "icm_memory_store" {
+        result.append_hint(&format!(
+            "\n[ICM: {} tool calls since last store. \
+             Consider saving important context with icm_memory_store before it is lost.]",
+            calls_since_store
+        ));
+    }
+
     JsonRpcResponse::ok(id, serde_json::to_value(result).unwrap_or(json!(null)))
 }

--- a/scripts/hooks/icm-post-tool.sh
+++ b/scripts/hooks/icm-post-tool.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# ICM PostToolUse hook for Claude Code
+# Counts tool calls and auto-extracts context every N calls.
+# Install: icm init --mode hook (or manually add to ~/.claude/settings.json)
+#
+# Input (stdin): JSON with tool_name, tool_input, tool_output, etc.
+# Output: nothing (PostToolUse hooks are fire-and-forget)
+
+set -euo pipefail
+
+# Config
+EXTRACT_EVERY=15           # Extract every N tool calls
+COUNTER_FILE="${ICM_HOOK_COUNTER:-/tmp/icm-hook-counter-$$}"
+ICM_BIN="${ICM_BIN:-icm}"
+
+# Read hook input
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+
+# Skip ICM's own tools (avoid infinite loop)
+case "$TOOL_NAME" in
+  icm_*|mcp__icm__*) exit 0 ;;
+esac
+
+# Increment counter
+COUNT=0
+if [ -f "$COUNTER_FILE" ]; then
+  COUNT=$(cat "$COUNTER_FILE" 2>/dev/null || echo "0")
+fi
+COUNT=$((COUNT + 1))
+echo "$COUNT" > "$COUNTER_FILE"
+
+# Reset counter on icm_memory_store (agent stored voluntarily)
+if [ "$TOOL_NAME" = "icm_memory_store" ] || [ "$TOOL_NAME" = "mcp__icm__icm_memory_store" ]; then
+  echo "0" > "$COUNTER_FILE"
+  exit 0
+fi
+
+# Not time to extract yet
+if [ "$COUNT" -lt "$EXTRACT_EVERY" ]; then
+  exit 0
+fi
+
+# Reset counter
+echo "0" > "$COUNTER_FILE"
+
+# Extract from tool output if available
+TOOL_OUTPUT=$(echo "$INPUT" | jq -r '.tool_output // empty' 2>/dev/null)
+if [ -z "$TOOL_OUTPUT" ]; then
+  exit 0
+fi
+
+# Get project name from cwd
+PROJECT=$(basename "$(pwd)" 2>/dev/null || echo "project")
+
+# Extract facts and store (async, don't block the agent)
+echo "$TOOL_OUTPUT" | "$ICM_BIN" extract -p "$PROJECT" 2>/dev/null &
+
+exit 0


### PR DESCRIPTION
## Summary
- MCP server tracks tool calls since last `icm_memory_store` and appends a reminder after 10 calls without storing
- Enhanced MCP instructions to emphasize frequent storing before context compaction
- PostToolUse hook (`scripts/hooks/icm-post-tool.sh`) auto-extracts context every 15 tool calls via `icm extract`
- `icm init --mode hook` installs the hook into Claude Code settings

## Test plan
- [ ] Verify nudge appears after 10+ non-store MCP tool calls
- [ ] Verify counter resets on `icm_memory_store`
- [ ] Test hook script: counts calls, skips ICM tools, runs extract in background
- [ ] Test `icm init --mode hook` injects into `~/.claude/settings.json`