### PR TITLE
Add performance tests, improve docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,6 +1188,7 @@ name = "icm-core"
 version = "0.10.0"
 dependencies = [
  "chrono",
+ "directories",
  "fastembed",
  "serde",
  "serde_json",

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -824,3 +824,32 @@ Le serveur compte les appels d'outils consecutifs sans `icm_memory_store`. Apres
 [ICM: 12 tool calls since last store. Consider saving important context.]
 ```
 Le compteur se reinitialise a chaque `icm_memory_store`. C'est un rappel discret pour que l'agent n'oublie pas de stocker.
+
+## Troubleshooting
+
+**Agent doesn't use ICM tools**
+- Run `icm init` and check the output for errors
+- Verify the MCP config file exists for your tool
+- Test manually: `echo '{"jsonrpc":"2.0","id":1,"method":"initialize"}' | icm serve`
+- Check `icm serve` starts without errors
+
+**Recall returns nothing**
+- `icm topics` — are there stored memories?
+- `icm stats` — check total count
+- Try broader queries or remove topic/keyword filters
+- `icm health` — check if memories decayed too much
+
+**Embeddings slow on first run**
+- Normal: model downloads on first use (~100MB for multilingual-e5-base)
+- Subsequent runs load from cache (~1-2s)
+- Build without embeddings: `cargo build --no-default-features`
+
+**Duplicate memories**
+- Auto-dedup works via MCP (>85% similarity in same topic → update)
+- CLI `icm store` does not auto-dedup (no embedder in basic mode)
+- Backfill embeddings: `icm embed`, then dedup happens on next store
+
+**Database issues**
+- WAL mode: safe for concurrent reads, single writer
+- Corruption: `icm stats` will fail → delete DB file and re-populate
+- Migration: automatic on startup, no manual steps needed


### PR DESCRIPTION
## Summary
- 7 perf tests with time assertions (1000 stores, 100x searches, decay, gets)
- Rewritten docs: full trait signatures, tool dispatch table, CLI reference, expanded use cases

## Test plan
- [x] `cargo test` — 110 passed (1.54s)