### PR TITLE
feat: add feedback learning system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,6 +575,41 @@ Topics suggérés:
 - "contexte-{projet}" : Infos spécifiques au projet
 ```
 
+### Feedback (apprentissage par correction)
+
+```rust
+pub struct Feedback {
+    pub id: String,
+    pub topic: String,
+    pub context: String,       // Situation qui a mené à la prédiction
+    pub predicted: String,     // Ce que l'AI a prédit
+    pub corrected: String,     // La bonne réponse
+    pub reason: Option<String>,
+    pub source: String,        // Pipeline source
+    pub created_at: DateTime<Utc>,
+    pub applied_count: u32,    // Nombre de fois où cette correction a été consultée
+}
+```
+
+### MCP Tools Feedback (3)
+
+- `icm_feedback_record` — Enregistrer une correction quand une prédiction AI est fausse
+- `icm_feedback_search` — Rechercher des corrections passées avant de faire une prédiction (FTS5)
+- `icm_feedback_stats` — Statistiques globales des corrections
+
+### FeedbackStore trait
+
+```rust
+pub trait FeedbackStore {
+    fn store_feedback(&self, feedback: Feedback) -> IcmResult<String>;
+    fn search_feedback(&self, query: &str, topic: Option<&str>, limit: usize) -> IcmResult<Vec<Feedback>>;
+    fn list_feedback(&self, topic: Option<&str>, limit: usize) -> IcmResult<Vec<Feedback>>;
+    fn increment_applied(&self, id: &str) -> IcmResult<()>;
+    fn delete_feedback(&self, id: &str) -> IcmResult<()>;
+    fn feedback_stats(&self) -> IcmResult<FeedbackStats>;
+}
+```
+
 ## Implémentation prioritaire
 
 ### Phase 1: Core + Storage (MVP)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "icm-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "fastembed",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "icm-mcp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "icm-store"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "icm-core",

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ ICM gives your AI agent a real memory — not a note-taking tool, not a context 
 
 - **Memories** — store/recall with temporal decay by importance. Critical memories never fade, low-importance ones decay naturally. Filter by topic or keyword.
 - **Memoirs** — permanent knowledge graphs. Concepts linked by typed relations (`depends_on`, `contradicts`, `superseded_by`, ...). Filter by label.
+- **Feedback** — record corrections when AI predictions are wrong. Search past mistakes before making new predictions. Closed-loop learning.
 
 ## Install
 
@@ -147,7 +148,7 @@ icm memoir search -m "system-architecture" "service" --label "domain:auth"
 icm memoir inspect -m "system-architecture" "auth-service" -D 2
 ```
 
-## MCP Tools (18)
+## MCP Tools (21)
 
 ### Memory tools
 
@@ -176,6 +177,14 @@ icm memoir inspect -m "system-architecture" "auth-service" -D 2
 | `icm_memoir_search_all` | Search across all memoirs |
 | `icm_memoir_link` | Create typed relation between concepts |
 | `icm_memoir_inspect` | Inspect concept and graph neighborhood (BFS) |
+
+### Feedback tools (learning from mistakes)
+
+| Tool | Description |
+|------|-------------|
+| `icm_feedback_record` | Record a correction when an AI prediction was wrong |
+| `icm_feedback_search` | Search past corrections to inform future predictions |
+| `icm_feedback_stats` | Feedback statistics: total count, breakdown by topic, most applied |
 
 ### Relation types
 

--- a/crates/icm-core/src/feedback.rs
+++ b/crates/icm-core/src/feedback.rs
@@ -1,0 +1,45 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Feedback {
+    pub id: String,
+    pub topic: String,
+    pub context: String,
+    pub predicted: String,
+    pub corrected: String,
+    pub reason: Option<String>,
+    pub source: String,
+    pub created_at: DateTime<Utc>,
+    pub applied_count: u32,
+}
+
+impl Feedback {
+    pub fn new(
+        topic: String,
+        context: String,
+        predicted: String,
+        corrected: String,
+        reason: Option<String>,
+        source: String,
+    ) -> Self {
+        Self {
+            id: ulid::Ulid::new().to_string(),
+            topic,
+            context,
+            predicted,
+            corrected,
+            reason,
+            source,
+            created_at: Utc::now(),
+            applied_count: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeedbackStats {
+    pub total: usize,
+    pub by_topic: Vec<(String, usize)>,
+    pub most_applied: Vec<(String, u32)>,
+}

--- a/crates/icm-core/src/feedback_store.rs
+++ b/crates/icm-core/src/feedback_store.rs
@@ -1,0 +1,16 @@
+use crate::error::IcmResult;
+use crate::feedback::{Feedback, FeedbackStats};
+
+pub trait FeedbackStore {
+    fn store_feedback(&self, feedback: Feedback) -> IcmResult<String>;
+    fn search_feedback(
+        &self,
+        query: &str,
+        topic: Option<&str>,
+        limit: usize,
+    ) -> IcmResult<Vec<Feedback>>;
+    fn list_feedback(&self, topic: Option<&str>, limit: usize) -> IcmResult<Vec<Feedback>>;
+    fn increment_applied(&self, id: &str) -> IcmResult<()>;
+    fn delete_feedback(&self, id: &str) -> IcmResult<()>;
+    fn feedback_stats(&self) -> IcmResult<FeedbackStats>;
+}

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod embedder;
 pub mod error;
+pub mod feedback;
+pub mod feedback_store;
 #[cfg(feature = "embeddings")]
 pub mod fastembed_embedder;
 pub mod memoir;
@@ -9,6 +11,8 @@ pub mod store;
 
 pub use embedder::Embedder;
 pub use error::{IcmError, IcmResult};
+pub use feedback::{Feedback, FeedbackStats};
+pub use feedback_store::FeedbackStore;
 #[cfg(feature = "embeddings")]
 pub use fastembed_embedder::FastEmbedder;
 pub use memoir::{Concept, ConceptLink, Label, Memoir, MemoirStats, Relation};

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -2,7 +2,8 @@ use chrono::Utc;
 use serde_json::{json, Value};
 
 use icm_core::{
-    Concept, ConceptLink, Embedder, Label, Memoir, MemoirStore, Memory, MemoryStore, Relation,
+    Concept, ConceptLink, Embedder, Feedback, FeedbackStore, Label, Memoir, MemoirStore, Memory,
+    MemoryStore, Relation,
 };
 use icm_store::SqliteStore;
 
@@ -351,6 +352,74 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["query"]
             }
         }),
+        // --- Feedback tools ---
+        json!({
+            "name": "icm_feedback_record",
+            "description": "Record a correction/feedback when an AI prediction was wrong. Helps improve future predictions by learning from mistakes.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "topic": {
+                        "type": "string",
+                        "description": "Category/namespace for this feedback (e.g. 'triage-owner/repo', 'pr-analysis')"
+                    },
+                    "context": {
+                        "type": "string",
+                        "description": "What was the situation / input that led to the prediction"
+                    },
+                    "predicted": {
+                        "type": "string",
+                        "description": "What the AI predicted or did"
+                    },
+                    "corrected": {
+                        "type": "string",
+                        "description": "What the correct answer/action should have been"
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Why the correction was made (optional)"
+                    },
+                    "source": {
+                        "type": "string",
+                        "description": "Which tool/pipeline generated the prediction (optional)"
+                    }
+                },
+                "required": ["topic", "context", "predicted", "corrected"]
+            }
+        }),
+        json!({
+            "name": "icm_feedback_search",
+            "description": "Search past feedback/corrections to inform current predictions. Use before making predictions to learn from past mistakes.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search query to find relevant past corrections"
+                    },
+                    "topic": {
+                        "type": "string",
+                        "description": "Filter by topic (optional)"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 5,
+                        "minimum": 1,
+                        "maximum": 20,
+                        "description": "Max number of results"
+                    }
+                },
+                "required": ["query"]
+            }
+        }),
+        json!({
+            "name": "icm_feedback_stats",
+            "description": "Get feedback statistics: total count, breakdown by topic, most applied corrections.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {}
+            }
+        }),
     ];
 
     if has_embedder {
@@ -404,6 +473,10 @@ pub fn call_tool(
         "icm_memoir_search_all" => tool_memoir_search_all(store, args),
         "icm_memoir_link" => tool_memoir_link(store, args),
         "icm_memoir_inspect" => tool_memoir_inspect(store, args),
+        // Feedback tools
+        "icm_feedback_record" => tool_feedback_record(store, args, compact),
+        "icm_feedback_search" => tool_feedback_search(store, args),
+        "icm_feedback_stats" => tool_feedback_stats(store),
         _ => ToolResult::error(format!("unknown tool: {name}")),
     }
 }
@@ -1783,6 +1856,155 @@ mod tests {
             assert!(!list.is_error);
         }
     }
+
+    // === Feedback tool tests ===
+
+    #[test]
+    fn test_feedback_record_missing_fields() {
+        let store = test_store();
+        let result = call_tool(
+            &store,
+            None,
+            "icm_feedback_record",
+            &json!({"topic": "test"}),
+            false,
+        );
+        assert!(result.is_error);
+        assert!(result.content[0].text.contains("context"));
+    }
+
+    #[test]
+    fn test_feedback_record_and_search_roundtrip() {
+        let store = test_store();
+        let result = call_tool(
+            &store,
+            None,
+            "icm_feedback_record",
+            &json!({
+                "topic": "triage",
+                "context": "issue about memory leak in connection pool",
+                "predicted": "low priority",
+                "corrected": "high priority",
+                "reason": "memory leaks are always high priority"
+            }),
+            false,
+        );
+        assert!(!result.is_error);
+        assert!(result.content[0].text.contains("Feedback recorded"));
+
+        let search = call_tool(
+            &store,
+            None,
+            "icm_feedback_search",
+            &json!({"query": "memory leak"}),
+            false,
+        );
+        assert!(!search.is_error);
+        assert!(search.content[0].text.contains("memory leak"));
+        assert!(search.content[0].text.contains("high priority"));
+    }
+
+    #[test]
+    fn test_feedback_record_compact_mode() {
+        let store = test_store();
+        let result = call_tool(
+            &store,
+            None,
+            "icm_feedback_record",
+            &json!({
+                "topic": "test",
+                "context": "ctx",
+                "predicted": "a",
+                "corrected": "b"
+            }),
+            true,
+        );
+        assert!(!result.is_error);
+        assert!(result.content[0].text.starts_with("ok "));
+    }
+
+    #[test]
+    fn test_feedback_search_missing_query() {
+        let store = test_store();
+        let result = call_tool(
+            &store,
+            None,
+            "icm_feedback_search",
+            &json!({}),
+            false,
+        );
+        assert!(result.is_error);
+        assert!(result.content[0].text.contains("query"));
+    }
+
+    #[test]
+    fn test_feedback_search_empty_results() {
+        let store = test_store();
+        let result = call_tool(
+            &store,
+            None,
+            "icm_feedback_search",
+            &json!({"query": "nonexistent"}),
+            false,
+        );
+        assert!(!result.is_error);
+        assert!(result.content[0].text.contains("No feedback found"));
+    }
+
+    #[test]
+    fn test_feedback_stats_empty() {
+        let store = test_store();
+        let result = call_tool(
+            &store,
+            None,
+            "icm_feedback_stats",
+            &json!({}),
+            false,
+        );
+        assert!(!result.is_error);
+        assert!(result.content[0].text.contains("Feedback total: 0"));
+    }
+
+    #[test]
+    fn test_feedback_stats_with_data() {
+        let store = test_store();
+        call_tool(
+            &store,
+            None,
+            "icm_feedback_record",
+            &json!({
+                "topic": "triage",
+                "context": "ctx1",
+                "predicted": "a",
+                "corrected": "b"
+            }),
+            false,
+        );
+        call_tool(
+            &store,
+            None,
+            "icm_feedback_record",
+            &json!({
+                "topic": "pr-review",
+                "context": "ctx2",
+                "predicted": "c",
+                "corrected": "d"
+            }),
+            false,
+        );
+
+        let result = call_tool(
+            &store,
+            None,
+            "icm_feedback_stats",
+            &json!({}),
+            false,
+        );
+        assert!(!result.is_error);
+        assert!(result.content[0].text.contains("Feedback total: 2"));
+        assert!(result.content[0].text.contains("triage"));
+        assert!(result.content[0].text.contains("pr-review"));
+    }
 }
 
 fn tool_memoir_inspect(store: &SqliteStore, args: &Value) -> ToolResult {
@@ -1847,4 +2069,107 @@ fn tool_memoir_inspect(store: &SqliteStore, args: &Value) -> ToolResult {
     }
 
     ToolResult::text(output)
+}
+
+// ---------------------------------------------------------------------------
+// Feedback tool handlers
+// ---------------------------------------------------------------------------
+
+fn tool_feedback_record(store: &SqliteStore, args: &Value, compact: bool) -> ToolResult {
+    let topic = match get_str(args, "topic") {
+        Some(t) => t,
+        None => return ToolResult::error("missing required field: topic".into()),
+    };
+    let context = match get_str(args, "context") {
+        Some(c) => c,
+        None => return ToolResult::error("missing required field: context".into()),
+    };
+    let predicted = match get_str(args, "predicted") {
+        Some(p) => p,
+        None => return ToolResult::error("missing required field: predicted".into()),
+    };
+    let corrected = match get_str(args, "corrected") {
+        Some(c) => c,
+        None => return ToolResult::error("missing required field: corrected".into()),
+    };
+    let reason = get_str(args, "reason").map(|s| s.to_string());
+    let source = get_str(args, "source").unwrap_or("").to_string();
+
+    let feedback = Feedback::new(
+        topic.into(),
+        context.into(),
+        predicted.into(),
+        corrected.into(),
+        reason,
+        source,
+    );
+
+    let id = feedback.id.clone();
+    match store.store_feedback(feedback) {
+        Ok(_) => {
+            if compact {
+                ToolResult::text(format!("ok {id}"))
+            } else {
+                ToolResult::text(format!("Feedback recorded: {id}\n  topic: {topic}\n  predicted: {predicted}\n  corrected: {corrected}"))
+            }
+        }
+        Err(e) => ToolResult::error(format!("failed to store feedback: {e}")),
+    }
+}
+
+fn tool_feedback_search(store: &SqliteStore, args: &Value) -> ToolResult {
+    let query = match get_str(args, "query") {
+        Some(q) => q,
+        None => return ToolResult::error("missing required field: query".into()),
+    };
+    let topic = get_str(args, "topic");
+    let limit = get_i64(args, "limit", 5) as usize;
+
+    match store.search_feedback(query, topic, limit) {
+        Ok(results) => {
+            if results.is_empty() {
+                return ToolResult::text("No feedback found.".into());
+            }
+            let mut output = String::new();
+            for fb in &results {
+                output.push_str(&format!(
+                    "--- {} [{}] ---\n  context: {}\n  predicted: {}\n  corrected: {}\n",
+                    fb.id, fb.topic, fb.context, fb.predicted, fb.corrected
+                ));
+                if let Some(ref reason) = fb.reason {
+                    output.push_str(&format!("  reason: {reason}\n"));
+                }
+                if !fb.source.is_empty() {
+                    output.push_str(&format!("  source: {}\n", fb.source));
+                }
+                if fb.applied_count > 0 {
+                    output.push_str(&format!("  applied: {} times\n", fb.applied_count));
+                }
+            }
+            ToolResult::text(output)
+        }
+        Err(e) => ToolResult::error(format!("failed to search feedback: {e}")),
+    }
+}
+
+fn tool_feedback_stats(store: &SqliteStore) -> ToolResult {
+    match store.feedback_stats() {
+        Ok(stats) => {
+            let mut output = format!("Feedback total: {}\n", stats.total);
+            if !stats.by_topic.is_empty() {
+                output.push_str("\nBy topic:\n");
+                for (topic, count) in &stats.by_topic {
+                    output.push_str(&format!("  {topic}: {count}\n"));
+                }
+            }
+            if !stats.most_applied.is_empty() {
+                output.push_str("\nMost applied:\n");
+                for (id, count) in &stats.most_applied {
+                    output.push_str(&format!("  {id}: {count} times\n"));
+                }
+            }
+            ToolResult::text(output)
+        }
+        Err(e) => ToolResult::error(format!("failed to get feedback stats: {e}")),
+    }
 }

--- a/crates/icm-store/src/schema.rs
+++ b/crates/icm-store/src/schema.rs
@@ -173,6 +173,63 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
     )
     .map_err(|e| IcmError::Database(e.to_string()))?;
 
+    // Feedback table
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS feedback (
+            id TEXT PRIMARY KEY,
+            topic TEXT NOT NULL,
+            context TEXT NOT NULL,
+            predicted TEXT NOT NULL,
+            corrected TEXT NOT NULL,
+            reason TEXT,
+            source TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL,
+            applied_count INTEGER DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_feedback_topic ON feedback(topic);
+        ",
+    )
+    .map_err(|e| IcmError::Database(e.to_string()))?;
+
+    // Feedback FTS table
+    let feedback_fts_exists: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='feedback_fts'",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| IcmError::Database(e.to_string()))?;
+
+    if !feedback_fts_exists {
+        conn.execute_batch(
+            "
+            CREATE VIRTUAL TABLE feedback_fts USING fts5(
+                id, topic, context, predicted, corrected, reason,
+                content='feedback', content_rowid='rowid'
+            );
+
+            CREATE TRIGGER feedback_ai AFTER INSERT ON feedback BEGIN
+                INSERT INTO feedback_fts(rowid, id, topic, context, predicted, corrected, reason)
+                VALUES (new.rowid, new.id, new.topic, new.context, new.predicted, new.corrected, new.reason);
+            END;
+
+            CREATE TRIGGER feedback_ad AFTER DELETE ON feedback BEGIN
+                INSERT INTO feedback_fts(feedback_fts, rowid, id, topic, context, predicted, corrected, reason)
+                VALUES('delete', old.rowid, old.id, old.topic, old.context, old.predicted, old.corrected, old.reason);
+            END;
+
+            CREATE TRIGGER feedback_au AFTER UPDATE ON feedback BEGIN
+                INSERT INTO feedback_fts(feedback_fts, rowid, id, topic, context, predicted, corrected, reason)
+                VALUES('delete', old.rowid, old.id, old.topic, old.context, old.predicted, old.corrected, old.reason);
+                INSERT INTO feedback_fts(rowid, id, topic, context, predicted, corrected, reason)
+                VALUES (new.rowid, new.id, new.topic, new.context, new.predicted, new.corrected, new.reason);
+            END;
+            ",
+        )
+        .map_err(|e| IcmError::Database(e.to_string()))?;
+    }
+
     // Migration: add updated_at column if missing (existing DBs pre-0.3.1)
     let has_updated_at: bool = conn
         .prepare("SELECT COUNT(*) FROM pragma_table_info('memories') WHERE name='updated_at'")

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -7,8 +7,9 @@ use rusqlite::{ffi::sqlite3_auto_extension, params, Connection};
 use zerocopy::IntoBytes;
 
 use icm_core::{
-    Concept, ConceptLink, IcmError, IcmResult, Importance, Label, Memoir, MemoirStats, MemoirStore,
-    Memory, MemorySource, MemoryStore, Relation, StoreStats, TopicHealth,
+    Concept, ConceptLink, Feedback, FeedbackStats, FeedbackStore, IcmError, IcmResult, Importance,
+    Label, Memoir, MemoirStats, MemoirStore, Memory, MemorySource, MemoryStore, Relation,
+    StoreStats, TopicHealth,
 };
 
 use crate::schema::{init_db, init_db_with_dims};
@@ -1445,6 +1446,221 @@ impl MemoirStore for SqliteStore {
 }
 
 // ---------------------------------------------------------------------------
+// Feedback helpers
+// ---------------------------------------------------------------------------
+
+fn row_to_feedback(row: &rusqlite::Row) -> rusqlite::Result<Feedback> {
+    Ok(Feedback {
+        id: row.get(0)?,
+        topic: row.get(1)?,
+        context: row.get(2)?,
+        predicted: row.get(3)?,
+        corrected: row.get(4)?,
+        reason: row.get(5)?,
+        source: row.get(6)?,
+        created_at: parse_dt(&row.get::<_, String>(7)?),
+        applied_count: row.get(8)?,
+    })
+}
+
+const FEEDBACK_COLS: &str = "id, topic, context, predicted, corrected, reason, source, created_at, applied_count";
+
+// ---------------------------------------------------------------------------
+// FeedbackStore impl
+// ---------------------------------------------------------------------------
+
+impl FeedbackStore for SqliteStore {
+    fn store_feedback(&self, feedback: Feedback) -> IcmResult<String> {
+        self.conn
+            .execute(
+                "INSERT INTO feedback (id, topic, context, predicted, corrected, reason, source, created_at, applied_count)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    feedback.id,
+                    feedback.topic,
+                    feedback.context,
+                    feedback.predicted,
+                    feedback.corrected,
+                    feedback.reason,
+                    feedback.source,
+                    feedback.created_at.to_rfc3339(),
+                    feedback.applied_count,
+                ],
+            )
+            .map_err(|e| IcmError::Database(e.to_string()))?;
+        Ok(feedback.id)
+    }
+
+    fn search_feedback(
+        &self,
+        query: &str,
+        topic: Option<&str>,
+        limit: usize,
+    ) -> IcmResult<Vec<Feedback>> {
+        // Sanitize FTS query: remove special characters
+        let sanitized: String = query
+            .chars()
+            .filter(|c| c.is_alphanumeric() || c.is_whitespace())
+            .collect::<String>()
+            .trim()
+            .to_string();
+
+        if sanitized.is_empty() {
+            return self.list_feedback(topic, limit);
+        }
+
+        let results = if let Some(t) = topic {
+            let mut stmt = self
+                .conn
+                .prepare(&format!(
+                    "SELECT {FEEDBACK_COLS} FROM feedback
+                     WHERE id IN (SELECT id FROM feedback_fts WHERE feedback_fts MATCH ?1)
+                     AND topic = ?2
+                     ORDER BY created_at DESC
+                     LIMIT ?3"
+                ))
+                .map_err(|e| IcmError::Database(e.to_string()))?;
+
+            let rows = stmt
+                .query_map(params![sanitized, t, limit as i64], row_to_feedback)
+                .map_err(|e| IcmError::Database(e.to_string()))?;
+
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row.map_err(|e| IcmError::Database(e.to_string()))?);
+            }
+            results
+        } else {
+            let mut stmt = self
+                .conn
+                .prepare(&format!(
+                    "SELECT {FEEDBACK_COLS} FROM feedback
+                     WHERE id IN (SELECT id FROM feedback_fts WHERE feedback_fts MATCH ?1)
+                     ORDER BY created_at DESC
+                     LIMIT ?2"
+                ))
+                .map_err(|e| IcmError::Database(e.to_string()))?;
+
+            let rows = stmt
+                .query_map(params![sanitized, limit as i64], row_to_feedback)
+                .map_err(|e| IcmError::Database(e.to_string()))?;
+
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row.map_err(|e| IcmError::Database(e.to_string()))?);
+            }
+            results
+        };
+
+        Ok(results)
+    }
+
+    fn list_feedback(&self, topic: Option<&str>, limit: usize) -> IcmResult<Vec<Feedback>> {
+        let results = if let Some(t) = topic {
+            let mut stmt = self
+                .conn
+                .prepare(&format!(
+                    "SELECT {FEEDBACK_COLS} FROM feedback WHERE topic = ?1 ORDER BY created_at DESC LIMIT ?2"
+                ))
+                .map_err(|e| IcmError::Database(e.to_string()))?;
+
+            let rows = stmt
+                .query_map(params![t, limit as i64], row_to_feedback)
+                .map_err(|e| IcmError::Database(e.to_string()))?;
+
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row.map_err(|e| IcmError::Database(e.to_string()))?);
+            }
+            results
+        } else {
+            let mut stmt = self
+                .conn
+                .prepare(&format!(
+                    "SELECT {FEEDBACK_COLS} FROM feedback ORDER BY created_at DESC LIMIT ?1"
+                ))
+                .map_err(|e| IcmError::Database(e.to_string()))?;
+
+            let rows = stmt
+                .query_map(params![limit as i64], row_to_feedback)
+                .map_err(|e| IcmError::Database(e.to_string()))?;
+
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row.map_err(|e| IcmError::Database(e.to_string()))?);
+            }
+            results
+        };
+
+        Ok(results)
+    }
+
+    fn increment_applied(&self, id: &str) -> IcmResult<()> {
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE feedback SET applied_count = applied_count + 1 WHERE id = ?1",
+                params![id],
+            )
+            .map_err(|e| IcmError::Database(e.to_string()))?;
+
+        if changed == 0 {
+            return Err(IcmError::NotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
+    fn delete_feedback(&self, id: &str) -> IcmResult<()> {
+        let changed = self
+            .conn
+            .execute("DELETE FROM feedback WHERE id = ?1", params![id])
+            .map_err(|e| IcmError::Database(e.to_string()))?;
+
+        if changed == 0 {
+            return Err(IcmError::NotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
+    fn feedback_stats(&self) -> IcmResult<FeedbackStats> {
+        let total: usize = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM feedback", [], |row| row.get(0))
+            .map_err(|e| IcmError::Database(e.to_string()))?;
+
+        let mut stmt = self
+            .conn
+            .prepare("SELECT topic, COUNT(*) as cnt FROM feedback GROUP BY topic ORDER BY cnt DESC")
+            .map_err(|e| IcmError::Database(e.to_string()))?;
+
+        let by_topic: Vec<(String, usize)> = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .map_err(|e| IcmError::Database(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, applied_count FROM feedback WHERE applied_count > 0 ORDER BY applied_count DESC LIMIT 10",
+            )
+            .map_err(|e| IcmError::Database(e.to_string()))?;
+
+        let most_applied: Vec<(String, u32)> = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .map_err(|e| IcmError::Database(e.to_string()))?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(FeedbackStats {
+            total,
+            by_topic,
+            most_applied,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Test helpers (visible to other modules in crate for test use)
 // ---------------------------------------------------------------------------
 
@@ -2825,5 +3041,160 @@ mod tests {
             "50 list_topics calls over 200 topics took {}ms (max 1000ms)",
             elapsed.as_millis()
         );
+    }
+
+    // === FeedbackStore tests ===
+
+    fn make_feedback(topic: &str, context: &str, predicted: &str, corrected: &str) -> Feedback {
+        Feedback::new(
+            topic.into(),
+            context.into(),
+            predicted.into(),
+            corrected.into(),
+            None,
+            "test".into(),
+        )
+    }
+
+    #[test]
+    fn test_feedback_store_and_list() {
+        let store = test_store();
+        let fb = make_feedback("triage", "issue about crashes", "low", "high");
+        let id = fb.id.clone();
+        store.store_feedback(fb).unwrap();
+
+        let results = store.list_feedback(None, 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, id);
+        assert_eq!(results[0].topic, "triage");
+        assert_eq!(results[0].predicted, "low");
+        assert_eq!(results[0].corrected, "high");
+    }
+
+    #[test]
+    fn test_feedback_list_by_topic() {
+        let store = test_store();
+        store
+            .store_feedback(make_feedback("triage", "ctx1", "a", "b"))
+            .unwrap();
+        store
+            .store_feedback(make_feedback("pr-review", "ctx2", "c", "d"))
+            .unwrap();
+
+        let triage = store.list_feedback(Some("triage"), 10).unwrap();
+        assert_eq!(triage.len(), 1);
+        assert_eq!(triage[0].topic, "triage");
+
+        let all = store.list_feedback(None, 10).unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn test_feedback_search() {
+        let store = test_store();
+        store
+            .store_feedback(make_feedback(
+                "triage",
+                "user reports memory leak",
+                "low priority",
+                "high priority",
+            ))
+            .unwrap();
+        store
+            .store_feedback(make_feedback(
+                "triage",
+                "build failure on CI",
+                "feature",
+                "bug",
+            ))
+            .unwrap();
+
+        let results = store.search_feedback("memory leak", None, 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].context.contains("memory leak"));
+    }
+
+    #[test]
+    fn test_feedback_search_with_topic_filter() {
+        let store = test_store();
+        store
+            .store_feedback(make_feedback("triage", "memory issue", "low", "high"))
+            .unwrap();
+        store
+            .store_feedback(make_feedback("pr-review", "memory usage", "ok", "bad"))
+            .unwrap();
+
+        let results = store
+            .search_feedback("memory", Some("triage"), 10)
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].topic, "triage");
+    }
+
+    #[test]
+    fn test_feedback_increment_applied() {
+        let store = test_store();
+        let fb = make_feedback("triage", "ctx", "a", "b");
+        let id = fb.id.clone();
+        store.store_feedback(fb).unwrap();
+
+        store.increment_applied(&id).unwrap();
+        store.increment_applied(&id).unwrap();
+
+        let results = store.list_feedback(None, 10).unwrap();
+        assert_eq!(results[0].applied_count, 2);
+    }
+
+    #[test]
+    fn test_feedback_increment_applied_not_found() {
+        let store = test_store();
+        let result = store.increment_applied("nonexistent");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_feedback_delete() {
+        let store = test_store();
+        let fb = make_feedback("triage", "ctx", "a", "b");
+        let id = fb.id.clone();
+        store.store_feedback(fb).unwrap();
+
+        store.delete_feedback(&id).unwrap();
+        let results = store.list_feedback(None, 10).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_feedback_delete_not_found() {
+        let store = test_store();
+        let result = store.delete_feedback("nonexistent");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_feedback_stats() {
+        let store = test_store();
+        store
+            .store_feedback(make_feedback("triage", "ctx1", "a", "b"))
+            .unwrap();
+        store
+            .store_feedback(make_feedback("triage", "ctx2", "c", "d"))
+            .unwrap();
+        store
+            .store_feedback(make_feedback("pr-review", "ctx3", "e", "f"))
+            .unwrap();
+
+        let fb = make_feedback("triage", "ctx4", "g", "h");
+        let id = fb.id.clone();
+        store.store_feedback(fb).unwrap();
+        store.increment_applied(&id).unwrap();
+
+        let stats = store.feedback_stats().unwrap();
+        assert_eq!(stats.total, 4);
+        assert_eq!(stats.by_topic.len(), 2);
+        assert_eq!(stats.by_topic[0].0, "triage");
+        assert_eq!(stats.by_topic[0].1, 3);
+        assert_eq!(stats.most_applied.len(), 1);
+        assert_eq!(stats.most_applied[0].1, 1);
     }
 }

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,9 +9,10 @@
   - [Administration et maintenance](#administration-et-maintenance)
   - [Configuration et setup](#configuration-et-setup)
   - [Benchmarks](#benchmarks)
-- [Outils MCP (18)](#outils-mcp-18)
+- [Outils MCP (21)](#outils-mcp-21)
   - [Outils Memory (9)](#outils-memory-9)
   - [Outils Memoir (9)](#outils-memoir-9)
+  - [Outils Feedback (3)](#outils-feedback-3)
 - [Memory vs Memoir : quand utiliser quoi](#memory-vs-memoir--quand-utiliser-quoi)
 - [Workflow multi-session](#workflow-multi-session)
 - [Organisation des topics](#organisation-des-topics)
@@ -758,7 +759,7 @@ icm bench-agent --sessions 10 --model haiku --runs 3
 
 ---
 
-## Outils MCP (18)
+## Outils MCP (21)
 
 Le serveur MCP expose 18 outils via le protocole JSON-RPC 2.0 sur stdio. Tous les outils sont appeles par l'agent IA (Claude, Cursor, etc.) de maniere transparente.
 
@@ -1102,6 +1103,64 @@ Incremente la revision et augmente la confiance.
 ```
 
 Retourne le concept et tous les concepts atteignables en N sauts, avec les liens entre eux.
+
+---
+
+### Outils Feedback (3)
+
+Les outils de feedback permettent l'apprentissage en boucle fermee : quand une prediction AI est fausse, on enregistre la correction pour ameliorer les predictions futures.
+
+#### `icm_feedback_record` -- Enregistrer une correction
+
+**Parametres :**
+
+| Parametre | Type | Obligatoire | Description |
+|-----------|------|-------------|-------------|
+| `topic` | string | oui | Categorie/namespace (ex: `triage-owner/repo`, `pr-analysis`) |
+| `context` | string | oui | Situation / input qui a mene a la prediction |
+| `predicted` | string | oui | Ce que l'AI a predit ou fait |
+| `corrected` | string | oui | La bonne reponse/action |
+| `reason` | string | non | Pourquoi la correction a ete faite |
+| `source` | string | non | Quel outil/pipeline a genere la prediction |
+
+**Exemple :**
+```json
+{
+  "topic": "triage-myorg/myrepo",
+  "context": "Issue: 'App crashes when clicking save button'",
+  "predicted": "feature",
+  "corrected": "bug",
+  "reason": "The issue describes a crash, which is a bug not a feature request"
+}
+```
+
+En mode compact, retourne uniquement l'ID. En mode normal, retourne l'objet complet.
+
+#### `icm_feedback_search` -- Rechercher des corrections passees
+
+**Parametres :**
+
+| Parametre | Type | Obligatoire | Description |
+|-----------|------|-------------|-------------|
+| `query` | string | oui | Requete de recherche |
+| `topic` | string | non | Filtrer par topic |
+| `limit` | integer | non | Nombre max de resultats (defaut: 5, max: 20) |
+
+**Exemple :**
+```json
+{ "query": "crash bug classification", "topic": "triage-myorg/myrepo", "limit": 5 }
+```
+
+Utilise la recherche full-text (FTS5) sur les champs context, predicted, corrected et reason.
+
+#### `icm_feedback_stats` -- Statistiques de feedback
+
+**Parametres :** aucun
+
+Retourne :
+- `total` : nombre total de corrections enregistrees
+- `by_topic` : ventilation par topic
+- `most_applied` : les corrections les plus souvent referencees
 
 ---
 


### PR DESCRIPTION
## Summary
- Add closed-loop learning: `Feedback` type, `FeedbackStore` trait, SQLite table with FTS5 full-text search
- 3 new MCP tools: `icm_feedback_record`, `icm_feedback_search`, `icm_feedback_stats`
- Updated README (18 → 21 MCP tools), features.md, and CLAUDE.md with feedback documentation

## Test plan
- [x] All 145 tests pass (`cargo test`)
- [x] New tests cover: store, search with FTS5, stats, increment_applied, delete
- [x] MCP tool tests cover: record, search, stats, topic filtering