### PR TITLE
fix: cross-platform config path (Windows/Linux/macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ With embeddings enabled, ICM uses hybrid search:
 - **FTS5 BM25** (30%) — full-text keyword matching
 - **Cosine similarity** (70%) — semantic vector search via sqlite-vec
 
-Default model: `intfloat/multilingual-e5-base` (768d, 100+ languages). Configurable in `~/.config/icm/config.toml`:
+Default model: `intfloat/multilingual-e5-base` (768d, 100+ languages). Configurable in your [config file](#configuration):
 
 ```toml
 [embeddings]
@@ -239,15 +239,23 @@ Without embeddings, falls back to FTS5 then keyword LIKE search.
 Single SQLite file. No external services, no network dependency.
 
 ```
-~/Library/Application Support/dev.icm.icm/memories.db   # macOS
-~/.local/share/dev.icm.icm/memories.db                  # Linux
+~/Library/Application Support/dev.icm.icm/memories.db                    # macOS
+~/.local/share/dev.icm.icm/memories.db                                   # Linux
+C:\Users\<user>\AppData\Local\icm\icm\data\memories.db                   # Windows
 ```
 
 ### Configuration
 
 ```bash
 icm config                    # Show active config
-# Edit: ~/.config/icm/config.toml (or $ICM_CONFIG)
+```
+
+Config file location (platform-specific, or `$ICM_CONFIG`):
+
+```
+~/Library/Application Support/dev.icm.icm/config.toml                    # macOS
+~/.config/icm/config.toml                                                # Linux
+C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml              # Windows
 ```
 
 See [config/default.toml](config/default.toml) for all options.

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,10 +1,15 @@
 # ICM Configuration
-# Place at: ~/.config/icm/config.toml
-# Or set ICM_CONFIG=/path/to/config.toml
+#
+# Location (platform-specific):
+#   macOS:   ~/Library/Application Support/dev.icm.icm/config.toml
+#   Linux:   ~/.config/icm/config.toml
+#   Windows: C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml
+# Or override with: ICM_CONFIG=/path/to/config.toml
 
 [store]
-# SQLite database path (default: platform data dir)
-# path = "~/Library/Application Support/dev.icm.icm/memories.db"
+# SQLite database path (default: platform data dir).
+# Uncomment to use a custom location:
+# path = "/custom/path/to/memories.db"
 
 [memory]
 default_importance = "medium"

--- a/crates/icm-cli/src/config.rs
+++ b/crates/icm-cli/src/config.rs
@@ -173,24 +173,19 @@ pub fn load_config() -> Result<Config> {
     Ok(Config::default())
 }
 
-/// Resolve the config file path.
+/// Resolve the config file path (cross-platform via `directories`).
 fn config_path() -> Option<PathBuf> {
     // 1. Environment variable
     if let Ok(p) = std::env::var("ICM_CONFIG") {
         return Some(PathBuf::from(p));
     }
 
-    // 2. ~/.config/icm/config.toml
-    if let Some(home) = dirs_home() {
-        let p = home.join(".config").join("icm").join("config.toml");
-        return Some(p);
-    }
-
-    None
-}
-
-fn dirs_home() -> Option<PathBuf> {
-    std::env::var("HOME").ok().map(PathBuf::from)
+    // 2. Platform-specific config dir:
+    //    macOS:   ~/Library/Application Support/dev.icm.icm/config.toml
+    //    Linux:   ~/.config/icm/config.toml  (XDG_CONFIG_HOME)
+    //    Windows: C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml
+    directories::ProjectDirs::from("dev", "icm", "icm")
+        .map(|dirs| dirs.config_dir().join("config.toml"))
 }
 
 /// Show the active config path (for `icm config show`).


### PR DESCRIPTION
## Summary
- Replace `$HOME/.config/icm/` hardcoded path with `directories::ProjectDirs` for cross-platform support
- Update `config/default.toml` header with all platform paths and customizable DB path
- Update README with Windows paths for storage and configuration sections

Closes #22

## Paths after fix

| Data | macOS | Linux | Windows |
|------|-------|-------|---------|
| DB | `~/Library/Application Support/dev.icm.icm/memories.db` | `~/.local/share/dev.icm.icm/memories.db` | `AppData\Local\icm\icm\data\memories.db` |
| Config | `~/Library/Application Support/dev.icm.icm/config.toml` | `~/.config/icm/config.toml` | `AppData\Roaming\icm\icm\config\config.toml` |
| Cache | `~/Library/Caches/dev.icm.icm/models/` | `~/.cache/icm/models/` | `AppData\Local\icm\icm\cache\models\` |

## Test plan
- [x] `cargo check -p icm-cli` passes
- [x] `cargo test -p icm-cli -- config` — 4/4 tests pass
- [ ] Verify `icm config` shows correct platform path on macOS