### PR TITLE
fix: add opt-out for embedding model download

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Default model: `intfloat/multilingual-e5-base` (768d, 100+ languages). Configura
 
 ```toml
 [embeddings]
+# enabled = false                          # Disable entirely (no model download)
 model = "intfloat/multilingual-e5-base"    # 768d, multilingual (default)
 # model = "intfloat/multilingual-e5-small" # 384d, multilingual (lighter)
 # model = "intfloat/multilingual-e5-large" # 1024d, multilingual (best accuracy)
@@ -240,9 +241,14 @@ model = "intfloat/multilingual-e5-base"    # 768d, multilingual (default)
 # model = "jinaai/jina-embeddings-v2-base-code"  # 768d, code-optimized
 ```
 
-Changing the model automatically re-creates the vector index (existing embeddings are cleared and can be regenerated with `icm_memory_embed_all`).
+To skip the embedding model download entirely, use any of these:
+```bash
+icm --no-embeddings serve          # CLI flag
+ICM_NO_EMBEDDINGS=1 icm serve     # Environment variable
+```
+Or set `enabled = false` in your config file. ICM will fall back to FTS5 keyword search (still works, just no semantic matching).
 
-Without embeddings, falls back to FTS5 then keyword LIKE search.
+Changing the model automatically re-creates the vector index (existing embeddings are cleared and can be regenerated with `icm_memory_embed_all`).
 
 ### Storage
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -21,6 +21,9 @@ decay_rate = 0.95
 prune_threshold = 0.1
 
 [embeddings]
+# Set to false to disable embeddings entirely (no model download, keyword search only)
+# enabled = false
+
 # Embedding model (fastembed model_code). Default: multilingual-e5-small (384d, 100+ languages)
 # Other options:
 #   "BAAI/bge-small-en-v1.5"              — 384d, English-only (fastest)

--- a/crates/icm-cli/src/config.rs
+++ b/crates/icm-cli/src/config.rs
@@ -48,6 +48,8 @@ pub struct MemoryConfig {
 #[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct EmbeddingsConfig {
+    /// Enable embeddings (set to false to skip model download entirely).
+    pub enabled: bool,
     /// Model identifier (fastembed model_code, e.g. "intfloat/multilingual-e5-small").
     pub model: String,
 }
@@ -55,6 +57,7 @@ pub struct EmbeddingsConfig {
 impl Default for EmbeddingsConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             model: "intfloat/multilingual-e5-base".into(),
         }
     }

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -28,6 +28,10 @@ struct Cli {
     #[arg(long, global = true)]
     db: Option<PathBuf>,
 
+    /// Disable embeddings (skip model download, use keyword search only)
+    #[arg(long, global = true)]
+    no_embeddings: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -641,8 +645,14 @@ fn main() -> Result<()> {
 
     let cli = Cli::parse();
     let cfg = config::load_config()?;
+    let embeddings_enabled =
+        cfg.embeddings.enabled && !cli.no_embeddings && std::env::var("ICM_NO_EMBEDDINGS").is_err();
     #[allow(unused_variables)]
-    let embedder = init_embedder(&cfg.embeddings.model);
+    let embedder = if embeddings_enabled {
+        init_embedder(&cfg.embeddings.model)
+    } else {
+        None
+    };
     let embedding_dims = embedder
         .as_ref()
         .map(|e| {


### PR DESCRIPTION
## Summary
- Add 3 ways to disable embeddings entirely (skip model download at startup):
  - **Config**: `[embeddings] enabled = false`
  - **CLI flag**: `icm --no-embeddings <command>`
  - **Env var**: `ICM_NO_EMBEDDINGS=1`
- When disabled, ICM falls back to FTS5 keyword search (still functional, no semantic matching)
- Update README and default config with documentation

Closes #8

## Test plan
- [x] `cargo test` — 147/147 pass
- [x] `icm --no-embeddings stats` works without model download
- [x] `ICM_NO_EMBEDDINGS=1 icm recall "test"` returns FTS results
- [x] Default behavior unchanged (embeddings enabled)