### PR TITLE
feat: conversational extraction patterns for PreCompact

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,20 +296,20 @@ See [config/default.toml](config/default.toml) for all options.
 ICM extracts memories automatically via three layers:
 
 ```
-  Layer 0: Pattern hooks              Layer 1: PreCompact           Layer 2: SessionStart
-  (zero LLM cost)                     (cheap LLM, ~500 tok)         (zero LLM cost)
+  Layer 0: Pattern hooks              Layer 1: PreCompact           Layer 2: UserPromptSubmit
+  (zero LLM cost)                     (zero LLM cost)               (zero LLM cost)
   ┌──────────────────┐                ┌──────────────────┐          ┌──────────────────┐
-  │ PostToolUse hook  │                │ PreCompact hook   │          │ SessionStart hook │
+  │ PostToolUse hook  │                │ PreCompact hook   │          │ UserPromptSubmit  │
   │                   │                │                   │          │                   │
-  │ • Bash exit != 0  │                │ Context about to  │          │ Read cwd project  │
-  │   → store error   │                │ be compressed →   │          │ → icm recall      │
-  │ • git commit      │                │ extract memories  │          │ → inject as       │
-  │   → store commit  │                │ before they're    │          │   additionalContext│
-  │ • Edit CLAUDE.md  │                │ lost forever      │          │                   │
-  │   → store context │                │                   │          │ Agent starts with  │
-  │                   │                │ This is the #1    │          │ relevant memories  │
-  │ Pure pattern      │                │ extraction point   │          │ already loaded     │
-  │ matching, no LLM  │                │ nobody else does  │          │                   │
+  │ • Bash errors     │                │ Context about to  │          │ User sends prompt │
+  │ • git commits     │                │ be compressed →   │          │ → icm recall      │
+  │ • config changes  │                │ extract memories  │          │ → inject context  │
+  │ • decisions       │                │ from transcript   │          │                   │
+  │ • preferences     │                │ before they're    │          │ Agent starts with  │
+  │ • learnings       │                │ lost forever      │          │ relevant memories  │
+  │ • constraints     │                │                   │          │ already loaded     │
+  │                   │                │ Same patterns +   │          │                   │
+  │ Rule-based, no LLM│                │ --store-raw fallbk│          │                   │
   └──────────────────┘                └──────────────────┘          └──────────────────┘
 ```
 

--- a/crates/icm-cli/src/extract.rs
+++ b/crates/icm-cli/src/extract.rs
@@ -12,6 +12,16 @@ use icm_store::SqliteStore;
 /// Extract key facts from text and store them in ICM.
 /// Returns the number of facts stored.
 pub fn extract_and_store(store: &SqliteStore, text: &str, project: &str) -> Result<usize> {
+    extract_and_store_with_opts(store, text, project, false)
+}
+
+/// Extract and store with option to store raw text as fallback.
+pub fn extract_and_store_with_opts(
+    store: &SqliteStore,
+    text: &str,
+    project: &str,
+    store_raw: bool,
+) -> Result<usize> {
     let facts = extract_facts(text, project);
     let mut stored = 0;
     for (topic, content, importance) in &facts {
@@ -19,6 +29,23 @@ pub fn extract_and_store(store: &SqliteStore, text: &str, project: &str) -> Resu
         store.store(mem)?;
         stored += 1;
     }
+
+    // Fallback: store truncated raw text as low-importance memory
+    if stored == 0 && store_raw && text.len() >= 50 {
+        let raw = if text.len() > 2000 {
+            &text[text.len() - 2000..]
+        } else {
+            text
+        };
+        let mem = Memory::new(
+            format!("context-{project}"),
+            raw.to_string(),
+            Importance::Low,
+        );
+        store.store(mem)?;
+        stored = 1;
+    }
+
     Ok(stored)
 }
 
@@ -317,6 +344,96 @@ fn extract_facts(text: &str, project: &str) -> Vec<(String, String, Importance)>
             score += 1.5;
         }
 
+        // --- Conversational signals (PreCompact / transcript context) ---
+
+        // Preferences and rules ("always do X", "never do Y", "use X instead of Y")
+        for kw in &[
+            "always ",
+            "never ",
+            "must ",
+            "should not",
+            "shouldn't",
+            "don't ",
+            "do not ",
+            "prefer ",
+            "avoid ",
+            "make sure",
+            "important to",
+            "remember to",
+            "rule:",
+            "convention:",
+        ] {
+            if lower.contains(kw) {
+                score += 2.5;
+                importance = Importance::High;
+            }
+        }
+
+        // Learnings and insights
+        for kw in &[
+            "learned",
+            "realized",
+            "turns out",
+            "the trick is",
+            "the fix was",
+            "the solution",
+            "the key is",
+            "the problem was",
+            "discovered that",
+            "figured out",
+            "gotcha",
+            "caveat",
+            "pitfall",
+            "note to self",
+        ] {
+            if lower.contains(kw) {
+                score += 2.5;
+                importance = Importance::High;
+            }
+        }
+
+        // Project decisions and context from conversation
+        for kw in &[
+            "we're using",
+            "we use ",
+            "we switched",
+            "we migrated",
+            "we deploy",
+            "the project",
+            "the repo ",
+            "the codebase",
+            "our stack",
+            "we went with",
+            "we picked",
+        ] {
+            if lower.contains(kw) {
+                score += 2.5;
+            }
+        }
+
+        // Constraints and blockers
+        for kw in &[
+            "doesn't work",
+            "does not work",
+            "won't work",
+            "will not work",
+            "incompatible",
+            "breaks when",
+            "only works",
+            "doesn't support",
+            "does not support",
+            "limitation",
+            "can't use",
+            "cannot use",
+            "not compatible",
+            "not supported",
+        ] {
+            if lower.contains(kw) {
+                score += 2.5;
+                importance = Importance::High;
+            }
+        }
+
         if score >= 3.0 {
             scored.push((score, s.to_string(), importance));
         }
@@ -427,6 +544,43 @@ mod tests {
         let text = "Configured release-please for Cargo workspace with simple release-type instead of rust";
         let facts = extract_facts(text, "test");
         assert!(!facts.is_empty(), "should extract config facts");
+    }
+
+    #[test]
+    fn test_extract_conversational_preference() {
+        let text = "Always query ALL calendars in Google Calendar API, not just primary";
+        let facts = extract_facts(text, "test");
+        assert!(!facts.is_empty(), "should extract preference/rule");
+    }
+
+    #[test]
+    fn test_extract_conversational_learning() {
+        let text = "Turns out the hooks must be bash scripts not bun or TypeScript for Claude Code";
+        let facts = extract_facts(text, "test");
+        assert!(!facts.is_empty(), "should extract learning/insight");
+    }
+
+    #[test]
+    fn test_extract_conversational_constraint() {
+        let text =
+            "The fastembed crate does not work with cross-compilation for ARM64 on Linux CI runners";
+        let facts = extract_facts(text, "test");
+        assert!(!facts.is_empty(), "should extract constraint");
+    }
+
+    #[test]
+    fn test_extract_conversational_decision() {
+        let text = "We switched from OpenAI embeddings to fastembed because we wanted zero external dependencies";
+        let facts = extract_facts(text, "test");
+        assert!(!facts.is_empty(), "should extract project decision");
+    }
+
+    #[test]
+    fn test_store_raw_fallback() {
+        let store = SqliteStore::in_memory().unwrap();
+        let text = "Just some random conversation text that has no particular keywords but is still somewhat meaningful context about the ongoing work session";
+        let stored = extract_and_store_with_opts(&store, text, "test", true).unwrap();
+        assert_eq!(stored, 1, "should store raw text as fallback");
     }
 
     #[test]

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -229,6 +229,10 @@ enum Commands {
         /// Don't store, just print extracted facts
         #[arg(long)]
         dry_run: bool,
+
+        /// Store raw text as low-importance memory when no facts are extracted
+        #[arg(long)]
+        store_raw: bool,
     },
 
     /// Output recalled context formatted for prompt injection
@@ -817,7 +821,8 @@ fn main() -> Result<()> {
             project,
             text,
             dry_run,
-        } => cmd_extract(&store, &project, text, dry_run),
+            store_raw,
+        } => cmd_extract(&store, &project, text, dry_run, store_raw),
         Commands::RecallContext { query, limit } => cmd_recall_context(&store, &query, limit),
         Commands::Config => cmd_config(),
         Commands::Bench { count } => cmd_bench(count),
@@ -2258,6 +2263,7 @@ fn cmd_extract(
     project: &str,
     text: Option<String>,
     dry_run: bool,
+    store_raw: bool,
 ) -> Result<()> {
     let input = match text {
         Some(t) => t,
@@ -2272,7 +2278,6 @@ fn cmd_extract(
     };
 
     if dry_run {
-        // Just show what would be extracted
         let facts = extract::extract_facts_public(&input, project);
         if facts.is_empty() {
             println!("No facts extracted.");
@@ -2283,7 +2288,7 @@ fn cmd_extract(
             }
         }
     } else {
-        let stored = extract::extract_and_store(store, &input, project)?;
+        let stored = extract::extract_and_store_with_opts(store, &input, project, store_raw)?;
         println!("Extracted and stored {stored} facts.");
     }
     Ok(())


### PR DESCRIPTION
## Summary
Add 4 new pattern categories to `icm extract` so it captures conversational context (not just structured tool output):

| Category | Keywords | Score | Examples |
|----------|----------|-------|---------|
| Preferences/rules | "always", "never", "must", "avoid" | +2.5 (High) | "Always query ALL calendars, not just primary" |
| Learnings/insights | "turns out", "the fix was", "gotcha" | +2.5 (High) | "Turns out hooks must be bash not TypeScript" |
| Project context | "we switched", "we use", "our stack" | +2.5 | "We switched from OpenAI to fastembed" |
| Constraints | "doesn't work", "incompatible", "breaks when" | +2.5 (High) | "fastembed doesn't work with ARM cross-compilation" |

Also adds `--store-raw` flag: when no facts are extracted, stores truncated raw text as low-importance memory (safety net for PreCompact).

Closes #11

## Test plan
- [x] `cargo test` — 152/152 pass (5 new tests)
- [x] Issue example 1: "Always query ALL calendars" → extracted
- [x] Issue example 2: "hooks must be bash not bun" → extracted
- [x] `--store-raw` stores fallback when 0 facts extracted
- [x] Existing patterns still work unchanged