### PR TITLE
docs: add 12 translated READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[English](README.md) | [Français](README_fr.md) | [Español](README_es.md) | [Deutsch](README_de.md) | [Italiano](README_it.md) | [Português](README_pt.md) | [Nederlands](README_nl.md) | [Polski](README_pl.md) | [Русский](README_ru.md) | [日本語](README_ja.md) | [中文](README_zh.md) | [العربية](README_ar.md) | [한국어](README_ko.md)
+
 <p align="center">
   <img src="assets/banner.png" alt="ICM — Infinite Context Memory" width="600">
 </p>

--- a/README_ar.md
+++ b/README_ar.md
@@ -1,0 +1,453 @@
+[English](README.md) | [Français](README_fr.md) | [Español](README_es.md) | [Deutsch](README_de.md) | [Italiano](README_it.md) | [Português](README_pt.md) | [Nederlands](README_nl.md) | [Polski](README_pl.md) | [Русский](README_ru.md) | [日本語](README_ja.md) | [中文](README_zh.md) | **العربية** | [한국어](README_ko.md)
+
+<p align="center">
+  <img src="assets/banner.png" alt="ICM — Infinite Context Memory" width="600">
+</p>
+
+<h1 align="center">ICM</h1>
+
+<p align="center">
+  ذاكرة دائمة لعملاء الذكاء الاصطناعي. ملف تنفيذي واحد، بدون تبعيات، دعم MCP أصلي.
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/icm/actions/workflows/ci.yml"><img src="https://github.com/rtk-ai/icm/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/icm/releases/latest"><img src="https://img.shields.io/github/v/release/rtk-ai/icm?color=purple" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Source--Available-orange.svg" alt="Source-Available"></a>
+</p>
+
+---
+
+يمنح ICM عميلَ الذكاء الاصطناعي الخاص بك ذاكرةً حقيقية — ليست أداة تدوين ملاحظات، ولا مدير سياق، بل **ذاكرة** فعلية.
+
+```
+                       ICM (Infinite Context Memory)
+            ┌──────────────────────┬─────────────────────────┐
+            │   MEMORIES (Topics)  │   MEMOIRS (Knowledge)   │
+            │                      │                         │
+            │  Episodic, temporal  │  Permanent, structured  │
+            │                      │                         │
+            │  ┌───┐ ┌───┐ ┌───┐  │    ┌───┐               │
+            │  │ m │ │ m │ │ m │  │    │ C │──depends_on──┐ │
+            │  └─┬─┘ └─┬─┘ └─┬─┘  │    └───┘              │ │
+            │    │decay │     │    │      │ refines      ┌─▼─┐│
+            │    ▼      ▼     ▼    │    ┌─▼─┐            │ C ││
+            │  weight decreases    │    │ C │──part_of──>└───┘│
+            │  over time unless    │    └───┘                 │
+            │  accessed/critical   │  Concepts + Relations    │
+            ├──────────────────────┴─────────────────────────┤
+            │             SQLite + FTS5 + sqlite-vec          │
+            │        Hybrid search: BM25 (30%) + cosine (70%) │
+            └─────────────────────────────────────────────────┘
+```
+
+**نموذجان للذاكرة:**
+
+- **Memories (الذكريات)** — تخزين واسترجاع مع تلاشٍ زمني حسب الأهمية. الذكريات الحرجة لا تتلاشى أبدًا، أما ذات الأهمية المنخفضة فتتلاشى تلقائيًا. يمكن التصفية بحسب الموضوع أو الكلمة المفتاحية.
+- **Memoirs (المذكرات)** — رسوم بيانية دائمة للمعرفة. مفاهيم مرتبطة بعلاقات مكتوبة (`depends_on`، `contradicts`، `superseded_by`، ...). يمكن التصفية بحسب التصنيف.
+- **Feedback (التغذية الراجعة)** — تسجيل التصحيحات عند خطأ توقعات الذكاء الاصطناعي. البحث في الأخطاء السابقة قبل إجراء تنبؤات جديدة. تعلم في حلقة مغلقة.
+
+## التثبيت
+
+```bash
+# Homebrew (macOS / Linux)
+brew tap rtk-ai/tap && brew install icm
+
+# تثبيت سريع
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+
+# من المصدر
+cargo install --path crates/icm-cli
+```
+
+## الإعداد
+
+```bash
+# الكشف التلقائي وضبط جميع الأدوات المدعومة
+icm init
+```
+
+يضبط **14 أداة** بأمر واحد:
+
+| الأداة | ملف الضبط | الصيغة |
+|--------|-----------|--------|
+| Claude Code | `~/.claude.json` | JSON |
+| Claude Desktop | `~/Library/.../claude_desktop_config.json` | JSON |
+| Cursor | `~/.cursor/mcp.json` | JSON |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON |
+| VS Code / Copilot | `~/Library/.../Code/User/mcp.json` | JSON |
+| Gemini Code Assist | `~/.gemini/settings.json` | JSON |
+| Zed | `~/.zed/settings.json` | JSON |
+| Amp | `~/.config/amp/settings.json` | JSON |
+| Amazon Q | `~/.aws/amazonq/mcp.json` | JSON |
+| Cline | VS Code globalStorage | JSON |
+| Roo Code | VS Code globalStorage | JSON |
+| Kilo Code | VS Code globalStorage | JSON |
+| OpenAI Codex CLI | `~/.codex/config.toml` | TOML |
+| OpenCode | `~/.config/opencode/opencode.json` | JSON |
+
+أو يدويًا:
+
+```bash
+# Claude Code
+claude mcp add icm -- icm serve
+
+# الوضع المضغوط (ردود أقصر، توفير رموز)
+claude mcp add icm -- icm serve --compact
+
+# أي عميل MCP: command = "icm", args = ["serve"]
+```
+
+### المهارات / القواعد
+
+```bash
+icm init --mode skill
+```
+
+يثبّت أوامر الشريطة المائلة والقواعد لـ Claude Code (`/recall`، `/remember`)، وCursor (قاعدة `.mdc`)، وRoo Code (قاعدة `.md`)، وAmp (`/icm-recall`، `/icm-remember`).
+
+### الخطافات (Claude Code)
+
+```bash
+icm init --mode hook
+```
+
+يثبّت الطبقات الثلاث للاستخراج كخطافات Claude Code:
+
+**خطافات Claude Code:**
+
+| الخطاف | الحدث | ما يفعله |
+|--------|-------|----------|
+| `icm hook pre` | PreToolUse | السماح تلقائيًا لأوامر `icm` CLI (بدون طلب إذن) |
+| `icm hook post` | PostToolUse | استخراج الحقائق من مخرجات الأداة كل 15 استدعاء |
+| `icm hook compact` | PreCompact | استخراج الذكريات من النص قبل ضغط السياق |
+| `icm hook prompt` | UserPromptSubmit | حقن السياق المستعاد في بداية كل موجه |
+
+**إضافة OpenCode** (تُثبَّت تلقائيًا في `~/.config/opencode/plugins/icm.js`):
+
+| حدث OpenCode | طبقة ICM | ما تفعله |
+|--------------|----------|----------|
+| `tool.execute.after` | الطبقة 0 | استخراج الحقائق من مخرجات الأداة |
+| `experimental.session.compacting` | الطبقة 1 | الاستخراج من المحادثة قبل الضغط |
+| `session.created` | الطبقة 2 | استرجاع السياق عند بدء الجلسة |
+
+## CLI مقابل MCP
+
+يمكن استخدام ICM عبر CLI (أوامر `icm`) أو خادم MCP (`icm serve`). كلاهما يصلان إلى نفس قاعدة البيانات.
+
+| | CLI | MCP |
+|---|-----|-----|
+| **زمن الاستجابة** | ~30ms (ملف ثنائي مباشر) | ~50ms (JSON-RPC stdio) |
+| **تكلفة الرموز** | 0 (قائم على الخطافات، غير مرئي) | ~20-50 رمز/استدعاء (مخطط الأداة) |
+| **الإعداد** | `icm init --mode hook` | `icm init --mode mcp` |
+| **يعمل مع** | Claude Code، OpenCode (عبر الخطافات/الإضافات) | جميع الأدوات الـ14 المتوافقة مع MCP |
+| **الاستخراج التلقائي** | نعم (الخطافات تشغّل `icm extract`) | نعم (أدوات MCP تستدعي store) |
+| **الأفضل لـ** | المستخدمين المتقدمين، توفير الرموز | التوافق الشامل |
+
+## واجهة سطر الأوامر
+
+### الذكريات (حلقية، مع تلاشٍ)
+
+```bash
+# تخزين
+icm store -t "my-project" -c "Use PostgreSQL for the main DB" -i high -k "db,postgres"
+
+# استرجاع
+icm recall "database choice"
+icm recall "auth setup" --topic "my-project" --limit 10
+icm recall "architecture" --keyword "postgres"
+
+# إدارة
+icm forget <memory-id>
+icm consolidate --topic "my-project"
+icm topics
+icm stats
+
+# استخراج حقائق من النص (قائم على القواعد، بدون تكلفة LLM)
+echo "The parser uses Pratt algorithm" | icm extract -p my-project
+```
+
+### المذكرات (رسوم بيانية دائمة للمعرفة)
+
+```bash
+# إنشاء مذكرة
+icm memoir create -n "system-architecture" -d "System design decisions"
+
+# إضافة مفاهيم مع تصنيفات
+icm memoir add-concept -m "system-architecture" -n "auth-service" \
+  -d "Handles JWT tokens and OAuth2 flows" -l "domain:auth,type:service"
+
+# ربط المفاهيم
+icm memoir link -m "system-architecture" --from "api-gateway" --to "auth-service" -r depends-on
+
+# البحث مع تصفية التصنيف
+icm memoir search -m "system-architecture" "authentication"
+icm memoir search -m "system-architecture" "service" --label "domain:auth"
+
+# فحص الجوار
+icm memoir inspect -m "system-architecture" "auth-service" -D 2
+
+# تصدير الرسم البياني (الصيغ: json, dot, ascii, ai)
+icm memoir export -m "system-architecture" -f ascii   # رسم بالأحرف مع أشرطة الثقة
+icm memoir export -m "system-architecture" -f dot      # Graphviz DOT (اللون = مستوى الثقة)
+icm memoir export -m "system-architecture" -f ai       # Markdown محسّن لسياق LLM
+icm memoir export -m "system-architecture" -f json     # JSON منظم مع جميع البيانات الوصفية
+
+# توليد تصور SVG
+icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
+```
+
+## أدوات MCP (22 أداة)
+
+### أدوات الذاكرة
+
+| الأداة | الوصف |
+|--------|-------|
+| `icm_memory_store` | التخزين مع إزالة التكرار التلقائي (تشابه >85% → تحديث بدلًا من تكرار) |
+| `icm_memory_recall` | البحث بالاستعلام، التصفية بحسب الموضوع و/أو الكلمة المفتاحية |
+| `icm_memory_update` | تعديل ذاكرة في مكانها (المحتوى، الأهمية، الكلمات المفتاحية) |
+| `icm_memory_forget` | حذف ذاكرة بالمعرّف |
+| `icm_memory_consolidate` | دمج جميع ذكريات موضوع واحد في ملخص |
+| `icm_memory_list_topics` | سرد جميع المواضيع مع الأعداد |
+| `icm_memory_stats` | إحصاءات الذاكرة الإجمالية |
+| `icm_memory_health` | تدقيق نظافة المواضيع (القِدَم، الحاجة للدمج) |
+| `icm_memory_embed_all` | ملء التضمينات للبحث الشعاعي بأثر رجعي |
+
+### أدوات المذكرات (الرسوم البيانية للمعرفة)
+
+| الأداة | الوصف |
+|--------|-------|
+| `icm_memoir_create` | إنشاء مذكرة جديدة (حاوية المعرفة) |
+| `icm_memoir_list` | سرد جميع المذكرات |
+| `icm_memoir_show` | عرض تفاصيل المذكرة وجميع المفاهيم |
+| `icm_memoir_add_concept` | إضافة مفهوم مع تصنيفات |
+| `icm_memoir_refine` | تحديث تعريف مفهوم |
+| `icm_memoir_search` | بحث نصي كامل، مع تصفية اختيارية بحسب التصنيف |
+| `icm_memoir_search_all` | البحث عبر جميع المذكرات |
+| `icm_memoir_link` | إنشاء علاقة مكتوبة بين مفهومين |
+| `icm_memoir_inspect` | فحص المفهوم والجوار في الرسم البياني (BFS) |
+| `icm_memoir_export` | تصدير الرسم البياني (json, dot, ascii, ai) مع مستويات الثقة |
+
+### أدوات التغذية الراجعة (التعلم من الأخطاء)
+
+| الأداة | الوصف |
+|--------|-------|
+| `icm_feedback_record` | تسجيل تصحيح عند خطأ توقع الذكاء الاصطناعي |
+| `icm_feedback_search` | البحث في التصحيحات السابقة لتوجيه التنبؤات المستقبلية |
+| `icm_feedback_stats` | إحصاءات التغذية الراجعة: العدد الإجمالي، التوزيع بحسب الموضوع، الأكثر تطبيقًا |
+
+### أنواع العلاقات
+
+`part_of` · `depends_on` · `related_to` · `contradicts` · `refines` · `alternative_to` · `caused_by` · `instance_of` · `superseded_by`
+
+## كيف يعمل
+
+### نموذج الذاكرة المزدوج
+
+**الذاكرة الحلقية (المواضيع)** تلتقط القرارات والأخطاء والتفضيلات. لكل ذكرى وزن يتلاشى مع الوقت بناءً على الأهمية:
+
+| الأهمية | التلاشي | الحذف | السلوك |
+|---------|--------|-------|--------|
+| `critical` | لا يوجد | أبدًا | لا تُنسى أبدًا، ولا تُحذف |
+| `high` | بطيء (0.5× المعدل) | أبدًا | تتلاشى ببطء، ولا تُحذف تلقائيًا |
+| `medium` | عادي | نعم | تلاشٍ قياسي، تُحذف عند انخفاض الوزن عن الحد |
+| `low` | سريع (2× المعدل) | نعم | تُنسى بسرعة |
+
+التلاشي **واعٍ بالوصول**: الذكريات المُستعادة بكثرة تتلاشى بشكل أبطأ (`decay / (1 + access_count × 0.1)`). يُطبَّق تلقائيًا عند الاسترجاع (إذا مضى >24 ساعة منذ آخر تلاشٍ).
+
+**نظافة الذاكرة** مدمجة:
+- **إزالة التكرار التلقائي**: تخزين محتوى بتشابه >85% مع ذكرى موجودة في نفس الموضوع يُحدّثها بدلًا من إنشاء نسخة مكررة
+- **تلميحات الدمج**: عندما يتجاوز موضوعٌ ما 7 مدخلات، يُنبّه `icm_memory_store` المستدعي بالدمج
+- **تدقيق الصحة**: يُقدّم `icm_memory_health` تقريرًا بعدد المدخلات في كل موضوع، ومتوسط الوزن، والمدخلات القديمة، والحاجة للدمج
+- **لا فقدان صامت للبيانات**: الذكريات الحرجة وعالية الأهمية لا تُحذف تلقائيًا أبدًا
+
+**الذاكرة الدلالية (المذكرات)** تلتقط المعرفة المنظمة كرسم بياني. المفاهيم دائمة — تُحسَّن ولا تتلاشى. استخدم `superseded_by` للإشارة إلى الحقائق المتقادمة بدلًا من حذفها.
+
+### البحث الهجين
+
+عند تفعيل التضمينات، يستخدم ICM البحث الهجين:
+- **FTS5 BM25** (30%) — مطابقة كلمات مفتاحية نصية كاملة
+- **تشابه جيب التمام** (70%) — بحث شعاعي دلالي عبر sqlite-vec
+
+النموذج الافتراضي: `intfloat/multilingual-e5-base` (768d، أكثر من 100 لغة). قابل للضبط في [ملف الضبط](#الضبط):
+
+```toml
+[embeddings]
+# enabled = false                          # تعطيل كليًا (بدون تنزيل نموذج)
+model = "intfloat/multilingual-e5-base"    # 768d، متعدد اللغات (الافتراضي)
+# model = "intfloat/multilingual-e5-small" # 384d، متعدد اللغات (أخف)
+# model = "intfloat/multilingual-e5-large" # 1024d، متعدد اللغات (أعلى دقة)
+# model = "Xenova/bge-small-en-v1.5"      # 384d، إنجليزي فقط (الأسرع)
+# model = "jinaai/jina-embeddings-v2-base-code"  # 768d، محسّن للكود
+```
+
+لتخطي تنزيل نموذج التضمين كليًا، استخدم أيًا مما يلي:
+```bash
+icm --no-embeddings serve          # علامة CLI
+ICM_NO_EMBEDDINGS=1 icm serve     # متغير بيئة
+```
+أو اضبط `enabled = false` في ملف الضبط. سيعود ICM إلى البحث بكلمات مفتاحية FTS5 (يعمل مع ذلك، لكن بدون مطابقة دلالية).
+
+تغيير النموذج يُعيد إنشاء فهرس الشعاعيات تلقائيًا (تُمسح التضمينات الموجودة ويمكن إعادة توليدها بـ `icm_memory_embed_all`).
+
+### التخزين
+
+ملف SQLite واحد. بدون خدمات خارجية، بدون تبعية على الشبكة.
+
+```
+~/Library/Application Support/dev.icm.icm/memories.db                    # macOS
+~/.local/share/dev.icm.icm/memories.db                                   # Linux
+C:\Users\<user>\AppData\Local\icm\icm\data\memories.db                   # Windows
+```
+
+### الضبط
+
+```bash
+icm config                    # عرض الضبط النشط
+```
+
+موقع ملف الضبط (خاص بكل منصة، أو `$ICM_CONFIG`):
+
+```
+~/Library/Application Support/dev.icm.icm/config.toml                    # macOS
+~/.config/icm/config.toml                                                # Linux
+C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml              # Windows
+```
+
+راجع [config/default.toml](config/default.toml) لجميع الخيارات.
+
+## الاستخراج التلقائي
+
+يستخرج ICM الذكريات تلقائيًا عبر ثلاث طبقات:
+
+```
+  Layer 0: Pattern hooks              Layer 1: PreCompact           Layer 2: UserPromptSubmit
+  (zero LLM cost)                     (zero LLM cost)               (zero LLM cost)
+  ┌──────────────────┐                ┌──────────────────┐          ┌──────────────────┐
+  │ PostToolUse hook  │                │ PreCompact hook   │          │ UserPromptSubmit  │
+  │                   │                │                   │          │                   │
+  │ • Bash errors     │                │ Context about to  │          │ User sends prompt │
+  │ • git commits     │                │ be compressed →   │          │ → icm recall      │
+  │ • config changes  │                │ extract memories  │          │ → inject context  │
+  │ • decisions       │                │ from transcript   │          │                   │
+  │ • preferences     │                │ before they're    │          │ Agent starts with  │
+  │ • learnings       │                │ lost forever      │          │ relevant memories  │
+  │ • constraints     │                │                   │          │ already loaded     │
+  │                   │                │ Same patterns +   │          │                   │
+  │ Rule-based, no LLM│                │ --store-raw fallbk│          │                   │
+  └──────────────────┘                └──────────────────┘          └──────────────────┘
+```
+
+| الطبقة | الحالة | تكلفة LLM | أمر الخطاف | الوصف |
+|--------|--------|-----------|-----------|-------|
+| الطبقة 0 | مُنفَّذة | 0 | `icm hook post` | استخراج كلمات مفتاحية قائم على القواعد من مخرجات الأداة |
+| الطبقة 1 | مُنفَّذة | 0 | `icm hook compact` | استخراج من النص قبل ضغط السياق |
+| الطبقة 2 | مُنفَّذة | 0 | `icm hook prompt` | حقن الذكريات المُستعادة عند كل موجه مستخدم |
+
+تُثبَّت الطبقات الثلاث تلقائيًا بـ `icm init --mode hook`.
+
+### مقارنة مع البدائل
+
+| النظام | الطريقة | تكلفة LLM | زمن الاستجابة | يلتقط الضغط؟ |
+|--------|--------|-----------|---------|---------------------|
+| **ICM** | استخراج بـ3 طبقات | 0 إلى ~500 رمز/جلسة | 0ms | **نعم (PreCompact)** |
+| Mem0 | استدعاءان LLM/رسالة | ~2k رمز/رسالة | 200-2000ms | لا |
+| claude-mem | PostToolUse + غير متزامن | ~1-5k رمز/جلسة | 8ms خطاف | لا |
+| MemGPT/Letta | العميل يدير نفسه | 0 هامشية | 0ms | لا |
+| DiffMem | فروق Git | 0 | 0ms | لا |
+
+## المعايير
+
+### أداء التخزين
+
+```
+ICM Benchmark (1000 memories, 384d embeddings)
+──────────────────────────────────────────────────────────
+Store (no embeddings)      1000 ops      34.2 ms      34.2 µs/op
+Store (with embeddings)    1000 ops      51.6 ms      51.6 µs/op
+FTS5 search                 100 ops       4.7 ms      46.6 µs/op
+Vector search (KNN)         100 ops      59.0 ms     590.0 µs/op
+Hybrid search               100 ops      95.1 ms     951.1 µs/op
+Decay (batch)                 1 ops       5.8 ms       5.8 ms/op
+──────────────────────────────────────────────────────────
+```
+
+Apple M1 Pro، SQLite في الذاكرة، خيط واحد. `icm bench --count 1000`
+
+### كفاءة العميل
+
+سير عمل متعدد الجلسات مع مشروع Rust حقيقي (12 ملفًا، ~550 سطرًا). الجلسات الثانية وما بعدها تُظهر أكبر المكاسب حيث يستعيد ICM بدلًا من إعادة قراءة الملفات.
+
+```
+ICM Agent Benchmark (10 sessions, model: haiku, 3 runs averaged)
+══════════════════════════════════════════════════════════════════
+                            Without ICM         With ICM      Delta
+Session 2 (recall)
+  Turns                             5.7              4.0       -29%
+  Context (input)                 99.9k            67.5k       -32%
+  Cost                          $0.0298          $0.0249       -17%
+
+Session 3 (recall)
+  Turns                             3.3              2.0       -40%
+  Context (input)                 74.7k            41.6k       -44%
+  Cost                          $0.0249          $0.0194       -22%
+══════════════════════════════════════════════════════════════════
+```
+
+`icm bench-agent --sessions 10 --model haiku`
+
+### احتفاظ المعرفة
+
+يستعيد العميل حقائق محددة من وثيقة تقنية مكثفة عبر الجلسات. الجلسة 1 تقرأ وتحفظ؛ الجلسات الثانية وما بعدها تجيب على 10 أسئلة واقعية **بدون** النص المصدر.
+
+```
+ICM Recall Benchmark (10 questions, model: haiku, 5 runs averaged)
+══════════════════════════════════════════════════════════════════════
+                                               No ICM     With ICM
+──────────────────────────────────────────────────────────────────────
+Average score                                      5%          68%
+Questions passed                                 0/10         5/10
+══════════════════════════════════════════════════════════════════════
+```
+
+`icm bench-recall --model haiku`
+
+### النماذج المحلية (ollama)
+
+نفس الاختبار مع النماذج المحلية — حقن السياق البحت، بدون حاجة لاستخدام الأدوات.
+
+```
+Model               Params   No ICM   With ICM     Delta
+─────────────────────────────────────────────────────────
+qwen2.5:14b           14B       4%       97%       +93%
+mistral:7b             7B       4%       93%       +89%
+llama3.1:8b            8B       4%       93%       +89%
+qwen2.5:7b             7B       4%       90%       +86%
+phi4:14b              14B       6%       79%       +73%
+llama3.2:3b            3B       0%       76%       +76%
+gemma2:9b              9B       4%       76%       +72%
+qwen2.5:3b             3B       2%       58%       +56%
+─────────────────────────────────────────────────────────
+```
+
+`scripts/bench-ollama.sh qwen2.5:14b`
+
+### بروتوكول الاختبار
+
+جميع المعايير تستخدم **استدعاءات API حقيقية** — بدون محاكاة، بدون ردود وهمية، بدون إجابات مخزنة مؤقتًا.
+
+- **معيار العميل**: يُنشئ مشروع Rust حقيقيًا في مجلد مؤقت. يُشغّل N جلسات مع `claude -p --output-format json`. بدون ICM: ضبط MCP فارغ. مع ICM: خادم MCP حقيقي + استخراج تلقائي + حقن السياق.
+- **احتفاظ المعرفة**: يستخدم وثيقة تقنية خيالية ("بروتوكول ميريديان"). يُسجّل الإجابات بمطابقة الكلمات المفتاحية مع الحقائق المتوقعة. مهلة 120 ثانية لكل استدعاء.
+- **العزل**: كل تشغيل يستخدم مجلده المؤقت الخاص وقاعدة بيانات SQLite جديدة. لا استمرارية للجلسة.
+
+## التوثيق
+
+| الوثيقة | الوصف |
+|---------|-------|
+| [البنية التقنية](docs/architecture.md) | هيكل الحزم، مسار البحث، نموذج التلاشي، تكامل sqlite-vec، الاختبار |
+| [دليل المستخدم](docs/guide.md) | التثبيت، تنظيم المواضيع، الدمج، الاستخراج، استكشاف الأخطاء |
+| [نظرة عامة على المنتج](docs/product.md) | حالات الاستخدام، المعايير، المقارنة مع البدائل |
+
+## الترخيص
+
+[المصدر المتاح](LICENSE) — مجاني للأفراد والفرق التي لا يتجاوز عددها 20 شخصًا. يُشترط ترخيص المؤسسات للمنظمات الأكبر. التواصل: license@rtk.ai

--- a/README_de.md
+++ b/README_de.md
@@ -1,0 +1,454 @@
+[English](README.md) | [Français](README_fr.md) | [Español](README_es.md) | **Deutsch** | [Italiano](README_it.md) | [Português](README_pt.md) | [Nederlands](README_nl.md) | [Polski](README_pl.md) | [Русский](README_ru.md) | [日本語](README_ja.md) | [中文](README_zh.md) | [العربية](README_ar.md) | [한국어](README_ko.md)
+
+<p align="center">
+  <img src="assets/banner.png" alt="ICM — Infinite Context Memory" width="600">
+</p>
+
+<h1 align="center">ICM</h1>
+
+<p align="center">
+  Persistentes Gedächtnis für KI-Agenten. Einzelne Binärdatei, keine Abhängigkeiten, MCP-nativ.
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/icm/actions/workflows/ci.yml"><img src="https://github.com/rtk-ai/icm/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/icm/releases/latest"><img src="https://img.shields.io/github/v/release/rtk-ai/icm?color=purple" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Source--Available-orange.svg" alt="Source-Available"></a>
+</p>
+
+---
+
+ICM gibt Ihrem KI-Agenten ein echtes Gedächtnis — kein Notiztool, kein Kontextmanager, sondern ein **Gedächtnis**.
+
+```
+                       ICM (Infinite Context Memory)
+            ┌──────────────────────┬─────────────────────────┐
+            │   MEMORIES (Topics)  │   MEMOIRS (Knowledge)   │
+            │                      │                         │
+            │  Episodisch, temporal│  Permanent, strukturiert│
+            │                      │                         │
+            │  ┌───┐ ┌───┐ ┌───┐  │    ┌───┐               │
+            │  │ m │ │ m │ │ m │  │    │ C │──depends_on──┐ │
+            │  └─┬─┘ └─┬─┘ └─┬─┘  │    └───┘              │ │
+            │    │decay │     │    │      │ refines      ┌─▼─┐│
+            │    ▼      ▼     ▼    │    ┌─▼─┐            │ C ││
+            │  weight decreases    │    │ C │──part_of──>└───┘│
+            │  over time unless    │    └───┘                 │
+            │  accessed/critical   │  Concepts + Relations    │
+            ├──────────────────────┴─────────────────────────┤
+            │             SQLite + FTS5 + sqlite-vec          │
+            │        Hybrid search: BM25 (30%) + cosine (70%) │
+            └─────────────────────────────────────────────────┘
+```
+
+**Zwei Gedächtnismodelle:**
+
+- **Memories** — Speichern und Abrufen mit zeitlichem Verfall nach Wichtigkeit. Kritische Erinnerungen verblassen nie, unwichtige verblassen natürlich. Nach Thema oder Schlüsselwort filtern.
+- **Memoirs** — Permanente Wissensgraphen. Konzepte verknüpft durch typisierte Relationen (`depends_on`, `contradicts`, `superseded_by`, ...). Nach Label filtern.
+- **Feedback** — Korrekturen aufzeichnen, wenn KI-Vorhersagen falsch sind. Vergangene Fehler durchsuchen, bevor neue Vorhersagen gemacht werden. Geschlossener Lernkreislauf.
+
+## Installation
+
+```bash
+# Homebrew (macOS / Linux)
+brew tap rtk-ai/tap && brew install icm
+
+# Schnellinstallation
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+
+# Aus Quellcode
+cargo install --path crates/icm-cli
+```
+
+## Einrichtung
+
+```bash
+# Alle unterstützten Tools automatisch erkennen und konfigurieren
+icm init
+```
+
+Konfiguriert **14 Tools** mit einem einzigen Befehl:
+
+| Tool | Konfigurationsdatei | Format |
+|------|---------------------|--------|
+| Claude Code | `~/.claude.json` | JSON |
+| Claude Desktop | `~/Library/.../claude_desktop_config.json` | JSON |
+| Cursor | `~/.cursor/mcp.json` | JSON |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON |
+| VS Code / Copilot | `~/Library/.../Code/User/mcp.json` | JSON |
+| Gemini Code Assist | `~/.gemini/settings.json` | JSON |
+| Zed | `~/.zed/settings.json` | JSON |
+| Amp | `~/.config/amp/settings.json` | JSON |
+| Amazon Q | `~/.aws/amazonq/mcp.json` | JSON |
+| Cline | VS Code globalStorage | JSON |
+| Roo Code | VS Code globalStorage | JSON |
+| Kilo Code | VS Code globalStorage | JSON |
+| OpenAI Codex CLI | `~/.codex/config.toml` | TOML |
+| OpenCode | `~/.config/opencode/opencode.json` | JSON |
+
+Oder manuell:
+
+```bash
+# Claude Code
+claude mcp add icm -- icm serve
+
+# Kompaktmodus (kürzere Antworten, spart Tokens)
+claude mcp add icm -- icm serve --compact
+
+# Beliebiger MCP-Client: command = "icm", args = ["serve"]
+```
+
+### Skills / Regeln
+
+```bash
+icm init --mode skill
+```
+
+Installiert Slash-Befehle und Regeln für Claude Code (`/recall`, `/remember`), Cursor (`.mdc`-Regel), Roo Code (`.md`-Regel) und Amp (`/icm-recall`, `/icm-remember`).
+
+### Hooks (Claude Code)
+
+```bash
+icm init --mode hook
+```
+
+Installiert alle 3 Extraktionsebenen als Claude Code Hooks:
+
+**Claude Code** Hooks:
+
+| Hook | Ereignis | Funktion |
+|------|----------|----------|
+| `icm hook pre` | PreToolUse | `icm` CLI-Befehle automatisch erlauben (keine Berechtigungsabfrage) |
+| `icm hook post` | PostToolUse | Fakten aus Tool-Ausgaben alle 15 Aufrufe extrahieren |
+| `icm hook compact` | PreCompact | Erinnerungen aus Transkript vor der Kontextkomprimierung extrahieren |
+| `icm hook prompt` | UserPromptSubmit | Abgerufenen Kontext am Anfang jeder Eingabe einfügen |
+
+**OpenCode** Plugin (automatisch installiert nach `~/.config/opencode/plugins/icm.js`):
+
+| OpenCode-Ereignis | ICM-Ebene | Funktion |
+|-------------------|-----------|----------|
+| `tool.execute.after` | Layer 0 | Fakten aus Tool-Ausgaben extrahieren |
+| `experimental.session.compacting` | Layer 1 | Aus Konversation vor der Komprimierung extrahieren |
+| `session.created` | Layer 2 | Kontext beim Sitzungsstart abrufen |
+
+## CLI vs MCP
+
+ICM kann über die CLI (`icm`-Befehle) oder den MCP-Server (`icm serve`) verwendet werden. Beide greifen auf dieselbe Datenbank zu.
+
+| | CLI | MCP |
+|---|-----|-----|
+| **Latenz** | ~30ms (direkte Binärdatei) | ~50ms (JSON-RPC stdio) |
+| **Token-Kosten** | 0 (hook-basiert, unsichtbar) | ~20-50 Tokens/Aufruf (Tool-Schema) |
+| **Einrichtung** | `icm init --mode hook` | `icm init --mode mcp` |
+| **Kompatibel mit** | Claude Code, OpenCode (über Hooks/Plugins) | Allen 14 MCP-kompatiblen Tools |
+| **Auto-Extraktion** | Ja (Hooks lösen `icm extract` aus) | Ja (MCP-Tools rufen store auf) |
+| **Geeignet für** | Power-User, Token-Einsparung | Universelle Kompatibilität |
+
+## CLI
+
+### Memories (episodisch, mit Verfall)
+
+```bash
+# Speichern
+icm store -t "my-project" -c "Use PostgreSQL for the main DB" -i high -k "db,postgres"
+
+# Abrufen
+icm recall "database choice"
+icm recall "auth setup" --topic "my-project" --limit 10
+icm recall "architecture" --keyword "postgres"
+
+# Verwalten
+icm forget <memory-id>
+icm consolidate --topic "my-project"
+icm topics
+icm stats
+
+# Fakten aus Text extrahieren (regelbasiert, keine LLM-Kosten)
+echo "The parser uses Pratt algorithm" | icm extract -p my-project
+```
+
+### Memoirs (permanente Wissensgraphen)
+
+```bash
+# Memoir erstellen
+icm memoir create -n "system-architecture" -d "System design decisions"
+
+# Konzepte mit Labels hinzufügen
+icm memoir add-concept -m "system-architecture" -n "auth-service" \
+  -d "Handles JWT tokens and OAuth2 flows" -l "domain:auth,type:service"
+
+# Konzepte verknüpfen
+icm memoir link -m "system-architecture" --from "api-gateway" --to "auth-service" -r depends-on
+
+# Mit Label-Filter suchen
+icm memoir search -m "system-architecture" "authentication"
+icm memoir search -m "system-architecture" "service" --label "domain:auth"
+
+# Nachbarschaft inspizieren
+icm memoir inspect -m "system-architecture" "auth-service" -D 2
+
+# Graphen exportieren (Formate: json, dot, ascii, ai)
+icm memoir export -m "system-architecture" -f ascii   # Boxzeichnungen mit Konfidenzbalkenz
+icm memoir export -m "system-architecture" -f dot      # Graphviz DOT (Farbe = Konfidenzgrad)
+icm memoir export -m "system-architecture" -f ai       # Markdown optimiert für LLM-Kontext
+icm memoir export -m "system-architecture" -f json     # Strukturiertes JSON mit allen Metadaten
+
+# SVG-Visualisierung erzeugen
+icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
+```
+
+## MCP-Tools (22)
+
+### Gedächtnis-Tools
+
+| Tool | Beschreibung |
+|------|--------------|
+| `icm_memory_store` | Speichern mit Auto-Deduplizierung (>85% Ähnlichkeit → Aktualisierung statt Duplikat) |
+| `icm_memory_recall` | Suche nach Abfrage, Filter nach Thema und/oder Schlüsselwort |
+| `icm_memory_update` | Erinnerung direkt bearbeiten (Inhalt, Wichtigkeit, Schlüsselwörter) |
+| `icm_memory_forget` | Erinnerung anhand ID löschen |
+| `icm_memory_consolidate` | Alle Erinnerungen eines Themas zu einer Zusammenfassung zusammenführen |
+| `icm_memory_list_topics` | Alle Themen mit Anzahl auflisten |
+| `icm_memory_stats` | Globale Gedächtnisstatistiken |
+| `icm_memory_health` | Hygiene-Prüfung pro Thema (Veralterung, Konsolidierungsbedarf) |
+| `icm_memory_embed_all` | Fehlende Embeddings für die Vektorsuche nachträglich erzeugen |
+
+### Memoir-Tools (Wissensgraphen)
+
+| Tool | Beschreibung |
+|------|--------------|
+| `icm_memoir_create` | Neues Memoir erstellen (Wissenscontainer) |
+| `icm_memoir_list` | Alle Memoirs auflisten |
+| `icm_memoir_show` | Memoir-Details und alle Konzepte anzeigen |
+| `icm_memoir_add_concept` | Konzept mit Labels hinzufügen |
+| `icm_memoir_refine` | Definition eines Konzepts aktualisieren |
+| `icm_memoir_search` | Volltextsuche, optional nach Label gefiltert |
+| `icm_memoir_search_all` | Über alle Memoirs hinweg suchen |
+| `icm_memoir_link` | Typisierte Relation zwischen Konzepten erstellen |
+| `icm_memoir_inspect` | Konzept und Graph-Nachbarschaft inspizieren (BFS) |
+| `icm_memoir_export` | Graphen exportieren (json, dot, ascii, ai) mit Konfidenzgraden |
+
+### Feedback-Tools (Lernen aus Fehlern)
+
+| Tool | Beschreibung |
+|------|--------------|
+| `icm_feedback_record` | Korrektur aufzeichnen, wenn eine KI-Vorhersage falsch war |
+| `icm_feedback_search` | Vergangene Korrekturen durchsuchen, um künftige Vorhersagen zu verbessern |
+| `icm_feedback_stats` | Feedback-Statistiken: Gesamtanzahl, Aufschlüsselung nach Thema, am häufigsten angewandt |
+
+### Relationstypen
+
+`part_of` · `depends_on` · `related_to` · `contradicts` · `refines` · `alternative_to` · `caused_by` · `instance_of` · `superseded_by`
+
+## Funktionsweise
+
+### Duales Gedächtnismodell
+
+Das **episodische Gedächtnis (Topics)** erfasst Entscheidungen, Fehler und Präferenzen. Jede Erinnerung hat ein Gewicht, das im Laufe der Zeit je nach Wichtigkeit abnimmt:
+
+| Wichtigkeit | Verfall | Bereinigung | Verhalten |
+|-------------|---------|-------------|-----------|
+| `critical` | keiner | nie | Wird nie vergessen, nie bereinigt |
+| `high` | langsam (0,5× Rate) | nie | Verblasst langsam, wird nie automatisch gelöscht |
+| `medium` | normal | ja | Standardverfall, bereinigt wenn Gewicht < Schwellenwert |
+| `low` | schnell (2× Rate) | ja | Wird schnell vergessen |
+
+Der Verfall ist **zugriffsbewusst**: häufig abgerufene Erinnerungen verblassen langsamer (`decay / (1 + access_count × 0.1)`). Wird automatisch beim Abrufen angewendet (wenn >24h seit dem letzten Verfall).
+
+**Gedächtnis-Hygiene** ist eingebaut:
+- **Auto-Deduplizierung**: Wird Inhalt mit >85% Ähnlichkeit zu einer bestehenden Erinnerung im selben Thema gespeichert, wird diese aktualisiert statt ein Duplikat zu erstellen
+- **Konsolidierungshinweise**: Überschreitet ein Thema 7 Einträge, warnt `icm_memory_store` den Aufrufer zur Konsolidierung
+- **Hygiene-Prüfung**: `icm_memory_health` meldet Eintragsanzahl, durchschnittliches Gewicht, veraltete Einträge und Konsolidierungsbedarf pro Thema
+- **Kein stiller Datenverlust**: Kritische und hochwertige Erinnerungen werden nie automatisch bereinigt
+
+Das **semantische Gedächtnis (Memoirs)** erfasst strukturiertes Wissen als Graphen. Konzepte sind permanent — sie werden verfeinert, nicht veraltet. Verwenden Sie `superseded_by`, um veraltete Fakten zu kennzeichnen, anstatt sie zu löschen.
+
+### Hybridsuche
+
+Mit aktivierten Embeddings verwendet ICM Hybridsuche:
+- **FTS5 BM25** (30%) — Volltextstichwortsuche
+- **Kosinus-Ähnlichkeit** (70%) — Semantische Vektorsuche via sqlite-vec
+
+Standardmodell: `intfloat/multilingual-e5-base` (768d, 100+ Sprachen). Konfigurierbar in der [Konfigurationsdatei](#konfiguration):
+
+```toml
+[embeddings]
+# enabled = false                          # Vollständig deaktivieren (kein Modell-Download)
+model = "intfloat/multilingual-e5-base"    # 768d, mehrsprachig (Standard)
+# model = "intfloat/multilingual-e5-small" # 384d, mehrsprachig (leichter)
+# model = "intfloat/multilingual-e5-large" # 1024d, mehrsprachig (beste Genauigkeit)
+# model = "Xenova/bge-small-en-v1.5"      # 384d, nur Englisch (schnellstes)
+# model = "jinaai/jina-embeddings-v2-base-code"  # 768d, code-optimiert
+```
+
+Um den Embedding-Modell-Download vollständig zu überspringen, verwenden Sie eine der folgenden Optionen:
+```bash
+icm --no-embeddings serve          # CLI-Flag
+ICM_NO_EMBEDDINGS=1 icm serve     # Umgebungsvariable
+```
+Oder setzen Sie `enabled = false` in Ihrer Konfigurationsdatei. ICM fällt auf FTS5-Schlüsselwortsuche zurück (funktioniert weiterhin, nur ohne semantisches Matching).
+
+Durch Ändern des Modells wird der Vektorindex automatisch neu erstellt (vorhandene Embeddings werden gelöscht und können mit `icm_memory_embed_all` neu erzeugt werden).
+
+### Speicherung
+
+Einzelne SQLite-Datei. Keine externen Dienste, keine Netzwerkabhängigkeit.
+
+```
+~/Library/Application Support/dev.icm.icm/memories.db                    # macOS
+~/.local/share/dev.icm.icm/memories.db                                   # Linux
+C:\Users\<user>\AppData\Local\icm\icm\data\memories.db                   # Windows
+```
+
+### Konfiguration
+
+```bash
+icm config                    # Aktive Konfiguration anzeigen
+```
+
+Speicherort der Konfigurationsdatei (plattformspezifisch oder `$ICM_CONFIG`):
+
+```
+~/Library/Application Support/dev.icm.icm/config.toml                    # macOS
+~/.config/icm/config.toml                                                # Linux
+C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml              # Windows
+```
+
+Alle Optionen finden Sie unter [config/default.toml](config/default.toml).
+
+## Auto-Extraktion
+
+ICM extrahiert Erinnerungen automatisch über drei Ebenen:
+
+```
+  Ebene 0: Pattern-Hooks            Ebene 1: PreCompact           Ebene 2: UserPromptSubmit
+  (keine LLM-Kosten)                (keine LLM-Kosten)            (keine LLM-Kosten)
+  ┌──────────────────┐                ┌──────────────────┐          ┌──────────────────┐
+  │ PostToolUse hook  │                │ PreCompact hook   │          │ UserPromptSubmit  │
+  │                   │                │                   │          │                   │
+  │ • Bash-Fehler     │                │ Kontext wird      │          │ Nutzer sendet     │
+  │ • git commits     │                │ komprimiert →     │          │ Eingabe           │
+  │ • Konfig-Änder.   │                │ Erinnerungen aus  │          │ → icm recall      │
+  │ • Entscheidungen  │                │ Transkript         │          │ → Kontext einfügen│
+  │ • Präferenzen     │                │ extrahieren bevor │          │                   │
+  │ • Erkenntnisse    │                │ sie verloren gehen│          │ Agent startet mit  │
+  │ • Einschränkungen │                │                   │          │ relevanten Erinne-│
+  │                   │                │ Gleiche Muster +  │          │ rungen geladen    │
+  │ Regelbasiert,     │                │ --store-raw Fallbk│          │                   │
+  │ kein LLM          │                │                   │          │                   │
+  └──────────────────┘                └──────────────────┘          └──────────────────┘
+```
+
+| Ebene | Status | LLM-Kosten | Hook-Befehl | Beschreibung |
+|-------|--------|------------|-------------|--------------|
+| Ebene 0 | Implementiert | 0 | `icm hook post` | Regelbasierte Schlüsselwortextraktion aus Tool-Ausgaben |
+| Ebene 1 | Implementiert | 0 | `icm hook compact` | Extraktion aus Transkript vor der Kontextkomprimierung |
+| Ebene 2 | Implementiert | 0 | `icm hook prompt` | Erinnerungen bei jeder Nutzereingabe einfügen |
+
+Alle 3 Ebenen werden automatisch durch `icm init --mode hook` installiert.
+
+### Vergleich mit Alternativen
+
+| System | Methode | LLM-Kosten | Latenz | Erfasst Komprimierung? |
+|--------|---------|------------|--------|------------------------|
+| **ICM** | 3-Ebenen-Extraktion | 0 bis ~500 Tok/Sitzung | 0ms | **Ja (PreCompact)** |
+| Mem0 | 2 LLM-Aufrufe/Nachricht | ~2k Tok/Nachricht | 200-2000ms | Nein |
+| claude-mem | PostToolUse + async | ~1-5k Tok/Sitzung | 8ms Hook | Nein |
+| MemGPT/Letta | Agent selbstverwaltend | 0 marginal | 0ms | Nein |
+| DiffMem | Git-basierte Diffs | 0 | 0ms | Nein |
+
+## Benchmarks
+
+### Speicherleistung
+
+```
+ICM Benchmark (1000 memories, 384d embeddings)
+──────────────────────────────────────────────────────────
+Store (no embeddings)      1000 ops      34.2 ms      34.2 µs/op
+Store (with embeddings)    1000 ops      51.6 ms      51.6 µs/op
+FTS5 search                 100 ops       4.7 ms      46.6 µs/op
+Vector search (KNN)         100 ops      59.0 ms     590.0 µs/op
+Hybrid search               100 ops      95.1 ms     951.1 µs/op
+Decay (batch)                 1 ops       5.8 ms       5.8 ms/op
+──────────────────────────────────────────────────────────
+```
+
+Apple M1 Pro, In-Memory-SQLite, single-threaded. `icm bench --count 1000`
+
+### Agenteneffizienz
+
+Mehrere Sitzungen mit einem echten Rust-Projekt (12 Dateien, ~550 Zeilen). Ab Sitzung 2 zeigen sich die größten Gewinne, da ICM abruft statt Dateien erneut zu lesen.
+
+```
+ICM Agent Benchmark (10 sessions, model: haiku, 3 runs averaged)
+══════════════════════════════════════════════════════════════════
+                            Without ICM         With ICM      Delta
+Session 2 (recall)
+  Turns                             5.7              4.0       -29%
+  Context (input)                 99.9k            67.5k       -32%
+  Cost                          $0.0298          $0.0249       -17%
+
+Session 3 (recall)
+  Turns                             3.3              2.0       -40%
+  Context (input)                 74.7k            41.6k       -44%
+  Cost                          $0.0249          $0.0194       -22%
+══════════════════════════════════════════════════════════════════
+```
+
+`icm bench-agent --sessions 10 --model haiku`
+
+### Wissenserhalt
+
+Der Agent ruft spezifische Fakten aus einem dichten technischen Dokument über mehrere Sitzungen ab. Sitzung 1 liest und memoriert; Sitzung 2+ beantwortet 10 Sachfragen **ohne** den Quellentext.
+
+```
+ICM Recall Benchmark (10 questions, model: haiku, 5 runs averaged)
+══════════════════════════════════════════════════════════════════════
+                                               No ICM     With ICM
+──────────────────────────────────────────────────────────────────────
+Average score                                      5%          68%
+Questions passed                                 0/10         5/10
+══════════════════════════════════════════════════════════════════════
+```
+
+`icm bench-recall --model haiku`
+
+### Lokale LLMs (ollama)
+
+Gleicher Test mit lokalen Modellen — reine Kontextinjektion, keine Tool-Nutzung erforderlich.
+
+```
+Model               Params   No ICM   With ICM     Delta
+─────────────────────────────────────────────────────────
+qwen2.5:14b           14B       4%       97%       +93%
+mistral:7b             7B       4%       93%       +89%
+llama3.1:8b            8B       4%       93%       +89%
+qwen2.5:7b             7B       4%       90%       +86%
+phi4:14b              14B       6%       79%       +73%
+llama3.2:3b            3B       0%       76%       +76%
+gemma2:9b              9B       4%       76%       +72%
+qwen2.5:3b             3B       2%       58%       +56%
+─────────────────────────────────────────────────────────
+```
+
+`scripts/bench-ollama.sh qwen2.5:14b`
+
+### Testprotokoll
+
+Alle Benchmarks verwenden **echte API-Aufrufe** — keine Mocks, keine simulierten Antworten, keine gecachten Ergebnisse.
+
+- **Agenten-Benchmark**: Erstellt ein echtes Rust-Projekt in einem temporären Verzeichnis. Führt N Sitzungen mit `claude -p --output-format json` aus. Ohne ICM: leere MCP-Konfiguration. Mit ICM: echter MCP-Server + Auto-Extraktion + Kontextinjektion.
+- **Wissenserhalt**: Verwendet ein fiktives technisches Dokument (das „Meridian Protocol"). Bewertet Antworten durch Schlüsselwortabgleich mit erwarteten Fakten. 120s Zeitlimit pro Aufruf.
+- **Isolation**: Jeder Lauf verwendet ein eigenes temporäres Verzeichnis und eine frische SQLite-Datenbank. Keine Sitzungspersistenz.
+
+## Dokumentation
+
+| Dokument | Beschreibung |
+|----------|--------------|
+| [Technische Architektur](docs/architecture.md) | Crate-Struktur, Such-Pipeline, Verfallsmodell, sqlite-vec-Integration, Tests |
+| [Benutzerhandbuch](docs/guide.md) | Installation, Themenorganisation, Konsolidierung, Extraktion, Fehlerbehebung |
+| [Produktübersicht](docs/product.md) | Anwendungsfälle, Benchmarks, Vergleich mit Alternativen |
+
+## Lizenz
+
+[Source-Available](LICENSE) — Kostenlos für Einzelpersonen und Teams mit bis zu 20 Personen. Für größere Organisationen ist eine Unternehmenslizenz erforderlich. Kontakt: license@rtk.ai

--- a/README_es.md
+++ b/README_es.md
@@ -1,0 +1,454 @@
+[English](README.md) | [Français](README_fr.md) | **Español** | [Deutsch](README_de.md) | [Italiano](README_it.md) | [Português](README_pt.md) | [Nederlands](README_nl.md) | [Polski](README_pl.md) | [Русский](README_ru.md) | [日本語](README_ja.md) | [中文](README_zh.md) | [العربية](README_ar.md) | [한국어](README_ko.md)
+
+<p align="center">
+  <img src="assets/banner.png" alt="ICM — Infinite Context Memory" width="600">
+</p>
+
+<h1 align="center">ICM</h1>
+
+<p align="center">
+  Memoria permanente para agentes de IA. Binario único, sin dependencias, MCP nativo.
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/icm/actions/workflows/ci.yml"><img src="https://github.com/rtk-ai/icm/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/icm/releases/latest"><img src="https://img.shields.io/github/v/release/rtk-ai/icm?color=purple" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Source--Available-orange.svg" alt="Source-Available"></a>
+</p>
+
+---
+
+ICM le da a tu agente de IA una memoria real — no una herramienta de notas, no un gestor de contexto, una **memoria**.
+
+```
+                       ICM (Infinite Context Memory)
+            ┌──────────────────────┬─────────────────────────┐
+            │   MEMORIES (Topics)  │   MEMOIRS (Knowledge)   │
+            │                      │                         │
+            │  Episodic, temporal  │  Permanent, structured  │
+            │                      │                         │
+            │  ┌───┐ ┌───┐ ┌───┐  │    ┌───┐               │
+            │  │ m │ │ m │ │ m │  │    │ C │──depends_on──┐ │
+            │  └─┬─┘ └─┬─┘ └─┬─┘  │    └───┘              │ │
+            │    │decay │     │    │      │ refines      ┌─▼─┐│
+            │    ▼      ▼     ▼    │    ┌─▼─┐            │ C ││
+            │  weight decreases    │    │ C │──part_of──>└───┘│
+            │  over time unless    │    └───┘                 │
+            │  accessed/critical   │  Concepts + Relations    │
+            ├──────────────────────┴─────────────────────────┤
+            │             SQLite + FTS5 + sqlite-vec          │
+            │        Hybrid search: BM25 (30%) + cosine (70%) │
+            └─────────────────────────────────────────────────┘
+```
+
+**Dos modelos de memoria:**
+
+- **Memories** — almacena/recupera con decaimiento temporal por importancia. Las memorias críticas nunca desaparecen, las de baja importancia decaen de forma natural. Filtra por tema o palabra clave.
+- **Memoirs** — grafos de conocimiento permanentes. Conceptos vinculados por relaciones tipadas (`depends_on`, `contradicts`, `superseded_by`, ...). Filtra por etiqueta.
+- **Feedback** — registra correcciones cuando las predicciones de la IA son incorrectas. Busca errores pasados antes de hacer nuevas predicciones. Aprendizaje de bucle cerrado.
+
+## Instalación
+
+```bash
+# Homebrew (macOS / Linux)
+brew tap rtk-ai/tap && brew install icm
+
+# Instalación rápida
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+
+# Desde el código fuente
+cargo install --path crates/icm-cli
+```
+
+## Configuración inicial
+
+```bash
+# Detectar y configurar automáticamente todas las herramientas soportadas
+icm init
+```
+
+Configura **14 herramientas** con un solo comando:
+
+| Herramienta | Archivo de configuración | Formato |
+|-------------|--------------------------|---------|
+| Claude Code | `~/.claude.json` | JSON |
+| Claude Desktop | `~/Library/.../claude_desktop_config.json` | JSON |
+| Cursor | `~/.cursor/mcp.json` | JSON |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON |
+| VS Code / Copilot | `~/Library/.../Code/User/mcp.json` | JSON |
+| Gemini Code Assist | `~/.gemini/settings.json` | JSON |
+| Zed | `~/.zed/settings.json` | JSON |
+| Amp | `~/.config/amp/settings.json` | JSON |
+| Amazon Q | `~/.aws/amazonq/mcp.json` | JSON |
+| Cline | VS Code globalStorage | JSON |
+| Roo Code | VS Code globalStorage | JSON |
+| Kilo Code | VS Code globalStorage | JSON |
+| OpenAI Codex CLI | `~/.codex/config.toml` | TOML |
+| OpenCode | `~/.config/opencode/opencode.json` | JSON |
+
+O manualmente:
+
+```bash
+# Claude Code
+claude mcp add icm -- icm serve
+
+# Modo compacto (respuestas más cortas, ahorra tokens)
+claude mcp add icm -- icm serve --compact
+
+# Cualquier cliente MCP: command = "icm", args = ["serve"]
+```
+
+### Skills / rules
+
+```bash
+icm init --mode skill
+```
+
+Instala comandos slash y reglas para Claude Code (`/recall`, `/remember`), Cursor (regla `.mdc`), Roo Code (regla `.md`) y Amp (`/icm-recall`, `/icm-remember`).
+
+### Hooks (Claude Code)
+
+```bash
+icm init --mode hook
+```
+
+Instala las 3 capas de extracción como hooks de Claude Code:
+
+**Hooks de Claude Code**:
+
+| Hook | Evento | Qué hace |
+|------|--------|----------|
+| `icm hook pre` | PreToolUse | Permite automáticamente los comandos CLI `icm` (sin prompt de permiso) |
+| `icm hook post` | PostToolUse | Extrae hechos de la salida de herramientas cada 15 llamadas |
+| `icm hook compact` | PreCompact | Extrae memorias del transcript antes de la compresión de contexto |
+| `icm hook prompt` | UserPromptSubmit | Inyecta contexto recuperado al inicio de cada prompt |
+
+**Plugin de OpenCode** (instalado automáticamente en `~/.config/opencode/plugins/icm.js`):
+
+| Evento de OpenCode | Capa ICM | Qué hace |
+|--------------------|----------|----------|
+| `tool.execute.after` | Capa 0 | Extrae hechos de la salida de herramientas |
+| `experimental.session.compacting` | Capa 1 | Extrae de la conversación antes de la compactación |
+| `session.created` | Capa 2 | Recupera contexto al inicio de la sesión |
+
+## CLI vs MCP
+
+ICM puede usarse vía CLI (comandos `icm`) o servidor MCP (`icm serve`). Ambos acceden a la misma base de datos.
+
+| | CLI | MCP |
+|---|-----|-----|
+| **Latencia** | ~30ms (binario directo) | ~50ms (JSON-RPC stdio) |
+| **Coste en tokens** | 0 (basado en hooks, invisible) | ~20-50 tokens/llamada (esquema de herramienta) |
+| **Configuración** | `icm init --mode hook` | `icm init --mode mcp` |
+| **Compatible con** | Claude Code, OpenCode (vía hooks/plugins) | Las 14 herramientas compatibles con MCP |
+| **Auto-extracción** | Sí (los hooks lanzan `icm extract`) | Sí (las herramientas MCP llaman a store) |
+| **Ideal para** | Usuarios avanzados, ahorro de tokens | Compatibilidad universal |
+
+## CLI
+
+### Memories (episódicas, con decaimiento)
+
+```bash
+# Almacenar
+icm store -t "my-project" -c "Use PostgreSQL for the main DB" -i high -k "db,postgres"
+
+# Recuperar
+icm recall "database choice"
+icm recall "auth setup" --topic "my-project" --limit 10
+icm recall "architecture" --keyword "postgres"
+
+# Gestionar
+icm forget <memory-id>
+icm consolidate --topic "my-project"
+icm topics
+icm stats
+
+# Extraer hechos de texto (basado en reglas, sin coste LLM)
+echo "The parser uses Pratt algorithm" | icm extract -p my-project
+```
+
+### Memoirs (grafos de conocimiento permanentes)
+
+```bash
+# Crear un memoir
+icm memoir create -n "system-architecture" -d "System design decisions"
+
+# Añadir conceptos con etiquetas
+icm memoir add-concept -m "system-architecture" -n "auth-service" \
+  -d "Handles JWT tokens and OAuth2 flows" -l "domain:auth,type:service"
+
+# Vincular conceptos
+icm memoir link -m "system-architecture" --from "api-gateway" --to "auth-service" -r depends-on
+
+# Buscar con filtro de etiqueta
+icm memoir search -m "system-architecture" "authentication"
+icm memoir search -m "system-architecture" "service" --label "domain:auth"
+
+# Inspeccionar vecindad
+icm memoir inspect -m "system-architecture" "auth-service" -D 2
+
+# Exportar grafo (formatos: json, dot, ascii, ai)
+icm memoir export -m "system-architecture" -f ascii   # Dibujo en caja con barras de confianza
+icm memoir export -m "system-architecture" -f dot      # Graphviz DOT (color = nivel de confianza)
+icm memoir export -m "system-architecture" -f ai       # Markdown optimizado para contexto LLM
+icm memoir export -m "system-architecture" -f json     # JSON estructurado con todos los metadatos
+
+# Generar visualización SVG
+icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
+```
+
+## Herramientas MCP (22)
+
+### Herramientas de Memory
+
+| Herramienta | Descripción |
+|-------------|-------------|
+| `icm_memory_store` | Almacena con deduplicación automática (>85% similitud → actualiza en lugar de duplicar) |
+| `icm_memory_recall` | Busca por consulta, filtra por tema y/o palabra clave |
+| `icm_memory_update` | Edita una memoria en el lugar (contenido, importancia, palabras clave) |
+| `icm_memory_forget` | Elimina una memoria por ID |
+| `icm_memory_consolidate` | Fusiona todas las memorias de un tema en un único resumen |
+| `icm_memory_list_topics` | Lista todos los temas con sus conteos |
+| `icm_memory_stats` | Estadísticas globales de memoria |
+| `icm_memory_health` | Auditoría de higiene por tema (antigüedad, necesidades de consolidación) |
+| `icm_memory_embed_all` | Rellena embeddings para búsqueda vectorial |
+
+### Herramientas de Memoir (grafos de conocimiento)
+
+| Herramienta | Descripción |
+|-------------|-------------|
+| `icm_memoir_create` | Crea un nuevo memoir (contenedor de conocimiento) |
+| `icm_memoir_list` | Lista todos los memoirs |
+| `icm_memoir_show` | Muestra los detalles del memoir y todos los conceptos |
+| `icm_memoir_add_concept` | Añade un concepto con etiquetas |
+| `icm_memoir_refine` | Actualiza la definición de un concepto |
+| `icm_memoir_search` | Búsqueda de texto completo, opcionalmente filtrada por etiqueta |
+| `icm_memoir_search_all` | Busca en todos los memoirs |
+| `icm_memoir_link` | Crea una relación tipada entre conceptos |
+| `icm_memoir_inspect` | Inspecciona el concepto y la vecindad del grafo (BFS) |
+| `icm_memoir_export` | Exporta el grafo (json, dot, ascii, ai) con niveles de confianza |
+
+### Herramientas de Feedback (aprendizaje de errores)
+
+| Herramienta | Descripción |
+|-------------|-------------|
+| `icm_feedback_record` | Registra una corrección cuando una predicción de IA fue incorrecta |
+| `icm_feedback_search` | Busca correcciones pasadas para informar predicciones futuras |
+| `icm_feedback_stats` | Estadísticas de feedback: total, desglose por tema, más aplicados |
+
+### Tipos de relación
+
+`part_of` · `depends_on` · `related_to` · `contradicts` · `refines` · `alternative_to` · `caused_by` · `instance_of` · `superseded_by`
+
+## Cómo funciona
+
+### Modelo de memoria dual
+
+**Memoria episódica (Topics)** captura decisiones, errores, preferencias. Cada memoria tiene un peso que decae con el tiempo según la importancia:
+
+| Importancia | Decaimiento | Poda | Comportamiento |
+|-------------|-------------|------|----------------|
+| `critical` | ninguno | nunca | Nunca olvidada, nunca podada |
+| `high` | lento (0.5x tasa) | nunca | Desvanece lentamente, nunca se elimina automáticamente |
+| `medium` | normal | sí | Decaimiento estándar, podada cuando el peso < umbral |
+| `low` | rápido (2x tasa) | sí | Olvidada rápidamente |
+
+El decaimiento es **consciente del acceso**: las memorias frecuentemente recuperadas decaen más lento (`decay / (1 + access_count × 0.1)`). Se aplica automáticamente al recuperar (si han pasado >24h desde el último decaimiento).
+
+**La higiene de memoria** está incorporada:
+- **Deduplicación automática**: almacenar contenido >85% similar a una memoria existente en el mismo tema la actualiza en lugar de crear un duplicado
+- **Avisos de consolidación**: cuando un tema supera las 7 entradas, `icm_memory_store` advierte al llamador que consolide
+- **Auditoría de salud**: `icm_memory_health` reporta el número de entradas por tema, peso promedio, entradas antiguas y necesidades de consolidación
+- **Sin pérdida silenciosa de datos**: las memorias críticas y de alta importancia nunca se podan automáticamente
+
+**Memoria semántica (Memoirs)** captura conocimiento estructurado como un grafo. Los conceptos son permanentes — se refinan, nunca decaen. Usa `superseded_by` para marcar hechos obsoletos en lugar de eliminarlos.
+
+### Búsqueda híbrida
+
+Con embeddings habilitados, ICM usa búsqueda híbrida:
+- **FTS5 BM25** (30%) — coincidencia de texto completo por palabras clave
+- **Similitud coseno** (70%) — búsqueda vectorial semántica vía sqlite-vec
+
+Modelo por defecto: `intfloat/multilingual-e5-base` (768d, más de 100 idiomas). Configurable en tu [archivo de configuración](#configuración):
+
+```toml
+[embeddings]
+# enabled = false                          # Deshabilitar completamente (sin descarga de modelo)
+model = "intfloat/multilingual-e5-base"    # 768d, multilingüe (por defecto)
+# model = "intfloat/multilingual-e5-small" # 384d, multilingüe (más ligero)
+# model = "intfloat/multilingual-e5-large" # 1024d, multilingüe (mejor precisión)
+# model = "Xenova/bge-small-en-v1.5"      # 384d, solo inglés (más rápido)
+# model = "jinaai/jina-embeddings-v2-base-code"  # 768d, optimizado para código
+```
+
+Para omitir completamente la descarga del modelo de embeddings, usa cualquiera de estos:
+```bash
+icm --no-embeddings serve          # Flag CLI
+ICM_NO_EMBEDDINGS=1 icm serve     # Variable de entorno
+```
+O establece `enabled = false` en tu archivo de configuración. ICM recurrirá a la búsqueda por palabras clave FTS5 (sigue funcionando, simplemente sin coincidencia semántica).
+
+Cambiar el modelo recrea automáticamente el índice vectorial (los embeddings existentes se borran y pueden regenerarse con `icm_memory_embed_all`).
+
+### Almacenamiento
+
+Archivo SQLite único. Sin servicios externos, sin dependencia de red.
+
+```
+~/Library/Application Support/dev.icm.icm/memories.db                    # macOS
+~/.local/share/dev.icm.icm/memories.db                                   # Linux
+C:\Users\<user>\AppData\Local\icm\icm\data\memories.db                   # Windows
+```
+
+### Configuración
+
+```bash
+icm config                    # Mostrar configuración activa
+```
+
+Ubicación del archivo de configuración (específico por plataforma, o `$ICM_CONFIG`):
+
+```
+~/Library/Application Support/dev.icm.icm/config.toml                    # macOS
+~/.config/icm/config.toml                                                # Linux
+C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml              # Windows
+```
+
+Ver [config/default.toml](config/default.toml) para todas las opciones.
+
+## Auto-extracción
+
+ICM extrae memorias automáticamente mediante tres capas:
+
+```
+  Capa 0: Hooks de patrones       Capa 1: PreCompact           Capa 2: UserPromptSubmit
+  (sin coste LLM)                 (sin coste LLM)               (sin coste LLM)
+  ┌──────────────────┐                ┌──────────────────┐          ┌──────────────────┐
+  │ Hook PostToolUse  │                │ Hook PreCompact   │          │ UserPromptSubmit  │
+  │                   │                │                   │          │                   │
+  │ • Errores Bash    │                │ El contexto está  │          │ El usuario envía  │
+  │ • git commits     │                │ a punto de        │          │ un prompt         │
+  │ • cambios config  │                │ comprimirse →     │          │ → icm recall      │
+  │ • decisiones      │                │ extraer memorias  │          │ → inyectar cont.  │
+  │ • preferencias    │                │ del transcript    │          │                   │
+  │ • aprendizajes    │                │ antes de perderlos│          │ El agente empieza  │
+  │ • restricciones   │                │ para siempre      │          │ con memorias       │
+  │                   │                │                   │          │ relevantes ya      │
+  │ Basado en reglas, │                │ Mismos patrones + │          │ cargadas           │
+  │ sin LLM           │                │ --store-raw fallbk│          │                   │
+  └──────────────────┘                └──────────────────┘          └──────────────────┘
+```
+
+| Capa | Estado | Coste LLM | Comando hook | Descripción |
+|------|--------|-----------|-------------|-------------|
+| Capa 0 | Implementada | 0 | `icm hook post` | Extracción de palabras clave basada en reglas de la salida de herramientas |
+| Capa 1 | Implementada | 0 | `icm hook compact` | Extrae del transcript antes de la compresión de contexto |
+| Capa 2 | Implementada | 0 | `icm hook prompt` | Inyecta memorias recuperadas en cada prompt del usuario |
+
+Las 3 capas se instalan automáticamente con `icm init --mode hook`.
+
+### Comparación con alternativas
+
+| Sistema | Método | Coste LLM | Latencia | ¿Captura compactación? |
+|---------|--------|-----------|---------|------------------------|
+| **ICM** | Extracción 3 capas | 0 a ~500 tok/sesión | 0ms | **Sí (PreCompact)** |
+| Mem0 | 2 llamadas LLM/mensaje | ~2k tok/mensaje | 200-2000ms | No |
+| claude-mem | PostToolUse + async | ~1-5k tok/sesión | 8ms hook | No |
+| MemGPT/Letta | El agente se gestiona solo | 0 marginal | 0ms | No |
+| DiffMem | Diffs basados en Git | 0 | 0ms | No |
+
+## Benchmarks
+
+### Rendimiento de almacenamiento
+
+```
+ICM Benchmark (1000 memories, 384d embeddings)
+──────────────────────────────────────────────────────────
+Store (no embeddings)      1000 ops      34.2 ms      34.2 µs/op
+Store (with embeddings)    1000 ops      51.6 ms      51.6 µs/op
+FTS5 search                 100 ops       4.7 ms      46.6 µs/op
+Vector search (KNN)         100 ops      59.0 ms     590.0 µs/op
+Hybrid search               100 ops      95.1 ms     951.1 µs/op
+Decay (batch)                 1 ops       5.8 ms       5.8 ms/op
+──────────────────────────────────────────────────────────
+```
+
+Apple M1 Pro, SQLite en memoria, monohilo. `icm bench --count 1000`
+
+### Eficiencia del agente
+
+Flujo de trabajo multisesión con un proyecto Rust real (12 archivos, ~550 líneas). Las sesiones 2+ muestran las mayores ganancias ya que ICM recupera en lugar de releer archivos.
+
+```
+ICM Agent Benchmark (10 sessions, model: haiku, 3 runs averaged)
+══════════════════════════════════════════════════════════════════
+                            Without ICM         With ICM      Delta
+Session 2 (recall)
+  Turns                             5.7              4.0       -29%
+  Context (input)                 99.9k            67.5k       -32%
+  Cost                          $0.0298          $0.0249       -17%
+
+Session 3 (recall)
+  Turns                             3.3              2.0       -40%
+  Context (input)                 74.7k            41.6k       -44%
+  Cost                          $0.0249          $0.0194       -22%
+══════════════════════════════════════════════════════════════════
+```
+
+`icm bench-agent --sessions 10 --model haiku`
+
+### Retención de conocimiento
+
+El agente recupera hechos específicos de un documento técnico denso entre sesiones. La sesión 1 lee y memoriza; las sesiones 2+ responden 10 preguntas de hecho **sin** el texto fuente.
+
+```
+ICM Recall Benchmark (10 questions, model: haiku, 5 runs averaged)
+══════════════════════════════════════════════════════════════════════
+                                               No ICM     With ICM
+──────────────────────────────────────────────────────────────────────
+Average score                                      5%          68%
+Questions passed                                 0/10         5/10
+══════════════════════════════════════════════════════════════════════
+```
+
+`icm bench-recall --model haiku`
+
+### LLMs locales (ollama)
+
+La misma prueba con modelos locales — inyección de contexto puro, sin necesidad de uso de herramientas.
+
+```
+Model               Params   No ICM   With ICM     Delta
+─────────────────────────────────────────────────────────
+qwen2.5:14b           14B       4%       97%       +93%
+mistral:7b             7B       4%       93%       +89%
+llama3.1:8b            8B       4%       93%       +89%
+qwen2.5:7b             7B       4%       90%       +86%
+phi4:14b              14B       6%       79%       +73%
+llama3.2:3b            3B       0%       76%       +76%
+gemma2:9b              9B       4%       76%       +72%
+qwen2.5:3b             3B       2%       58%       +56%
+─────────────────────────────────────────────────────────
+```
+
+`scripts/bench-ollama.sh qwen2.5:14b`
+
+### Protocolo de pruebas
+
+Todos los benchmarks usan **llamadas API reales** — sin mocks, sin respuestas simuladas, sin respuestas en caché.
+
+- **Benchmark de agente**: Crea un proyecto Rust real en un directorio temporal. Ejecuta N sesiones con `claude -p --output-format json`. Sin ICM: configuración MCP vacía. Con ICM: servidor MCP real + auto-extracción + inyección de contexto.
+- **Retención de conocimiento**: Usa un documento técnico ficticio (el "Protocolo Meridian"). Puntúa las respuestas por coincidencia de palabras clave contra hechos esperados. Tiempo límite de 120s por invocación.
+- **Aislamiento**: Cada ejecución usa su propio directorio temporal y base de datos SQLite nueva. Sin persistencia de sesión.
+
+## Documentación
+
+| Documento | Descripción |
+|-----------|-------------|
+| [Arquitectura técnica](docs/architecture.md) | Estructura de crates, pipeline de búsqueda, modelo de decaimiento, integración sqlite-vec, pruebas |
+| [Guía de usuario](docs/guide.md) | Instalación, organización de temas, consolidación, extracción, resolución de problemas |
+| [Descripción del producto](docs/product.md) | Casos de uso, benchmarks, comparación con alternativas |
+
+## Licencia
+
+[Source-Available](LICENSE) — Gratuito para individuos y equipos de ≤ 20 personas. Se requiere licencia empresarial para organizaciones más grandes. Contacto: license@rtk.ai

--- a/README_fr.md
+++ b/README_fr.md
@@ -1,0 +1,454 @@
+[English](README.md) | **Français** | [Español](README_es.md) | [Deutsch](README_de.md) | [Italiano](README_it.md) | [Português](README_pt.md) | [Nederlands](README_nl.md) | [Polski](README_pl.md) | [Русский](README_ru.md) | [日本語](README_ja.md) | [中文](README_zh.md) | [العربية](README_ar.md) | [한국어](README_ko.md)
+
+<p align="center">
+  <img src="assets/banner.png" alt="ICM — Infinite Context Memory" width="600">
+</p>
+
+<h1 align="center">ICM</h1>
+
+<p align="center">
+  Mémoire permanente pour agents IA. Binaire unique, zéro dépendance, natif MCP.
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/icm/actions/workflows/ci.yml"><img src="https://github.com/rtk-ai/icm/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/icm/releases/latest"><img src="https://img.shields.io/github/v/release/rtk-ai/icm?color=purple" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Source--Available-orange.svg" alt="Source-Available"></a>
+</p>
+
+---
+
+ICM donne à votre agent IA une vraie mémoire — pas un outil de prise de notes, pas un gestionnaire de contexte, une **mémoire**.
+
+```
+                       ICM (Infinite Context Memory)
+            ┌──────────────────────┬─────────────────────────┐
+            │   MEMORIES (Topics)  │   MEMOIRS (Knowledge)   │
+            │                      │                         │
+            │  Épisodique, temporel│  Permanent, structuré   │
+            │                      │                         │
+            │  ┌───┐ ┌───┐ ┌───┐  │    ┌───┐               │
+            │  │ m │ │ m │ │ m │  │    │ C │──depends_on──┐ │
+            │  └─┬─┘ └─┬─┘ └─┬─┘  │    └───┘              │ │
+            │    │decay │     │    │      │ refines      ┌─▼─┐│
+            │    ▼      ▼     ▼    │    ┌─▼─┐            │ C ││
+            │  le poids diminue    │    │ C │──part_of──>└───┘│
+            │  avec le temps sauf  │    └───┘                 │
+            │  si accédé/critique  │  Concepts + Relations    │
+            ├──────────────────────┴─────────────────────────┤
+            │             SQLite + FTS5 + sqlite-vec          │
+            │        Recherche hybride: BM25 (30%) + cosine (70%) │
+            └─────────────────────────────────────────────────┘
+```
+
+**Deux modèles de mémoire :**
+
+- **Memories** — stockage/rappel avec décroissance temporelle par importance. Les souvenirs critiques ne s'effacent jamais, ceux de faible importance décroissent naturellement. Filtrage par topic ou mot-clé.
+- **Memoirs** — graphes de connaissance permanents. Concepts reliés par des relations typées (`depends_on`, `contradicts`, `superseded_by`, ...). Filtrage par label.
+- **Feedback** — enregistrer les corrections quand les prédictions IA sont fausses. Rechercher les erreurs passées avant de faire de nouvelles prédictions. Apprentissage en boucle fermée.
+
+## Installation
+
+```bash
+# Homebrew (macOS / Linux)
+brew tap rtk-ai/tap && brew install icm
+
+# Installation rapide
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+
+# Depuis les sources
+cargo install --path crates/icm-cli
+```
+
+## Configuration
+
+```bash
+# Détection automatique et configuration de tous les outils supportés
+icm init
+```
+
+Configure **14 outils** en une seule commande :
+
+| Outil | Fichier de configuration | Format |
+|-------|--------------------------|--------|
+| Claude Code | `~/.claude.json` | JSON |
+| Claude Desktop | `~/Library/.../claude_desktop_config.json` | JSON |
+| Cursor | `~/.cursor/mcp.json` | JSON |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON |
+| VS Code / Copilot | `~/Library/.../Code/User/mcp.json` | JSON |
+| Gemini Code Assist | `~/.gemini/settings.json` | JSON |
+| Zed | `~/.zed/settings.json` | JSON |
+| Amp | `~/.config/amp/settings.json` | JSON |
+| Amazon Q | `~/.aws/amazonq/mcp.json` | JSON |
+| Cline | VS Code globalStorage | JSON |
+| Roo Code | VS Code globalStorage | JSON |
+| Kilo Code | VS Code globalStorage | JSON |
+| OpenAI Codex CLI | `~/.codex/config.toml` | TOML |
+| OpenCode | `~/.config/opencode/opencode.json` | JSON |
+
+Ou manuellement :
+
+```bash
+# Claude Code
+claude mcp add icm -- icm serve
+
+# Mode compact (réponses plus courtes, économise des tokens)
+claude mcp add icm -- icm serve --compact
+
+# N'importe quel client MCP : command = "icm", args = ["serve"]
+```
+
+### Skills / règles
+
+```bash
+icm init --mode skill
+```
+
+Installe des commandes slash et des règles pour Claude Code (`/recall`, `/remember`), Cursor (règle `.mdc`), Roo Code (règle `.md`), et Amp (`/icm-recall`, `/icm-remember`).
+
+### Hooks (Claude Code)
+
+```bash
+icm init --mode hook
+```
+
+Installe les 3 couches d'extraction en tant que hooks Claude Code :
+
+**Hooks Claude Code :**
+
+| Hook | Événement | Ce qu'il fait |
+|------|-----------|---------------|
+| `icm hook pre` | PreToolUse | Autorise automatiquement les commandes `icm` CLI (sans invite de permission) |
+| `icm hook post` | PostToolUse | Extrait des faits depuis la sortie des outils toutes les 15 invocations |
+| `icm hook compact` | PreCompact | Extrait des souvenirs depuis la transcription avant la compression du contexte |
+| `icm hook prompt` | UserPromptSubmit | Injecte le contexte rappelé au début de chaque prompt |
+
+**Plugin OpenCode** (installé automatiquement dans `~/.config/opencode/plugins/icm.js`) :
+
+| Événement OpenCode | Couche ICM | Ce qu'il fait |
+|--------------------|------------|---------------|
+| `tool.execute.after` | Couche 0 | Extrait des faits depuis la sortie des outils |
+| `experimental.session.compacting` | Couche 1 | Extrait depuis la conversation avant compaction |
+| `session.created` | Couche 2 | Rappelle le contexte au démarrage de session |
+
+## CLI vs MCP
+
+ICM peut être utilisé via CLI (commandes `icm`) ou serveur MCP (`icm serve`). Les deux accèdent à la même base de données.
+
+| | CLI | MCP |
+|---|-----|-----|
+| **Latence** | ~30ms (binaire direct) | ~50ms (JSON-RPC stdio) |
+| **Coût en tokens** | 0 (basé sur hooks, invisible) | ~20-50 tokens/appel (schéma d'outil) |
+| **Configuration** | `icm init --mode hook` | `icm init --mode mcp` |
+| **Compatible avec** | Claude Code, OpenCode (via hooks/plugins) | Les 14 outils compatibles MCP |
+| **Auto-extraction** | Oui (hooks déclenchent `icm extract`) | Oui (outils MCP appellent store) |
+| **Idéal pour** | Utilisateurs avancés, économie de tokens | Compatibilité universelle |
+
+## CLI
+
+### Memories (épisodiques, avec décroissance)
+
+```bash
+# Stocker
+icm store -t "my-project" -c "Use PostgreSQL for the main DB" -i high -k "db,postgres"
+
+# Rappeler
+icm recall "database choice"
+icm recall "auth setup" --topic "my-project" --limit 10
+icm recall "architecture" --keyword "postgres"
+
+# Gérer
+icm forget <memory-id>
+icm consolidate --topic "my-project"
+icm topics
+icm stats
+
+# Extraire des faits depuis du texte (basé sur des règles, zéro coût LLM)
+echo "The parser uses Pratt algorithm" | icm extract -p my-project
+```
+
+### Memoirs (graphes de connaissance permanents)
+
+```bash
+# Créer un memoir
+icm memoir create -n "system-architecture" -d "System design decisions"
+
+# Ajouter des concepts avec labels
+icm memoir add-concept -m "system-architecture" -n "auth-service" \
+  -d "Handles JWT tokens and OAuth2 flows" -l "domain:auth,type:service"
+
+# Relier des concepts
+icm memoir link -m "system-architecture" --from "api-gateway" --to "auth-service" -r depends-on
+
+# Rechercher avec filtre par label
+icm memoir search -m "system-architecture" "authentication"
+icm memoir search -m "system-architecture" "service" --label "domain:auth"
+
+# Inspecter le voisinage
+icm memoir inspect -m "system-architecture" "auth-service" -D 2
+
+# Exporter le graphe (formats : json, dot, ascii, ai)
+icm memoir export -m "system-architecture" -f ascii   # Tracé en boîtes avec barres de confiance
+icm memoir export -m "system-architecture" -f dot      # Graphviz DOT (couleur = niveau de confiance)
+icm memoir export -m "system-architecture" -f ai       # Markdown optimisé pour contexte LLM
+icm memoir export -m "system-architecture" -f json     # JSON structuré avec toutes les métadonnées
+
+# Générer une visualisation SVG
+icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
+```
+
+## Outils MCP (22)
+
+### Outils Memory
+
+| Outil | Description |
+|-------|-------------|
+| `icm_memory_store` | Stocker avec déduplication automatique (>85% de similarité → mise à jour au lieu de dupliquer) |
+| `icm_memory_recall` | Rechercher par requête, filtrer par topic et/ou mot-clé |
+| `icm_memory_update` | Modifier un souvenir sur place (contenu, importance, mots-clés) |
+| `icm_memory_forget` | Supprimer un souvenir par ID |
+| `icm_memory_consolidate` | Fusionner tous les souvenirs d'un topic en un résumé |
+| `icm_memory_list_topics` | Lister tous les topics avec leurs compteurs |
+| `icm_memory_stats` | Statistiques globales de la mémoire |
+| `icm_memory_health` | Audit d'hygiène par topic (obsolescence, besoins de consolidation) |
+| `icm_memory_embed_all` | Regénérer les embeddings pour la recherche vectorielle |
+
+### Outils Memoir (graphes de connaissance)
+
+| Outil | Description |
+|-------|-------------|
+| `icm_memoir_create` | Créer un nouveau memoir (conteneur de connaissance) |
+| `icm_memoir_list` | Lister tous les memoirs |
+| `icm_memoir_show` | Afficher les détails d'un memoir et tous ses concepts |
+| `icm_memoir_add_concept` | Ajouter un concept avec des labels |
+| `icm_memoir_refine` | Mettre à jour la définition d'un concept |
+| `icm_memoir_search` | Recherche plein texte, optionnellement filtrée par label |
+| `icm_memoir_search_all` | Rechercher dans tous les memoirs |
+| `icm_memoir_link` | Créer une relation typée entre concepts |
+| `icm_memoir_inspect` | Inspecter un concept et son voisinage dans le graphe (BFS) |
+| `icm_memoir_export` | Exporter le graphe (json, dot, ascii, ai) avec niveaux de confiance |
+
+### Outils Feedback (apprentissage par les erreurs)
+
+| Outil | Description |
+|-------|-------------|
+| `icm_feedback_record` | Enregistrer une correction quand une prédiction IA est fausse |
+| `icm_feedback_search` | Rechercher des corrections passées pour éclairer les prédictions futures |
+| `icm_feedback_stats` | Statistiques de feedback : nombre total, répartition par topic, les plus appliquées |
+
+### Types de relations
+
+`part_of` · `depends_on` · `related_to` · `contradicts` · `refines` · `alternative_to` · `caused_by` · `instance_of` · `superseded_by`
+
+## Fonctionnement
+
+### Modèle de mémoire dual
+
+**La mémoire épisodique (Topics)** capture les décisions, erreurs et préférences. Chaque souvenir a un poids qui décroît dans le temps selon son importance :
+
+| Importance | Décroissance | Élagage | Comportement |
+|------------|--------------|---------|--------------|
+| `critical` | aucune | jamais | Jamais oublié, jamais élagué |
+| `high` | lente (0,5x) | jamais | S'efface lentement, jamais supprimé automatiquement |
+| `medium` | normale | oui | Décroissance standard, élagué quand le poids < seuil |
+| `low` | rapide (2x) | oui | Oublié rapidement |
+
+La décroissance est **sensible aux accès** : les souvenirs fréquemment rappelés décroissent plus lentement (`decay / (1 + access_count × 0.1)`). Appliquée automatiquement au rappel (si >24h depuis la dernière décroissance).
+
+**L'hygiène mémorielle** est intégrée :
+- **Déduplication automatique** : stocker un contenu à plus de 85% de similarité avec un souvenir existant dans le même topic le met à jour au lieu de créer un doublon
+- **Conseils de consolidation** : quand un topic dépasse 7 entrées, `icm_memory_store` avertit l'appelant de consolider
+- **Audit de santé** : `icm_memory_health` rapporte le nombre d'entrées par topic, le poids moyen, les entrées obsolètes et les besoins de consolidation
+- **Pas de perte de données silencieuse** : les souvenirs critiques et à haute importance ne sont jamais élagués automatiquement
+
+**La mémoire sémantique (Memoirs)** capture des connaissances structurées sous forme de graphe. Les concepts sont permanents — ils se raffinent, ne décroissent jamais. Utilisez `superseded_by` pour marquer les faits obsolètes plutôt que de les supprimer.
+
+### Recherche hybride
+
+Avec les embeddings activés, ICM utilise la recherche hybride :
+- **FTS5 BM25** (30%) — correspondance de mots-clés en plein texte
+- **Similarité cosinus** (70%) — recherche vectorielle sémantique via sqlite-vec
+
+Modèle par défaut : `intfloat/multilingual-e5-base` (768d, 100+ langues). Configurable dans votre [fichier de configuration](#configuration) :
+
+```toml
+[embeddings]
+# enabled = false                          # Désactiver entièrement (pas de téléchargement de modèle)
+model = "intfloat/multilingual-e5-base"    # 768d, multilingue (défaut)
+# model = "intfloat/multilingual-e5-small" # 384d, multilingue (plus léger)
+# model = "intfloat/multilingual-e5-large" # 1024d, multilingue (meilleure précision)
+# model = "Xenova/bge-small-en-v1.5"      # 384d, anglais uniquement (plus rapide)
+# model = "jinaai/jina-embeddings-v2-base-code"  # 768d, optimisé pour le code
+```
+
+Pour ignorer entièrement le téléchargement du modèle d'embedding, utilisez l'une de ces options :
+```bash
+icm --no-embeddings serve          # Flag CLI
+ICM_NO_EMBEDDINGS=1 icm serve     # Variable d'environnement
+```
+Ou définissez `enabled = false` dans votre fichier de configuration. ICM bascule alors sur la recherche par mots-clés FTS5 (fonctionne toujours, sans correspondance sémantique).
+
+Changer de modèle recrée automatiquement l'index vectoriel (les embeddings existants sont effacés et peuvent être régénérés avec `icm_memory_embed_all`).
+
+### Stockage
+
+Fichier SQLite unique. Aucun service externe, aucune dépendance réseau.
+
+```
+~/Library/Application Support/dev.icm.icm/memories.db                    # macOS
+~/.local/share/dev.icm.icm/memories.db                                   # Linux
+C:\Users\<user>\AppData\Local\icm\icm\data\memories.db                   # Windows
+```
+
+### Configuration
+
+```bash
+icm config                    # Afficher la configuration active
+```
+
+Emplacement du fichier de configuration (spécifique à la plateforme, ou `$ICM_CONFIG`) :
+
+```
+~/Library/Application Support/dev.icm.icm/config.toml                    # macOS
+~/.config/icm/config.toml                                                # Linux
+C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml              # Windows
+```
+
+Voir [config/default.toml](config/default.toml) pour toutes les options.
+
+## Auto-extraction
+
+ICM extrait des souvenirs automatiquement via trois couches :
+
+```
+  Couche 0 : Hooks de patterns      Couche 1 : PreCompact         Couche 2 : UserPromptSubmit
+  (zéro coût LLM)                   (zéro coût LLM)               (zéro coût LLM)
+  ┌──────────────────┐              ┌──────────────────┐          ┌──────────────────┐
+  │ Hook PostToolUse  │              │ Hook PreCompact   │          │ UserPromptSubmit  │
+  │                   │              │                   │          │                   │
+  │ • Erreurs Bash    │              │ Contexte sur le   │          │ Utilisateur envoie│
+  │ • commits git     │              │ point d'être      │          │ un prompt         │
+  │ • changements cfg │              │ compressé →       │          │ → icm recall      │
+  │ • décisions       │              │ extraire souvenirs │          │ → injecter contexte│
+  │ • préférences     │              │ depuis transcript  │          │                   │
+  │ • apprentissages  │              │ avant qu'ils       │          │ L'agent démarre   │
+  │ • contraintes     │              │ soient perdus      │          │ avec les souvenirs │
+  │                   │              │                   │          │ pertinents déjà   │
+  │ Basé sur règles,  │              │ Mêmes patterns +  │          │ chargés            │
+  │ sans LLM          │              │ --store-raw fallbk│          │                   │
+  └──────────────────┘              └──────────────────┘          └──────────────────┘
+```
+
+| Couche | Statut | Coût LLM | Commande hook | Description |
+|--------|--------|----------|---------------|-------------|
+| Couche 0 | Implémentée | 0 | `icm hook post` | Extraction par mots-clés basée sur règles depuis la sortie des outils |
+| Couche 1 | Implémentée | 0 | `icm hook compact` | Extraction depuis la transcription avant compression du contexte |
+| Couche 2 | Implémentée | 0 | `icm hook prompt` | Injection des souvenirs rappelés à chaque prompt utilisateur |
+
+Les 3 couches sont installées automatiquement par `icm init --mode hook`.
+
+### Comparaison avec les alternatives
+
+| Système | Méthode | Coût LLM | Latence | Capture la compaction ? |
+|---------|---------|----------|---------|------------------------|
+| **ICM** | Extraction 3 couches | 0 à ~500 tok/session | 0ms | **Oui (PreCompact)** |
+| Mem0 | 2 appels LLM/message | ~2k tok/message | 200-2000ms | Non |
+| claude-mem | PostToolUse + async | ~1-5k tok/session | 8ms hook | Non |
+| MemGPT/Letta | L'agent se gère lui-même | 0 marginal | 0ms | Non |
+| DiffMem | Diffs basés sur Git | 0 | 0ms | Non |
+
+## Benchmarks
+
+### Performance de stockage
+
+```
+ICM Benchmark (1000 memories, 384d embeddings)
+──────────────────────────────────────────────────────────
+Store (no embeddings)      1000 ops      34.2 ms      34.2 µs/op
+Store (with embeddings)    1000 ops      51.6 ms      51.6 µs/op
+FTS5 search                 100 ops       4.7 ms      46.6 µs/op
+Vector search (KNN)         100 ops      59.0 ms     590.0 µs/op
+Hybrid search               100 ops      95.1 ms     951.1 µs/op
+Decay (batch)                 1 ops       5.8 ms       5.8 ms/op
+──────────────────────────────────────────────────────────
+```
+
+Apple M1 Pro, SQLite en mémoire, mono-thread. `icm bench --count 1000`
+
+### Efficacité agent
+
+Flux de travail multi-session sur un vrai projet Rust (12 fichiers, ~550 lignes). Les sessions 2+ montrent les gains les plus importants car ICM rappelle au lieu de relire les fichiers.
+
+```
+ICM Agent Benchmark (10 sessions, model: haiku, 3 runs averaged)
+══════════════════════════════════════════════════════════════════
+                            Without ICM         With ICM      Delta
+Session 2 (recall)
+  Turns                             5.7              4.0       -29%
+  Context (input)                 99.9k            67.5k       -32%
+  Cost                          $0.0298          $0.0249       -17%
+
+Session 3 (recall)
+  Turns                             3.3              2.0       -40%
+  Context (input)                 74.7k            41.6k       -44%
+  Cost                          $0.0249          $0.0194       -22%
+══════════════════════════════════════════════════════════════════
+```
+
+`icm bench-agent --sessions 10 --model haiku`
+
+### Rétention de connaissance
+
+L'agent rappelle des faits spécifiques depuis un document technique dense à travers les sessions. La session 1 lit et mémorise ; les sessions 2+ répondent à 10 questions factuelles **sans** le texte source.
+
+```
+ICM Recall Benchmark (10 questions, model: haiku, 5 runs averaged)
+══════════════════════════════════════════════════════════════════════
+                                               No ICM     With ICM
+──────────────────────────────────────────────────────────────────────
+Average score                                      5%          68%
+Questions passed                                 0/10         5/10
+══════════════════════════════════════════════════════════════════════
+```
+
+`icm bench-recall --model haiku`
+
+### LLMs locaux (ollama)
+
+Même test avec des modèles locaux — injection de contexte pure, sans besoin d'appels d'outils.
+
+```
+Model               Params   No ICM   With ICM     Delta
+─────────────────────────────────────────────────────────
+qwen2.5:14b           14B       4%       97%       +93%
+mistral:7b             7B       4%       93%       +89%
+llama3.1:8b            8B       4%       93%       +89%
+qwen2.5:7b             7B       4%       90%       +86%
+phi4:14b              14B       6%       79%       +73%
+llama3.2:3b            3B       0%       76%       +76%
+gemma2:9b              9B       4%       76%       +72%
+qwen2.5:3b             3B       2%       58%       +56%
+─────────────────────────────────────────────────────────
+```
+
+`scripts/bench-ollama.sh qwen2.5:14b`
+
+### Protocole de test
+
+Tous les benchmarks utilisent de **vrais appels API** — pas de mocks, pas de réponses simulées, pas de réponses en cache.
+
+- **Benchmark agent** : crée un vrai projet Rust dans un répertoire temporaire. Lance N sessions avec `claude -p --output-format json`. Sans ICM : configuration MCP vide. Avec ICM : vrai serveur MCP + auto-extraction + injection de contexte.
+- **Rétention de connaissance** : utilise un document technique fictif (le « Protocole Meridian »). Évalue les réponses par correspondance de mots-clés avec les faits attendus. Timeout de 120s par invocation.
+- **Isolation** : chaque exécution utilise son propre répertoire temporaire et une nouvelle base SQLite. Pas de persistance entre sessions.
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Architecture technique](docs/architecture.md) | Structure des crates, pipeline de recherche, modèle de décroissance, intégration sqlite-vec, tests |
+| [Guide utilisateur](docs/guide.md) | Installation, organisation des topics, consolidation, extraction, dépannage |
+| [Vue d'ensemble produit](docs/product.md) | Cas d'usage, benchmarks, comparaison avec les alternatives |
+
+## Licence
+
+[Source disponible](LICENSE) — Gratuit pour les particuliers et les équipes de 20 personnes ou moins. Licence entreprise requise pour les organisations plus grandes. Contact : license@rtk.ai

--- a/README_it.md
+++ b/README_it.md
@@ -1,0 +1,454 @@
+[English](README.md) | [Français](README_fr.md) | [Español](README_es.md) | [Deutsch](README_de.md) | **Italiano** | [Português](README_pt.md) | [Nederlands](README_nl.md) | [Polski](README_pl.md) | [Русский](README_ru.md) | [日本語](README_ja.md) | [中文](README_zh.md) | [العربية](README_ar.md) | [한국어](README_ko.md)
+
+<p align="center">
+  <img src="assets/banner.png" alt="ICM — Infinite Context Memory" width="600">
+</p>
+
+<h1 align="center">ICM</h1>
+
+<p align="center">
+  Memoria permanente per agenti AI. Binario singolo, zero dipendenze, nativo MCP.
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/icm/actions/workflows/ci.yml"><img src="https://github.com/rtk-ai/icm/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/icm/releases/latest"><img src="https://img.shields.io/github/v/release/rtk-ai/icm?color=purple" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Source--Available-orange.svg" alt="Source-Available"></a>
+</p>
+
+---
+
+ICM offre al tuo agente AI una vera memoria — non uno strumento per prendere appunti, non un gestore di contesto, ma una **memoria**.
+
+```
+                       ICM (Infinite Context Memory)
+            ┌──────────────────────┬─────────────────────────┐
+            │   MEMORIES (Topics)  │   MEMOIRS (Knowledge)   │
+            │                      │                         │
+            │  Episodic, temporal  │  Permanent, structured  │
+            │                      │                         │
+            │  ┌───┐ ┌───┐ ┌───┐  │    ┌───┐               │
+            │  │ m │ │ m │ │ m │  │    │ C │──depends_on──┐ │
+            │  └─┬─┘ └─┬─┘ └─┬─┘  │    └───┘              │ │
+            │    │decay │     │    │      │ refines      ┌─▼─┐│
+            │    ▼      ▼     ▼    │    ┌─▼─┐            │ C ││
+            │  weight decreases    │    │ C │──part_of──>└───┘│
+            │  over time unless    │    └───┘                 │
+            │  accessed/critical   │  Concepts + Relations    │
+            ├──────────────────────┴─────────────────────────┤
+            │             SQLite + FTS5 + sqlite-vec          │
+            │        Hybrid search: BM25 (30%) + cosine (70%) │
+            └─────────────────────────────────────────────────┘
+```
+
+**Due modelli di memoria:**
+
+- **Memories** — archivia/recupera con decadimento temporale basato sull'importanza. Le memorie critiche non svaniscono mai, quelle a bassa importanza decadono naturalmente. Filtra per topic o parola chiave.
+- **Memoirs** — grafi di conoscenza permanenti. Concetti collegati da relazioni tipizzate (`depends_on`, `contradicts`, `superseded_by`, ...). Filtra per etichetta.
+- **Feedback** — registra le correzioni quando le previsioni AI sono errate. Cerca gli errori passati prima di fare nuove previsioni. Apprendimento a ciclo chiuso.
+
+## Installazione
+
+```bash
+# Homebrew (macOS / Linux)
+brew tap rtk-ai/tap && brew install icm
+
+# Installazione rapida
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+
+# Dal sorgente
+cargo install --path crates/icm-cli
+```
+
+## Configurazione
+
+```bash
+# Rileva e configura automaticamente tutti gli strumenti supportati
+icm init
+```
+
+Configura **14 strumenti** con un solo comando:
+
+| Strumento | File di configurazione | Formato |
+|-----------|----------------------|---------|
+| Claude Code | `~/.claude.json` | JSON |
+| Claude Desktop | `~/Library/.../claude_desktop_config.json` | JSON |
+| Cursor | `~/.cursor/mcp.json` | JSON |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON |
+| VS Code / Copilot | `~/Library/.../Code/User/mcp.json` | JSON |
+| Gemini Code Assist | `~/.gemini/settings.json` | JSON |
+| Zed | `~/.zed/settings.json` | JSON |
+| Amp | `~/.config/amp/settings.json` | JSON |
+| Amazon Q | `~/.aws/amazonq/mcp.json` | JSON |
+| Cline | VS Code globalStorage | JSON |
+| Roo Code | VS Code globalStorage | JSON |
+| Kilo Code | VS Code globalStorage | JSON |
+| OpenAI Codex CLI | `~/.codex/config.toml` | TOML |
+| OpenCode | `~/.config/opencode/opencode.json` | JSON |
+
+Oppure manualmente:
+
+```bash
+# Claude Code
+claude mcp add icm -- icm serve
+
+# Modalità compatta (risposte più brevi, risparmio di token)
+claude mcp add icm -- icm serve --compact
+
+# Qualsiasi client MCP: command = "icm", args = ["serve"]
+```
+
+### Skills / regole
+
+```bash
+icm init --mode skill
+```
+
+Installa comandi slash e regole per Claude Code (`/recall`, `/remember`), Cursor (regola `.mdc`), Roo Code (regola `.md`), e Amp (`/icm-recall`, `/icm-remember`).
+
+### Hook (Claude Code)
+
+```bash
+icm init --mode hook
+```
+
+Installa tutti e 3 i livelli di estrazione come hook di Claude Code:
+
+**Hook Claude Code:**
+
+| Hook | Evento | Funzione |
+|------|--------|----------|
+| `icm hook pre` | PreToolUse | Autorizzazione automatica dei comandi CLI `icm` (senza richiesta di permesso) |
+| `icm hook post` | PostToolUse | Estrae fatti dall'output degli strumenti ogni 15 chiamate |
+| `icm hook compact` | PreCompact | Estrae memorie dalla trascrizione prima della compressione del contesto |
+| `icm hook prompt` | UserPromptSubmit | Inietta il contesto recuperato all'inizio di ogni prompt |
+
+**Plugin OpenCode** (installato automaticamente in `~/.config/opencode/plugins/icm.js`):
+
+| Evento OpenCode | Livello ICM | Funzione |
+|----------------|-------------|----------|
+| `tool.execute.after` | Livello 0 | Estrae fatti dall'output degli strumenti |
+| `experimental.session.compacting` | Livello 1 | Estrae dalla conversazione prima della compattazione |
+| `session.created` | Livello 2 | Recupera il contesto all'avvio della sessione |
+
+## CLI vs MCP
+
+ICM può essere usato tramite CLI (comandi `icm`) o server MCP (`icm serve`). Entrambi accedono allo stesso database.
+
+| | CLI | MCP |
+|---|-----|-----|
+| **Latenza** | ~30ms (binario diretto) | ~50ms (JSON-RPC stdio) |
+| **Costo in token** | 0 (basato su hook, invisibile) | ~20-50 token/chiamata (schema tool) |
+| **Configurazione** | `icm init --mode hook` | `icm init --mode mcp` |
+| **Compatibile con** | Claude Code, OpenCode (tramite hook/plugin) | Tutti i 14 strumenti compatibili MCP |
+| **Estrazione automatica** | Sì (gli hook attivano `icm extract`) | Sì (i tool MCP chiamano store) |
+| **Ideale per** | Utenti avanzati, risparmio di token | Compatibilità universale |
+
+## CLI
+
+### Memories (episodiche, con decadimento)
+
+```bash
+# Archivia
+icm store -t "my-project" -c "Use PostgreSQL for the main DB" -i high -k "db,postgres"
+
+# Recupera
+icm recall "database choice"
+icm recall "auth setup" --topic "my-project" --limit 10
+icm recall "architecture" --keyword "postgres"
+
+# Gestione
+icm forget <memory-id>
+icm consolidate --topic "my-project"
+icm topics
+icm stats
+
+# Estrai fatti dal testo (basato su regole, zero costo LLM)
+echo "The parser uses Pratt algorithm" | icm extract -p my-project
+```
+
+### Memoirs (grafi di conoscenza permanenti)
+
+```bash
+# Crea un memoir
+icm memoir create -n "system-architecture" -d "System design decisions"
+
+# Aggiungi concetti con etichette
+icm memoir add-concept -m "system-architecture" -n "auth-service" \
+  -d "Handles JWT tokens and OAuth2 flows" -l "domain:auth,type:service"
+
+# Collega concetti
+icm memoir link -m "system-architecture" --from "api-gateway" --to "auth-service" -r depends-on
+
+# Cerca con filtro per etichetta
+icm memoir search -m "system-architecture" "authentication"
+icm memoir search -m "system-architecture" "service" --label "domain:auth"
+
+# Ispeziona il vicinato
+icm memoir inspect -m "system-architecture" "auth-service" -D 2
+
+# Esporta grafo (formati: json, dot, ascii, ai)
+icm memoir export -m "system-architecture" -f ascii   # Box-drawing con barre di confidenza
+icm memoir export -m "system-architecture" -f dot      # Graphviz DOT (colore = livello di confidenza)
+icm memoir export -m "system-architecture" -f ai       # Markdown ottimizzato per contesto LLM
+icm memoir export -m "system-architecture" -f json     # JSON strutturato con tutti i metadati
+
+# Genera visualizzazione SVG
+icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
+```
+
+## Tool MCP (22)
+
+### Tool per le memorie
+
+| Tool | Descrizione |
+|------|-------------|
+| `icm_memory_store` | Archivia con deduplicazione automatica (similarità >85% → aggiorna invece di duplicare) |
+| `icm_memory_recall` | Cerca per query, filtra per topic e/o parola chiave |
+| `icm_memory_update` | Modifica una memoria in-place (contenuto, importanza, parole chiave) |
+| `icm_memory_forget` | Elimina una memoria tramite ID |
+| `icm_memory_consolidate` | Unisce tutte le memorie di un topic in un unico riepilogo |
+| `icm_memory_list_topics` | Elenca tutti i topic con i relativi conteggi |
+| `icm_memory_stats` | Statistiche globali della memoria |
+| `icm_memory_health` | Controllo igienico per topic (obsolescenza, necessità di consolidazione) |
+| `icm_memory_embed_all` | Ricalcola gli embedding per la ricerca vettoriale |
+
+### Tool per i memoir (grafi di conoscenza)
+
+| Tool | Descrizione |
+|------|-------------|
+| `icm_memoir_create` | Crea un nuovo memoir (contenitore di conoscenza) |
+| `icm_memoir_list` | Elenca tutti i memoir |
+| `icm_memoir_show` | Mostra i dettagli del memoir e tutti i concetti |
+| `icm_memoir_add_concept` | Aggiunge un concetto con etichette |
+| `icm_memoir_refine` | Aggiorna la definizione di un concetto |
+| `icm_memoir_search` | Ricerca full-text, opzionalmente filtrata per etichetta |
+| `icm_memoir_search_all` | Cerca in tutti i memoir |
+| `icm_memoir_link` | Crea una relazione tipizzata tra concetti |
+| `icm_memoir_inspect` | Ispeziona il concetto e il vicinato nel grafo (BFS) |
+| `icm_memoir_export` | Esporta il grafo (json, dot, ascii, ai) con livelli di confidenza |
+
+### Tool per il feedback (apprendere dagli errori)
+
+| Tool | Descrizione |
+|------|-------------|
+| `icm_feedback_record` | Registra una correzione quando una previsione AI era errata |
+| `icm_feedback_search` | Cerca le correzioni passate per informare le previsioni future |
+| `icm_feedback_stats` | Statistiche del feedback: conteggio totale, dettaglio per topic, più applicate |
+
+### Tipi di relazione
+
+`part_of` · `depends_on` · `related_to` · `contradicts` · `refines` · `alternative_to` · `caused_by` · `instance_of` · `superseded_by`
+
+## Come funziona
+
+### Modello di memoria duale
+
+**Memoria episodica (Topics)** cattura decisioni, errori, preferenze. Ogni memoria ha un peso che decade nel tempo in base all'importanza:
+
+| Importanza | Decadimento | Eliminazione | Comportamento |
+|-----------|-------------|--------------|---------------|
+| `critical` | nessuno | mai | Mai dimenticata, mai eliminata |
+| `high` | lento (0.5x tasso) | mai | Svanisce lentamente, mai eliminata automaticamente |
+| `medium` | normale | sì | Decadimento standard, eliminata quando il peso è sotto la soglia |
+| `low` | rapido (2x tasso) | sì | Dimenticata rapidamente |
+
+Il decadimento è **consapevole degli accessi**: le memorie richiamate frequentemente decadono più lentamente (`decay / (1 + access_count × 0.1)`). Applicato automaticamente al recupero (se >24h dall'ultimo decadimento).
+
+**L'igiene della memoria** è integrata:
+- **Deduplicazione automatica**: archiviare contenuti con similarità >85% rispetto a una memoria esistente nello stesso topic la aggiorna invece di creare un duplicato
+- **Suggerimenti di consolidazione**: quando un topic supera le 7 voci, `icm_memory_store` avvisa il chiamante di consolidare
+- **Controllo dello stato**: `icm_memory_health` riporta il numero di voci per topic, il peso medio, le voci obsolete e le necessità di consolidazione
+- **Nessuna perdita silenziosa di dati**: le memorie critiche e ad alta importanza non vengono mai eliminate automaticamente
+
+**Memoria semantica (Memoirs)** cattura la conoscenza strutturata come un grafo. I concetti sono permanenti — vengono raffinati, mai fatti decadere. Usa `superseded_by` per contrassegnare i fatti obsoleti invece di eliminarli.
+
+### Ricerca ibrida
+
+Con gli embedding abilitati, ICM utilizza la ricerca ibrida:
+- **FTS5 BM25** (30%) — corrispondenza full-text per parole chiave
+- **Similarità coseno** (70%) — ricerca vettoriale semantica tramite sqlite-vec
+
+Modello predefinito: `intfloat/multilingual-e5-base` (768d, 100+ lingue). Configurabile nel tuo [file di configurazione](#configurazione):
+
+```toml
+[embeddings]
+# enabled = false                          # Disabilita completamente (nessun download del modello)
+model = "intfloat/multilingual-e5-base"    # 768d, multilingue (predefinito)
+# model = "intfloat/multilingual-e5-small" # 384d, multilingue (più leggero)
+# model = "intfloat/multilingual-e5-large" # 1024d, multilingue (migliore precisione)
+# model = "Xenova/bge-small-en-v1.5"      # 384d, solo inglese (più veloce)
+# model = "jinaai/jina-embeddings-v2-base-code"  # 768d, ottimizzato per codice
+```
+
+Per saltare completamente il download del modello di embedding, usa uno di questi:
+```bash
+icm --no-embeddings serve          # Flag CLI
+ICM_NO_EMBEDDINGS=1 icm serve     # Variabile d'ambiente
+```
+Oppure imposta `enabled = false` nel tuo file di configurazione. ICM tornerà alla ricerca per parole chiave FTS5 (funziona comunque, ma senza corrispondenza semantica).
+
+La modifica del modello ricrea automaticamente l'indice vettoriale (gli embedding esistenti vengono cancellati e possono essere rigenerati con `icm_memory_embed_all`).
+
+### Storage
+
+Un singolo file SQLite. Nessun servizio esterno, nessuna dipendenza di rete.
+
+```
+~/Library/Application Support/dev.icm.icm/memories.db                    # macOS
+~/.local/share/dev.icm.icm/memories.db                                   # Linux
+C:\Users\<user>\AppData\Local\icm\icm\data\memories.db                   # Windows
+```
+
+### Configurazione
+
+```bash
+icm config                    # Mostra la configurazione attiva
+```
+
+Posizione del file di configurazione (specifica per piattaforma, o `$ICM_CONFIG`):
+
+```
+~/Library/Application Support/dev.icm.icm/config.toml                    # macOS
+~/.config/icm/config.toml                                                # Linux
+C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml              # Windows
+```
+
+Vedi [config/default.toml](config/default.toml) per tutte le opzioni.
+
+## Estrazione automatica
+
+ICM estrae le memorie automaticamente tramite tre livelli:
+
+```
+  Livello 0: Hook a pattern       Livello 1: PreCompact          Livello 2: UserPromptSubmit
+  (zero costo LLM)                (zero costo LLM)               (zero costo LLM)
+  ┌──────────────────┐            ┌──────────────────┐          ┌──────────────────┐
+  │ PostToolUse hook  │            │ PreCompact hook   │          │ UserPromptSubmit  │
+  │                   │            │                   │          │                   │
+  │ • Errori Bash     │            │ Contesto sul      │          │ L'utente invia    │
+  │ • commit git      │            │ punto di essere   │          │ un prompt →       │
+  │ • cambiam. config │            │ compresso →       │          │ icm recall        │
+  │ • decisioni       │            │ estrai memorie    │          │ → inietta context │
+  │ • preferenze      │            │ dalla trascrizione│          │                   │
+  │ • apprendimenti   │            │ prima che vadano  │          │ L'agente inizia   │
+  │ • vincoli         │            │ perdute per sempre│          │ con le memorie    │
+  │                   │            │                   │          │ pertinenti già    │
+  │ Basato su regole, │            │ Stessi pattern +  │          │ caricate          │
+  │ nessun LLM        │            │ --store-raw fallbk│          │                   │
+  └──────────────────┘            └──────────────────┘          └──────────────────┘
+```
+
+| Livello | Stato | Costo LLM | Comando hook | Descrizione |
+|---------|-------|-----------|-------------|-------------|
+| Livello 0 | Implementato | 0 | `icm hook post` | Estrazione di parole chiave basata su regole dall'output degli strumenti |
+| Livello 1 | Implementato | 0 | `icm hook compact` | Estrazione dalla trascrizione prima della compressione del contesto |
+| Livello 2 | Implementato | 0 | `icm hook prompt` | Iniezione delle memorie recuperate ad ogni prompt utente |
+
+Tutti e 3 i livelli vengono installati automaticamente da `icm init --mode hook`.
+
+### Confronto con le alternative
+
+| Sistema | Metodo | Costo LLM | Latenza | Cattura la compattazione? |
+|---------|--------|-----------|---------|--------------------------|
+| **ICM** | Estrazione a 3 livelli | da 0 a ~500 tok/sessione | 0ms | **Sì (PreCompact)** |
+| Mem0 | 2 chiamate LLM/messaggio | ~2k tok/messaggio | 200-2000ms | No |
+| claude-mem | PostToolUse + async | ~1-5k tok/sessione | 8ms hook | No |
+| MemGPT/Letta | Autogestione dell'agente | 0 marginale | 0ms | No |
+| DiffMem | Diff basati su Git | 0 | 0ms | No |
+
+## Benchmark
+
+### Performance di archiviazione
+
+```
+ICM Benchmark (1000 memories, 384d embeddings)
+──────────────────────────────────────────────────────────
+Store (no embeddings)      1000 ops      34.2 ms      34.2 µs/op
+Store (with embeddings)    1000 ops      51.6 ms      51.6 µs/op
+FTS5 search                 100 ops       4.7 ms      46.6 µs/op
+Vector search (KNN)         100 ops      59.0 ms     590.0 µs/op
+Hybrid search               100 ops      95.1 ms     951.1 µs/op
+Decay (batch)                 1 ops       5.8 ms       5.8 ms/op
+──────────────────────────────────────────────────────────
+```
+
+Apple M1 Pro, SQLite in-memory, single-threaded. `icm bench --count 1000`
+
+### Efficienza degli agenti
+
+Flusso di lavoro multi-sessione con un progetto Rust reale (12 file, ~550 righe). Le sessioni dalla 2 in poi mostrano i maggiori guadagni mentre ICM recupera invece di rileggere i file.
+
+```
+ICM Agent Benchmark (10 sessions, model: haiku, 3 runs averaged)
+══════════════════════════════════════════════════════════════════
+                            Without ICM         With ICM      Delta
+Session 2 (recall)
+  Turns                             5.7              4.0       -29%
+  Context (input)                 99.9k            67.5k       -32%
+  Cost                          $0.0298          $0.0249       -17%
+
+Session 3 (recall)
+  Turns                             3.3              2.0       -40%
+  Context (input)                 74.7k            41.6k       -44%
+  Cost                          $0.0249          $0.0194       -22%
+══════════════════════════════════════════════════════════════════
+```
+
+`icm bench-agent --sessions 10 --model haiku`
+
+### Ritenzione della conoscenza
+
+L'agente recupera fatti specifici da un documento tecnico denso attraverso le sessioni. La sessione 1 legge e memorizza; le sessioni 2+ rispondono a 10 domande fattuali **senza** il testo sorgente.
+
+```
+ICM Recall Benchmark (10 questions, model: haiku, 5 runs averaged)
+══════════════════════════════════════════════════════════════════════
+                                               No ICM     With ICM
+──────────────────────────────────────────────────────────────────────
+Average score                                      5%          68%
+Questions passed                                 0/10         5/10
+══════════════════════════════════════════════════════════════════════
+```
+
+`icm bench-recall --model haiku`
+
+### LLM locali (ollama)
+
+Stesso test con modelli locali — pura iniezione di contesto, nessun uso di strumenti necessario.
+
+```
+Model               Params   No ICM   With ICM     Delta
+─────────────────────────────────────────────────────────
+qwen2.5:14b           14B       4%       97%       +93%
+mistral:7b             7B       4%       93%       +89%
+llama3.1:8b            8B       4%       93%       +89%
+qwen2.5:7b             7B       4%       90%       +86%
+phi4:14b              14B       6%       79%       +73%
+llama3.2:3b            3B       0%       76%       +76%
+gemma2:9b              9B       4%       76%       +72%
+qwen2.5:3b             3B       2%       58%       +56%
+─────────────────────────────────────────────────────────
+```
+
+`scripts/bench-ollama.sh qwen2.5:14b`
+
+### Protocollo di test
+
+Tutti i benchmark utilizzano **chiamate API reali** — nessun mock, nessuna risposta simulata, nessuna risposta in cache.
+
+- **Benchmark degli agenti**: Crea un progetto Rust reale in una directory temporanea. Esegue N sessioni con `claude -p --output-format json`. Senza ICM: configurazione MCP vuota. Con ICM: server MCP reale + estrazione automatica + iniezione di contesto.
+- **Ritenzione della conoscenza**: Usa un documento tecnico fittizio (il "Protocollo Meridian"). Valuta le risposte tramite corrispondenza di parole chiave rispetto ai fatti attesi. Timeout di 120s per invocazione.
+- **Isolamento**: Ogni esecuzione utilizza la propria directory temporanea e un database SQLite nuovo. Nessuna persistenza tra sessioni.
+
+## Documentazione
+
+| Documento | Descrizione |
+|-----------|-------------|
+| [Architettura tecnica](docs/architecture.md) | Struttura dei crate, pipeline di ricerca, modello di decadimento, integrazione sqlite-vec, test |
+| [Guida utente](docs/guide.md) | Installazione, organizzazione dei topic, consolidazione, estrazione, risoluzione dei problemi |
+| [Panoramica del prodotto](docs/product.md) | Casi d'uso, benchmark, confronto con le alternative |
+
+## Licenza
+
+[Source-Available](LICENSE) — Gratuito per individui e team ≤ 20 persone. Licenza enterprise richiesta per organizzazioni più grandi. Contatto: license@rtk.ai

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,453 @@
+[English](README.md) | [Français](README_fr.md) | [Español](README_es.md) | [Deutsch](README_de.md) | [Italiano](README_it.md) | [Português](README_pt.md) | [Nederlands](README_nl.md) | [Polski](README_pl.md) | [Русский](README_ru.md) | **日本語** | [中文](README_zh.md) | [العربية](README_ar.md) | [한국어](README_ko.md)
+
+<p align="center">
+  <img src="assets/banner.png" alt="ICM — Infinite Context Memory" width="600">
+</p>
+
+<h1 align="center">ICM</h1>
+
+<p align="center">
+  AIエージェントのための永続的メモリ。シングルバイナリ、依存関係なし、MCPネイティブ。
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/icm/actions/workflows/ci.yml"><img src="https://github.com/rtk-ai/icm/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/icm/releases/latest"><img src="https://img.shields.io/github/v/release/rtk-ai/icm?color=purple" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Source--Available-orange.svg" alt="Source-Available"></a>
+</p>
+
+---
+
+ICMはAIエージェントに本物のメモリを与えます — メモ取りツールでもコンテキストマネージャーでもなく、**メモリ**そのものです。
+
+```
+                       ICM (Infinite Context Memory)
+            ┌──────────────────────┬─────────────────────────┐
+            │   MEMORIES (Topics)  │   MEMOIRS (Knowledge)   │
+            │                      │                         │
+            │  Episodic, temporal  │  Permanent, structured  │
+            │                      │                         │
+            │  ┌───┐ ┌───┐ ┌───┐  │    ┌───┐               │
+            │  │ m │ │ m │ │ m │  │    │ C │──depends_on──┐ │
+            │  └─┬─┘ └─┬─┘ └─┬─┘  │    └───┘              │ │
+            │    │decay │     │    │      │ refines      ┌─▼─┐│
+            │    ▼      ▼     ▼    │    ┌─▼─┐            │ C ││
+            │  weight decreases    │    │ C │──part_of──>└───┘│
+            │  over time unless    │    └───┘                 │
+            │  accessed/critical   │  Concepts + Relations    │
+            ├──────────────────────┴─────────────────────────┤
+            │             SQLite + FTS5 + sqlite-vec          │
+            │        Hybrid search: BM25 (30%) + cosine (70%) │
+            └─────────────────────────────────────────────────┘
+```
+
+**2つのメモリモデル:**
+
+- **Memories（メモリ）** — 重要度に応じた時間的減衰を伴う記録・想起。重要度が「critical」のメモリは消えることなく、重要度が低いものは自然に減衰します。トピックやキーワードでフィルタリング可能。
+- **Memoirs（回想録）** — 永続的ナレッジグラフ。コンセプトは型付きリレーション（`depends_on`、`contradicts`、`superseded_by` など）でリンクされます。ラベルでフィルタリング可能。
+- **Feedback（フィードバック）** — AIの予測が間違っていた場合に修正を記録します。新たな予測を行う前に過去の間違いを検索できます。クローズドループ学習。
+
+## インストール
+
+```bash
+# Homebrew (macOS / Linux)
+brew tap rtk-ai/tap && brew install icm
+
+# クイックインストール
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+
+# ソースから
+cargo install --path crates/icm-cli
+```
+
+## セットアップ
+
+```bash
+# サポートされているすべてのツールを自動検出して設定
+icm init
+```
+
+1つのコマンドで **14のツール** を設定します:
+
+| ツール | 設定ファイル | フォーマット |
+|--------|------------|--------|
+| Claude Code | `~/.claude.json` | JSON |
+| Claude Desktop | `~/Library/.../claude_desktop_config.json` | JSON |
+| Cursor | `~/.cursor/mcp.json` | JSON |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON |
+| VS Code / Copilot | `~/Library/.../Code/User/mcp.json` | JSON |
+| Gemini Code Assist | `~/.gemini/settings.json` | JSON |
+| Zed | `~/.zed/settings.json` | JSON |
+| Amp | `~/.config/amp/settings.json` | JSON |
+| Amazon Q | `~/.aws/amazonq/mcp.json` | JSON |
+| Cline | VS Code globalStorage | JSON |
+| Roo Code | VS Code globalStorage | JSON |
+| Kilo Code | VS Code globalStorage | JSON |
+| OpenAI Codex CLI | `~/.codex/config.toml` | TOML |
+| OpenCode | `~/.config/opencode/opencode.json` | JSON |
+
+または手動で:
+
+```bash
+# Claude Code
+claude mcp add icm -- icm serve
+
+# コンパクトモード（短いレスポンス、トークン節約）
+claude mcp add icm -- icm serve --compact
+
+# 任意のMCPクライアント: command = "icm", args = ["serve"]
+```
+
+### スキル / ルール
+
+```bash
+icm init --mode skill
+```
+
+Claude Code（`/recall`、`/remember`）、Cursor（`.mdc` ルール）、Roo Code（`.md` ルール）、Amp（`/icm-recall`、`/icm-remember`）用のスラッシュコマンドとルールをインストールします。
+
+### フック（Claude Code）
+
+```bash
+icm init --mode hook
+```
+
+3つの抽出レイヤーすべてをClaude Codeフックとしてインストールします:
+
+**Claude Code** フック:
+
+| フック | イベント | 動作 |
+|--------|-------|-------------|
+| `icm hook pre` | PreToolUse | `icm` CLIコマンドを自動許可（許可プロンプトなし） |
+| `icm hook post` | PostToolUse | 15回のツール呼び出しごとにツール出力からファクトを抽出 |
+| `icm hook compact` | PreCompact | コンテキスト圧縮前にトランスクリプトからメモリを抽出 |
+| `icm hook prompt` | UserPromptSubmit | 各プロンプトの先頭に想起したコンテキストを注入 |
+
+**OpenCode** プラグイン（`~/.config/opencode/plugins/icm.js` に自動インストール）:
+
+| OpenCodeイベント | ICMレイヤー | 動作 |
+|---------------|-----------|-------------|
+| `tool.execute.after` | Layer 0 | ツール出力からファクトを抽出 |
+| `experimental.session.compacting` | Layer 1 | 圧縮前に会話から抽出 |
+| `session.created` | Layer 2 | セッション開始時にコンテキストを想起 |
+
+## CLI vs MCP
+
+ICMはCLI（`icm` コマンド）またはMCPサーバー（`icm serve`）経由で使用できます。どちらも同じデータベースにアクセスします。
+
+| | CLI | MCP |
+|---|-----|-----|
+| **レイテンシ** | ~30ms（直接バイナリ） | ~50ms（JSON-RPC stdio） |
+| **トークンコスト** | 0（フックベース、不可視） | ~20-50トークン/呼び出し（ツールスキーマ） |
+| **セットアップ** | `icm init --mode hook` | `icm init --mode mcp` |
+| **対応ツール** | Claude Code、OpenCode（フック/プラグイン経由） | MCP対応の全14ツール |
+| **自動抽出** | あり（フックが `icm extract` を起動） | あり（MCPツールがstoreを呼び出し） |
+| **最適用途** | パワーユーザー、トークン節約 | ユニバーサル互換性 |
+
+## CLI
+
+### Memories（エピソード記憶、減衰あり）
+
+```bash
+# 記録
+icm store -t "my-project" -c "Use PostgreSQL for the main DB" -i high -k "db,postgres"
+
+# 想起
+icm recall "database choice"
+icm recall "auth setup" --topic "my-project" --limit 10
+icm recall "architecture" --keyword "postgres"
+
+# 管理
+icm forget <memory-id>
+icm consolidate --topic "my-project"
+icm topics
+icm stats
+
+# テキストからファクトを抽出（ルールベース、LLMコストなし）
+echo "The parser uses Pratt algorithm" | icm extract -p my-project
+```
+
+### Memoirs（永続的ナレッジグラフ）
+
+```bash
+# 回想録を作成
+icm memoir create -n "system-architecture" -d "System design decisions"
+
+# ラベル付きコンセプトを追加
+icm memoir add-concept -m "system-architecture" -n "auth-service" \
+  -d "Handles JWT tokens and OAuth2 flows" -l "domain:auth,type:service"
+
+# コンセプトをリンク
+icm memoir link -m "system-architecture" --from "api-gateway" --to "auth-service" -r depends-on
+
+# ラベルフィルターで検索
+icm memoir search -m "system-architecture" "authentication"
+icm memoir search -m "system-architecture" "service" --label "domain:auth"
+
+# 近傍を調査
+icm memoir inspect -m "system-architecture" "auth-service" -D 2
+
+# グラフをエクスポート（フォーマット: json, dot, ascii, ai）
+icm memoir export -m "system-architecture" -f ascii   # 信頼度バー付きボックス描画
+icm memoir export -m "system-architecture" -f dot      # Graphviz DOT（色 = 信頼度レベル）
+icm memoir export -m "system-architecture" -f ai       # LLMコンテキスト最適化Markdown
+icm memoir export -m "system-architecture" -f json     # 全メタデータ付き構造化JSON
+
+# SVGビジュアライゼーションを生成
+icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
+```
+
+## MCPツール（22個）
+
+### メモリツール
+
+| ツール | 説明 |
+|--------|-------------|
+| `icm_memory_store` | 自動重複排除付きで記録（類似度85%超 → 複製ではなく更新） |
+| `icm_memory_recall` | クエリで検索、トピックやキーワードでフィルタリング |
+| `icm_memory_update` | メモリをインプレースで編集（内容、重要度、キーワード） |
+| `icm_memory_forget` | IDでメモリを削除 |
+| `icm_memory_consolidate` | トピックのすべてのメモリを1つのサマリーにマージ |
+| `icm_memory_list_topics` | 件数付きで全トピックを一覧表示 |
+| `icm_memory_stats` | グローバルメモリ統計 |
+| `icm_memory_health` | トピック別衛生監査（陳腐化、統合の必要性） |
+| `icm_memory_embed_all` | ベクター検索用に埋め込みをバックフィル |
+
+### 回想録ツール（ナレッジグラフ）
+
+| ツール | 説明 |
+|--------|-------------|
+| `icm_memoir_create` | 新しい回想録（ナレッジコンテナ）を作成 |
+| `icm_memoir_list` | 全回想録を一覧表示 |
+| `icm_memoir_show` | 回想録の詳細と全コンセプトを表示 |
+| `icm_memoir_add_concept` | ラベル付きコンセプトを追加 |
+| `icm_memoir_refine` | コンセプトの定義を更新 |
+| `icm_memoir_search` | 全文検索、オプションでラベルフィルター |
+| `icm_memoir_search_all` | 全回想録を横断して検索 |
+| `icm_memoir_link` | コンセプト間に型付きリレーションを作成 |
+| `icm_memoir_inspect` | コンセプトとグラフ近傍を調査（BFS） |
+| `icm_memoir_export` | 信頼度レベル付きグラフをエクスポート（json, dot, ascii, ai） |
+
+### フィードバックツール（間違いから学ぶ）
+
+| ツール | 説明 |
+|--------|-------------|
+| `icm_feedback_record` | AIの予測が間違っていた際に修正を記録 |
+| `icm_feedback_search` | 将来の予測に活かすため過去の修正を検索 |
+| `icm_feedback_stats` | フィードバック統計：総件数、トピック別内訳、最も適用された修正 |
+
+### リレーションタイプ
+
+`part_of` · `depends_on` · `related_to` · `contradicts` · `refines` · `alternative_to` · `caused_by` · `instance_of` · `superseded_by`
+
+## 仕組み
+
+### デュアルメモリモデル
+
+**エピソード記憶（トピック）** は意思決定、エラー、好みを記録します。各メモリは重要度に基づいて時間とともに減衰するウェイトを持ちます:
+
+| 重要度 | 減衰 | 削除 | 動作 |
+|-----------|-------|-------|----------|
+| `critical` | なし | しない | 忘れられず、削除されることもない |
+| `high` | 遅い（0.5倍のレート） | しない | ゆっくり減衰し、自動削除されることはない |
+| `medium` | 通常 | あり | 標準的な減衰、ウェイトが閾値を下回ると削除 |
+| `low` | 速い（2倍のレート） | あり | 急速に忘れられる |
+
+減衰は**アクセスを考慮**します：頻繁に想起されるメモリはより遅く減衰します（`decay / (1 + access_count × 0.1)`）。想起時に自動適用されます（最終減衰から24時間以上経過している場合）。
+
+**メモリ衛生管理** が組み込まれています:
+- **自動重複排除**: 同じトピック内の既存メモリとの類似度が85%を超える内容を記録すると、複製を作成する代わりに更新されます
+- **統合ヒント**: トピックが7件を超えると、`icm_memory_store` が呼び出し元に統合を促します
+- **衛生監査**: `icm_memory_health` はトピック別のエントリ数、平均ウェイト、陳腐化エントリ、統合の必要性を報告します
+- **サイレントなデータ損失なし**: 重要度が「critical」と「high」のメモリは自動削除されることはありません
+
+**セマンティック記憶（回想録）** は構造化されたナレッジをグラフとして記録します。コンセプトは永続的で、洗練されるだけで減衰しません。古くなったファクトを削除する代わりに `superseded_by` を使用してマークします。
+
+### ハイブリッド検索
+
+埋め込みが有効な場合、ICMはハイブリッド検索を使用します:
+- **FTS5 BM25**（30%）— 全文キーワードマッチング
+- **コサイン類似度**（70%）— sqlite-vecによるセマンティックベクター検索
+
+デフォルトモデル: `intfloat/multilingual-e5-base`（768次元、100以上の言語）。[設定ファイル](#設定)で変更可能:
+
+```toml
+[embeddings]
+# enabled = false                          # 完全に無効化（モデルのダウンロードなし）
+model = "intfloat/multilingual-e5-base"    # 768次元、多言語（デフォルト）
+# model = "intfloat/multilingual-e5-small" # 384次元、多言語（軽量）
+# model = "intfloat/multilingual-e5-large" # 1024次元、多言語（最高精度）
+# model = "Xenova/bge-small-en-v1.5"      # 384次元、英語のみ（最速）
+# model = "jinaai/jina-embeddings-v2-base-code"  # 768次元、コード最適化
+```
+
+埋め込みモデルのダウンロードを完全にスキップするには、以下のいずれかを使用します:
+```bash
+icm --no-embeddings serve          # CLIフラグ
+ICM_NO_EMBEDDINGS=1 icm serve     # 環境変数
+```
+または設定ファイルで `enabled = false` を設定します。ICMはFTS5キーワード検索にフォールバックします（動作しますが、セマンティックマッチングはありません）。
+
+モデルを変更すると、自動的にベクターインデックスが再作成されます（既存の埋め込みはクリアされ、`icm_memory_embed_all` で再生成できます）。
+
+### ストレージ
+
+単一のSQLiteファイル。外部サービスやネットワーク依存なし。
+
+```
+~/Library/Application Support/dev.icm.icm/memories.db                    # macOS
+~/.local/share/dev.icm.icm/memories.db                                   # Linux
+C:\Users\<user>\AppData\Local\icm\icm\data\memories.db                   # Windows
+```
+
+### 設定
+
+```bash
+icm config                    # アクティブな設定を表示
+```
+
+設定ファイルの場所（プラットフォーム別、または `$ICM_CONFIG`）:
+
+```
+~/Library/Application Support/dev.icm.icm/config.toml                    # macOS
+~/.config/icm/config.toml                                                # Linux
+C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml              # Windows
+```
+
+すべてのオプションは [config/default.toml](config/default.toml) を参照してください。
+
+## 自動抽出
+
+ICMは3つのレイヤーを通じてメモリを自動的に抽出します:
+
+```
+  Layer 0: パターンフック           Layer 1: PreCompact           Layer 2: UserPromptSubmit
+  （LLMコストなし）                  （LLMコストなし）               （LLMコストなし）
+  ┌──────────────────┐                ┌──────────────────┐          ┌──────────────────┐
+  │ PostToolUse hook  │                │ PreCompact hook   │          │ UserPromptSubmit  │
+  │                   │                │                   │          │                   │
+  │ • Bash errors     │                │ Context about to  │          │ User sends prompt │
+  │ • git commits     │                │ be compressed →   │          │ → icm recall      │
+  │ • config changes  │                │ extract memories  │          │ → inject context  │
+  │ • decisions       │                │ from transcript   │          │                   │
+  │ • preferences     │                │ before they're    │          │ Agent starts with  │
+  │ • learnings       │                │ lost forever      │          │ relevant memories  │
+  │ • constraints     │                │                   │          │ already loaded     │
+  │                   │                │ Same patterns +   │          │                   │
+  │ Rule-based, no LLM│                │ --store-raw fallbk│          │                   │
+  └──────────────────┘                └──────────────────┘          └──────────────────┘
+```
+
+| レイヤー | 状態 | LLMコスト | フックコマンド | 説明 |
+|-------|--------|----------|-------------|-------------|
+| Layer 0 | 実装済み | 0 | `icm hook post` | ツール出力からのルールベースキーワード抽出 |
+| Layer 1 | 実装済み | 0 | `icm hook compact` | コンテキスト圧縮前にトランスクリプトから抽出 |
+| Layer 2 | 実装済み | 0 | `icm hook prompt` | 各ユーザープロンプト時に想起メモリを注入 |
+
+3つのレイヤーすべては `icm init --mode hook` によって自動的にインストールされます。
+
+### 代替手段との比較
+
+| システム | 方法 | LLMコスト | レイテンシ | 圧縮をキャプチャ？ |
+|--------|--------|----------|---------|---------------------|
+| **ICM** | 3層抽出 | 0〜約500トークン/セッション | 0ms | **あり（PreCompact）** |
+| Mem0 | メッセージごとに2回のLLM呼び出し | 約2kトークン/メッセージ | 200〜2000ms | なし |
+| claude-mem | PostToolUse + 非同期 | 約1〜5kトークン/セッション | 8msフック | なし |
+| MemGPT/Letta | エージェント自己管理 | 追加コスト0 | 0ms | なし |
+| DiffMem | Gitベースdiff | 0 | 0ms | なし |
+
+## ベンチマーク
+
+### ストレージパフォーマンス
+
+```
+ICM Benchmark (1000 memories, 384d embeddings)
+──────────────────────────────────────────────────────────
+Store (no embeddings)      1000 ops      34.2 ms      34.2 µs/op
+Store (with embeddings)    1000 ops      51.6 ms      51.6 µs/op
+FTS5 search                 100 ops       4.7 ms      46.6 µs/op
+Vector search (KNN)         100 ops      59.0 ms     590.0 µs/op
+Hybrid search               100 ops      95.1 ms     951.1 µs/op
+Decay (batch)                 1 ops       5.8 ms       5.8 ms/op
+──────────────────────────────────────────────────────────
+```
+
+Apple M1 Pro、インメモリSQLite、シングルスレッド。`icm bench --count 1000`
+
+### エージェント効率
+
+実際のRustプロジェクト（12ファイル、約550行）を使用したマルチセッションワークフロー。セッション2以降は、ICMがファイルを再読み込みする代わりに想起することで最大の効果を発揮します。
+
+```
+ICM Agent Benchmark (10 sessions, model: haiku, 3 runs averaged)
+══════════════════════════════════════════════════════════════════
+                            Without ICM         With ICM      Delta
+Session 2 (recall)
+  Turns                             5.7              4.0       -29%
+  Context (input)                 99.9k            67.5k       -32%
+  Cost                          $0.0298          $0.0249       -17%
+
+Session 3 (recall)
+  Turns                             3.3              2.0       -40%
+  Context (input)                 74.7k            41.6k       -44%
+  Cost                          $0.0249          $0.0194       -22%
+══════════════════════════════════════════════════════════════════
+```
+
+`icm bench-agent --sessions 10 --model haiku`
+
+### 知識保持
+
+エージェントがセッションをまたいで密度の高い技術文書から特定のファクトを想起します。セッション1で読み込んで記憶し、セッション2以降はソーステキスト**なし**で10の事実質問に回答します。
+
+```
+ICM Recall Benchmark (10 questions, model: haiku, 5 runs averaged)
+══════════════════════════════════════════════════════════════════════
+                                               No ICM     With ICM
+──────────────────────────────────────────────────────────────────────
+Average score                                      5%          68%
+Questions passed                                 0/10         5/10
+══════════════════════════════════════════════════════════════════════
+```
+
+`icm bench-recall --model haiku`
+
+### ローカルLLM（ollama）
+
+ローカルモデルを使用した同じテスト — 純粋なコンテキスト注入、ツール使用不要。
+
+```
+Model               Params   No ICM   With ICM     Delta
+─────────────────────────────────────────────────────────
+qwen2.5:14b           14B       4%       97%       +93%
+mistral:7b             7B       4%       93%       +89%
+llama3.1:8b            8B       4%       93%       +89%
+qwen2.5:7b             7B       4%       90%       +86%
+phi4:14b              14B       6%       79%       +73%
+llama3.2:3b            3B       0%       76%       +76%
+gemma2:9b              9B       4%       76%       +72%
+qwen2.5:3b             3B       2%       58%       +56%
+─────────────────────────────────────────────────────────
+```
+
+`scripts/bench-ollama.sh qwen2.5:14b`
+
+### テストプロトコル
+
+すべてのベンチマークは**実際のAPI呼び出し**を使用 — モックなし、シミュレートされたレスポンスなし、キャッシュされた回答なし。
+
+- **エージェントベンチマーク**: tempdir内に実際のRustプロジェクトを作成。`claude -p --output-format json` でNセッションを実行。ICMなし: 空のMCP設定。ICMあり: 実際のMCPサーバー + 自動抽出 + コンテキスト注入。
+- **知識保持**: 架空の技術文書（「Meridian Protocol」）を使用。期待されるファクトに対するキーワードマッチングで回答を採点。呼び出しごとに120秒タイムアウト。
+- **分離**: 各実行は独自のtempdir と新鮮なSQLite DBを使用。セッション持続性なし。
+
+## ドキュメント
+
+| ドキュメント | 説明 |
+|----------|-------------|
+| [技術アーキテクチャ](docs/architecture.md) | クレート構造、検索パイプライン、減衰モデル、sqlite-vec統合、テスト |
+| [ユーザーガイド](docs/guide.md) | インストール、トピック整理、統合、抽出、トラブルシューティング |
+| [製品概要](docs/product.md) | ユースケース、ベンチマーク、代替手段との比較 |
+
+## ライセンス
+
+[Source-Available](LICENSE) — 個人および20人以下のチームは無料。それ以上の組織にはエンタープライズライセンスが必要です。お問い合わせ: license@rtk.ai

--- a/README_ko.md
+++ b/README_ko.md
@@ -1,0 +1,453 @@
+[English](README.md) | [Français](README_fr.md) | [Español](README_es.md) | [Deutsch](README_de.md) | [Italiano](README_it.md) | [Português](README_pt.md) | [Nederlands](README_nl.md) | [Polski](README_pl.md) | [Русский](README_ru.md) | [日本語](README_ja.md) | [中文](README_zh.md) | [العربية](README_ar.md) | **한국어**
+
+<p align="center">
+  <img src="assets/banner.png" alt="ICM — Infinite Context Memory" width="600">
+</p>
+
+<h1 align="center">ICM</h1>
+
+<p align="center">
+  AI 에이전트를 위한 영구 메모리. 단일 바이너리, 의존성 없음, MCP 네이티브.
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/icm/actions/workflows/ci.yml"><img src="https://github.com/rtk-ai/icm/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/icm/releases/latest"><img src="https://img.shields.io/github/v/release/rtk-ai/icm?color=purple" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Source--Available-orange.svg" alt="Source-Available"></a>
+</p>
+
+---
+
+ICM은 AI 에이전트에게 진짜 메모리를 제공합니다 — 메모 도구도, 컨텍스트 관리자도 아닌, **메모리** 그 자체입니다.
+
+```
+                       ICM (Infinite Context Memory)
+            ┌──────────────────────┬─────────────────────────┐
+            │   MEMORIES (Topics)  │   MEMOIRS (Knowledge)   │
+            │                      │                         │
+            │  Episodic, temporal  │  Permanent, structured  │
+            │                      │                         │
+            │  ┌───┐ ┌───┐ ┌───┐  │    ┌───┐               │
+            │  │ m │ │ m │ │ m │  │    │ C │──depends_on──┐ │
+            │  └─┬─┘ └─┬─┘ └─┬─┘  │    └───┘              │ │
+            │    │decay │     │    │      │ refines      ┌─▼─┐│
+            │    ▼      ▼     ▼    │    ┌─▼─┐            │ C ││
+            │  weight decreases    │    │ C │──part_of──>└───┘│
+            │  over time unless    │    └───┘                 │
+            │  accessed/critical   │  Concepts + Relations    │
+            ├──────────────────────┴─────────────────────────┤
+            │             SQLite + FTS5 + sqlite-vec          │
+            │        Hybrid search: BM25 (30%) + cosine (70%) │
+            └─────────────────────────────────────────────────┘
+```
+
+**두 가지 메모리 모델:**
+
+- **Memories** — 중요도에 따른 시간적 감쇠와 함께 저장/검색. 중요 메모리는 절대 사라지지 않고, 낮은 중요도는 자연적으로 감쇠. 토픽 또는 키워드로 필터링 가능.
+- **Memoirs** — 영구 지식 그래프. 타입이 지정된 관계(`depends_on`, `contradicts`, `superseded_by`, ...)로 연결된 개념. 레이블로 필터링 가능.
+- **Feedback** — AI 예측이 틀렸을 때 수정 사항 기록. 새로운 예측 전에 과거 실수를 검색. 폐쇄 루프 학습.
+
+## 설치
+
+```bash
+# Homebrew (macOS / Linux)
+brew tap rtk-ai/tap && brew install icm
+
+# 빠른 설치
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+
+# 소스에서 빌드
+cargo install --path crates/icm-cli
+```
+
+## 설정
+
+```bash
+# 지원되는 모든 도구를 자동 감지 및 구성
+icm init
+```
+
+한 번의 명령으로 **14개 도구**를 구성합니다:
+
+| 도구 | 설정 파일 | 형식 |
+|------|------------|--------|
+| Claude Code | `~/.claude.json` | JSON |
+| Claude Desktop | `~/Library/.../claude_desktop_config.json` | JSON |
+| Cursor | `~/.cursor/mcp.json` | JSON |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON |
+| VS Code / Copilot | `~/Library/.../Code/User/mcp.json` | JSON |
+| Gemini Code Assist | `~/.gemini/settings.json` | JSON |
+| Zed | `~/.zed/settings.json` | JSON |
+| Amp | `~/.config/amp/settings.json` | JSON |
+| Amazon Q | `~/.aws/amazonq/mcp.json` | JSON |
+| Cline | VS Code globalStorage | JSON |
+| Roo Code | VS Code globalStorage | JSON |
+| Kilo Code | VS Code globalStorage | JSON |
+| OpenAI Codex CLI | `~/.codex/config.toml` | TOML |
+| OpenCode | `~/.config/opencode/opencode.json` | JSON |
+
+또는 수동으로:
+
+```bash
+# Claude Code
+claude mcp add icm -- icm serve
+
+# 컴팩트 모드 (더 짧은 응답, 토큰 절약)
+claude mcp add icm -- icm serve --compact
+
+# 모든 MCP 클라이언트: command = "icm", args = ["serve"]
+```
+
+### 스킬 / 규칙
+
+```bash
+icm init --mode skill
+```
+
+Claude Code(`/recall`, `/remember`), Cursor(`.mdc` 규칙), Roo Code(`.md` 규칙), Amp(`/icm-recall`, `/icm-remember`)에 슬래시 명령과 규칙을 설치합니다.
+
+### 훅 (Claude Code)
+
+```bash
+icm init --mode hook
+```
+
+모든 3가지 추출 레이어를 Claude Code 훅으로 설치합니다:
+
+**Claude Code** 훅:
+
+| 훅 | 이벤트 | 동작 |
+|------|-------|-------------|
+| `icm hook pre` | PreToolUse | `icm` CLI 명령 자동 허용 (권한 프롬프트 없음) |
+| `icm hook post` | PostToolUse | 15번 호출마다 도구 출력에서 사실 추출 |
+| `icm hook compact` | PreCompact | 컨텍스트 압축 전 스크립트에서 메모리 추출 |
+| `icm hook prompt` | UserPromptSubmit | 각 프롬프트 시작 시 회상된 컨텍스트 주입 |
+
+**OpenCode** 플러그인 (`~/.config/opencode/plugins/icm.js`에 자동 설치):
+
+| OpenCode 이벤트 | ICM 레이어 | 동작 |
+|---------------|-----------|-------------|
+| `tool.execute.after` | Layer 0 | 도구 출력에서 사실 추출 |
+| `experimental.session.compacting` | Layer 1 | 압축 전 대화에서 추출 |
+| `session.created` | Layer 2 | 세션 시작 시 컨텍스트 회상 |
+
+## CLI vs MCP
+
+ICM은 CLI(`icm` 명령) 또는 MCP 서버(`icm serve`)를 통해 사용할 수 있습니다. 둘 다 동일한 데이터베이스에 접근합니다.
+
+| | CLI | MCP |
+|---|-----|-----|
+| **지연 시간** | ~30ms (직접 바이너리) | ~50ms (JSON-RPC stdio) |
+| **토큰 비용** | 0 (훅 기반, 보이지 않음) | ~20-50 토큰/호출 (도구 스키마) |
+| **설정** | `icm init --mode hook` | `icm init --mode mcp` |
+| **호환 도구** | Claude Code, OpenCode (훅/플러그인 통해) | 14개 MCP 호환 도구 모두 |
+| **자동 추출** | 예 (훅이 `icm extract` 트리거) | 예 (MCP 도구가 store 호출) |
+| **최적 용도** | 파워 유저, 토큰 절약 | 범용 호환성 |
+
+## CLI
+
+### Memories (에피소드, 감쇠 포함)
+
+```bash
+# 저장
+icm store -t "my-project" -c "Use PostgreSQL for the main DB" -i high -k "db,postgres"
+
+# 회상
+icm recall "database choice"
+icm recall "auth setup" --topic "my-project" --limit 10
+icm recall "architecture" --keyword "postgres"
+
+# 관리
+icm forget <memory-id>
+icm consolidate --topic "my-project"
+icm topics
+icm stats
+
+# 텍스트에서 사실 추출 (규칙 기반, LLM 비용 없음)
+echo "The parser uses Pratt algorithm" | icm extract -p my-project
+```
+
+### Memoirs (영구 지식 그래프)
+
+```bash
+# memoir 생성
+icm memoir create -n "system-architecture" -d "System design decisions"
+
+# 레이블이 있는 개념 추가
+icm memoir add-concept -m "system-architecture" -n "auth-service" \
+  -d "Handles JWT tokens and OAuth2 flows" -l "domain:auth,type:service"
+
+# 개념 연결
+icm memoir link -m "system-architecture" --from "api-gateway" --to "auth-service" -r depends-on
+
+# 레이블 필터로 검색
+icm memoir search -m "system-architecture" "authentication"
+icm memoir search -m "system-architecture" "service" --label "domain:auth"
+
+# 이웃 검사
+icm memoir inspect -m "system-architecture" "auth-service" -D 2
+
+# 그래프 내보내기 (형식: json, dot, ascii, ai)
+icm memoir export -m "system-architecture" -f ascii   # 신뢰도 바 포함 박스 드로잉
+icm memoir export -m "system-architecture" -f dot      # Graphviz DOT (색상 = 신뢰도 수준)
+icm memoir export -m "system-architecture" -f ai       # LLM 컨텍스트에 최적화된 마크다운
+icm memoir export -m "system-architecture" -f json     # 모든 메타데이터 포함 구조화된 JSON
+
+# SVG 시각화 생성
+icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
+```
+
+## MCP 도구 (22개)
+
+### 메모리 도구
+
+| 도구 | 설명 |
+|------|-------------|
+| `icm_memory_store` | 자동 중복 제거와 함께 저장 (>85% 유사도 → 중복 대신 업데이트) |
+| `icm_memory_recall` | 쿼리로 검색, 토픽 및/또는 키워드로 필터링 |
+| `icm_memory_update` | 메모리 인플레이스 편집 (내용, 중요도, 키워드) |
+| `icm_memory_forget` | ID로 메모리 삭제 |
+| `icm_memory_consolidate` | 토픽의 모든 메모리를 하나의 요약으로 병합 |
+| `icm_memory_list_topics` | 카운트와 함께 모든 토픽 나열 |
+| `icm_memory_stats` | 글로벌 메모리 통계 |
+| `icm_memory_health` | 토픽별 위생 감사 (오래됨, 통합 필요) |
+| `icm_memory_embed_all` | 벡터 검색을 위한 임베딩 백필 |
+
+### Memoir 도구 (지식 그래프)
+
+| 도구 | 설명 |
+|------|-------------|
+| `icm_memoir_create` | 새 memoir 생성 (지식 컨테이너) |
+| `icm_memoir_list` | 모든 memoir 나열 |
+| `icm_memoir_show` | memoir 세부 정보 및 모든 개념 표시 |
+| `icm_memoir_add_concept` | 레이블이 있는 개념 추가 |
+| `icm_memoir_refine` | 개념의 정의 업데이트 |
+| `icm_memoir_search` | 전체 텍스트 검색, 레이블로 선택적 필터링 |
+| `icm_memoir_search_all` | 모든 memoir에서 검색 |
+| `icm_memoir_link` | 개념 간 타입이 지정된 관계 생성 |
+| `icm_memoir_inspect` | 개념 및 그래프 이웃 검사 (BFS) |
+| `icm_memoir_export` | 신뢰도 수준과 함께 그래프 내보내기 (json, dot, ascii, ai) |
+
+### 피드백 도구 (실수로부터 학습)
+
+| 도구 | 설명 |
+|------|-------------|
+| `icm_feedback_record` | AI 예측이 틀렸을 때 수정 사항 기록 |
+| `icm_feedback_search` | 미래 예측 정보를 위한 과거 수정 사항 검색 |
+| `icm_feedback_stats` | 피드백 통계: 총 카운트, 토픽별 분류, 가장 많이 적용된 항목 |
+
+### 관계 타입
+
+`part_of` · `depends_on` · `related_to` · `contradicts` · `refines` · `alternative_to` · `caused_by` · `instance_of` · `superseded_by`
+
+## 작동 방식
+
+### 이중 메모리 모델
+
+**에피소드 메모리 (Topics)**는 결정, 오류, 선호도를 캡처합니다. 각 메모리는 중요도에 따라 시간이 지남에 따라 감쇠하는 가중치를 가집니다:
+
+| 중요도 | 감쇠 | 정리 | 동작 |
+|-----------|-------|-------|----------|
+| `critical` | 없음 | 절대 안 함 | 절대 잊혀지지 않음, 절대 정리되지 않음 |
+| `high` | 느림 (0.5x 속도) | 절대 안 함 | 느리게 감쇠, 자동 삭제 없음 |
+| `medium` | 보통 | 예 | 표준 감쇠, 가중치 < 임계값이면 정리됨 |
+| `low` | 빠름 (2x 속도) | 예 | 빠르게 잊혀짐 |
+
+감쇠는 **접근 인식** 방식입니다: 자주 회상되는 메모리는 더 느리게 감쇠합니다(`decay / (1 + access_count × 0.1)`). 회상 시 자동으로 적용됩니다 (마지막 감쇠 이후 >24시간인 경우).
+
+**메모리 위생**이 내장되어 있습니다:
+- **자동 중복 제거**: 같은 토픽에서 기존 메모리와 >85% 유사한 내용을 저장하면 중복 생성 대신 업데이트됨
+- **통합 힌트**: 토픽이 7개 항목을 초과하면 `icm_memory_store`가 호출자에게 통합 권고
+- **건강 감사**: `icm_memory_health`는 토픽별 항목 수, 평균 가중치, 오래된 항목, 통합 필요 여부 보고
+- **무음 데이터 손실 없음**: critical 및 high 중요도 메모리는 자동 정리되지 않음
+
+**시맨틱 메모리 (Memoirs)**는 구조화된 지식을 그래프로 캡처합니다. 개념은 영구적입니다 — 정제되며, 감쇠되지 않습니다. 사실을 삭제하는 대신 `superseded_by`를 사용하여 오래된 사실을 표시합니다.
+
+### 하이브리드 검색
+
+임베딩이 활성화되면 ICM은 하이브리드 검색을 사용합니다:
+- **FTS5 BM25** (30%) — 전체 텍스트 키워드 매칭
+- **코사인 유사도** (70%) — sqlite-vec를 통한 시맨틱 벡터 검색
+
+기본 모델: `intfloat/multilingual-e5-base` (768d, 100+ 언어). [설정 파일](#설정)에서 구성 가능:
+
+```toml
+[embeddings]
+# enabled = false                          # 완전히 비활성화 (모델 다운로드 없음)
+model = "intfloat/multilingual-e5-base"    # 768d, 다국어 (기본값)
+# model = "intfloat/multilingual-e5-small" # 384d, 다국어 (더 가벼움)
+# model = "intfloat/multilingual-e5-large" # 1024d, 다국어 (최고 정확도)
+# model = "Xenova/bge-small-en-v1.5"      # 384d, 영어 전용 (가장 빠름)
+# model = "jinaai/jina-embeddings-v2-base-code"  # 768d, 코드 최적화
+```
+
+임베딩 모델 다운로드를 완전히 건너뛰려면 다음 중 하나를 사용합니다:
+```bash
+icm --no-embeddings serve          # CLI 플래그
+ICM_NO_EMBEDDINGS=1 icm serve     # 환경 변수
+```
+또는 설정 파일에서 `enabled = false`로 설정합니다. ICM은 FTS5 키워드 검색으로 대체됩니다 (여전히 작동하지만 시맨틱 매칭 없음).
+
+모델을 변경하면 자동으로 벡터 인덱스가 재생성됩니다 (기존 임베딩이 지워지며 `icm_memory_embed_all`로 재생성 가능).
+
+### 저장소
+
+단일 SQLite 파일. 외부 서비스, 네트워크 의존성 없음.
+
+```
+~/Library/Application Support/dev.icm.icm/memories.db                    # macOS
+~/.local/share/dev.icm.icm/memories.db                                   # Linux
+C:\Users\<user>\AppData\Local\icm\icm\data\memories.db                   # Windows
+```
+
+### 설정
+
+```bash
+icm config                    # 활성 설정 표시
+```
+
+설정 파일 위치 (플랫폼별, 또는 `$ICM_CONFIG`):
+
+```
+~/Library/Application Support/dev.icm.icm/config.toml                    # macOS
+~/.config/icm/config.toml                                                # Linux
+C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml              # Windows
+```
+
+모든 옵션은 [config/default.toml](config/default.toml)을 참조하세요.
+
+## 자동 추출
+
+ICM은 세 가지 레이어를 통해 메모리를 자동으로 추출합니다:
+
+```
+  Layer 0: Pattern hooks              Layer 1: PreCompact           Layer 2: UserPromptSubmit
+  (zero LLM cost)                     (zero LLM cost)               (zero LLM cost)
+  ┌──────────────────┐                ┌──────────────────┐          ┌──────────────────┐
+  │ PostToolUse hook  │                │ PreCompact hook   │          │ UserPromptSubmit  │
+  │                   │                │                   │          │                   │
+  │ • Bash errors     │                │ Context about to  │          │ User sends prompt │
+  │ • git commits     │                │ be compressed →   │          │ → icm recall      │
+  │ • config changes  │                │ extract memories  │          │ → inject context  │
+  │ • decisions       │                │ from transcript   │          │                   │
+  │ • preferences     │                │ before they're    │          │ Agent starts with  │
+  │ • learnings       │                │ lost forever      │          │ relevant memories  │
+  │ • constraints     │                │                   │          │ already loaded     │
+  │                   │                │ Same patterns +   │          │                   │
+  │ Rule-based, no LLM│                │ --store-raw fallbk│          │                   │
+  └──────────────────┘                └──────────────────┘          └──────────────────┘
+```
+
+| 레이어 | 상태 | LLM 비용 | 훅 명령 | 설명 |
+|-------|--------|----------|-------------|-------------|
+| Layer 0 | 구현됨 | 0 | `icm hook post` | 도구 출력에서 규칙 기반 키워드 추출 |
+| Layer 1 | 구현됨 | 0 | `icm hook compact` | 컨텍스트 압축 전 스크립트에서 추출 |
+| Layer 2 | 구현됨 | 0 | `icm hook prompt` | 각 사용자 프롬프트에서 회상된 메모리 주입 |
+
+3개 레이어 모두 `icm init --mode hook`으로 자동 설치됩니다.
+
+### 대안과의 비교
+
+| 시스템 | 방법 | LLM 비용 | 지연 시간 | 압축 캡처? |
+|--------|--------|----------|---------|---------------------|
+| **ICM** | 3레이어 추출 | 0 ~ ~500 토큰/세션 | 0ms | **예 (PreCompact)** |
+| Mem0 | 메시지당 2번 LLM 호출 | ~2k 토큰/메시지 | 200-2000ms | 아니오 |
+| claude-mem | PostToolUse + 비동기 | ~1-5k 토큰/세션 | 8ms 훅 | 아니오 |
+| MemGPT/Letta | 에이전트 자체 관리 | 추가 비용 없음 | 0ms | 아니오 |
+| DiffMem | Git 기반 diff | 0 | 0ms | 아니오 |
+
+## 벤치마크
+
+### 저장 성능
+
+```
+ICM Benchmark (1000 memories, 384d embeddings)
+──────────────────────────────────────────────────────────
+Store (no embeddings)      1000 ops      34.2 ms      34.2 µs/op
+Store (with embeddings)    1000 ops      51.6 ms      51.6 µs/op
+FTS5 search                 100 ops       4.7 ms      46.6 µs/op
+Vector search (KNN)         100 ops      59.0 ms     590.0 µs/op
+Hybrid search               100 ops      95.1 ms     951.1 µs/op
+Decay (batch)                 1 ops       5.8 ms       5.8 ms/op
+──────────────────────────────────────────────────────────
+```
+
+Apple M1 Pro, 인메모리 SQLite, 단일 스레드. `icm bench --count 1000`
+
+### 에이전트 효율성
+
+실제 Rust 프로젝트(12개 파일, ~550줄)를 사용한 다중 세션 워크플로. 세션 2+에서 ICM이 파일을 다시 읽는 대신 회상하면서 가장 큰 효율을 보입니다.
+
+```
+ICM Agent Benchmark (10 sessions, model: haiku, 3 runs averaged)
+══════════════════════════════════════════════════════════════════
+                            Without ICM         With ICM      Delta
+Session 2 (recall)
+  Turns                             5.7              4.0       -29%
+  Context (input)                 99.9k            67.5k       -32%
+  Cost                          $0.0298          $0.0249       -17%
+
+Session 3 (recall)
+  Turns                             3.3              2.0       -40%
+  Context (input)                 74.7k            41.6k       -44%
+  Cost                          $0.0249          $0.0194       -22%
+══════════════════════════════════════════════════════════════════
+```
+
+`icm bench-agent --sessions 10 --model haiku`
+
+### 지식 보존
+
+에이전트가 세션 간에 밀도 높은 기술 문서에서 특정 사실을 회상합니다. 세션 1은 읽고 기억하며; 세션 2+는 소스 텍스트 **없이** 10개의 사실적 질문에 답합니다.
+
+```
+ICM Recall Benchmark (10 questions, model: haiku, 5 runs averaged)
+══════════════════════════════════════════════════════════════════════
+                                               No ICM     With ICM
+──────────────────────────────────────────────────────────────────────
+Average score                                      5%          68%
+Questions passed                                 0/10         5/10
+══════════════════════════════════════════════════════════════════════
+```
+
+`icm bench-recall --model haiku`
+
+### 로컬 LLM (ollama)
+
+로컬 모델로 동일한 테스트 — 순수 컨텍스트 주입, 도구 사용 필요 없음.
+
+```
+Model               Params   No ICM   With ICM     Delta
+─────────────────────────────────────────────────────────
+qwen2.5:14b           14B       4%       97%       +93%
+mistral:7b             7B       4%       93%       +89%
+llama3.1:8b            8B       4%       93%       +89%
+qwen2.5:7b             7B       4%       90%       +86%
+phi4:14b              14B       6%       79%       +73%
+llama3.2:3b            3B       0%       76%       +76%
+gemma2:9b              9B       4%       76%       +72%
+qwen2.5:3b             3B       2%       58%       +56%
+─────────────────────────────────────────────────────────
+```
+
+`scripts/bench-ollama.sh qwen2.5:14b`
+
+### 테스트 프로토콜
+
+모든 벤치마크는 **실제 API 호출**을 사용합니다 — 목(mock) 없음, 시뮬레이션된 응답 없음, 캐시된 답변 없음.
+
+- **에이전트 벤치마크**: 임시 디렉터리에 실제 Rust 프로젝트를 생성합니다. `claude -p --output-format json`으로 N개의 세션을 실행합니다. ICM 없이: 빈 MCP 설정. ICM 있이: 실제 MCP 서버 + 자동 추출 + 컨텍스트 주입.
+- **지식 보존**: 가상의 기술 문서("Meridian Protocol")를 사용합니다. 예상 사실에 대한 키워드 매칭으로 답변 채점. 호출당 120초 타임아웃.
+- **격리**: 각 실행은 자체 임시 디렉터리와 새로운 SQLite DB를 사용합니다. 세션 지속성 없음.
+
+## 문서
+
+| 문서 | 설명 |
+|----------|-------------|
+| [기술 아키텍처](docs/architecture.md) | 크레이트 구조, 검색 파이프라인, 감쇠 모델, sqlite-vec 통합, 테스트 |
+| [사용자 가이드](docs/guide.md) | 설치, 토픽 구성, 통합, 추출, 문제 해결 |
+| [제품 개요](docs/product.md) | 사용 사례, 벤치마크, 대안과의 비교 |
+
+## 라이선스
+
+[Source-Available](LICENSE) — 개인 및 20명 이하 팀에게 무료. 대규모 조직은 엔터프라이즈 라이선스 필요. 문의: license@rtk.ai

--- a/README_nl.md
+++ b/README_nl.md
@@ -1,0 +1,455 @@
+[English](README.md) | [Français](README_fr.md) | [Español](README_es.md) | [Deutsch](README_de.md) | [Italiano](README_it.md) | [Português](README_pt.md) | **Nederlands** | [Polski](README_pl.md) | [Русский](README_ru.md) | [日本語](README_ja.md) | [中文](README_zh.md) | [العربية](README_ar.md) | [한국어](README_ko.md)
+
+<p align="center">
+  <img src="assets/banner.png" alt="ICM — Infinite Context Memory" width="600">
+</p>
+
+<h1 align="center">ICM</h1>
+
+<p align="center">
+  Permanent geheugen voor AI-agenten. Één binair bestand, geen afhankelijkheden, native MCP.
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/icm/actions/workflows/ci.yml"><img src="https://github.com/rtk-ai/icm/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/icm/releases/latest"><img src="https://img.shields.io/github/v/release/rtk-ai/icm?color=purple" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Source--Available-orange.svg" alt="Source-Available"></a>
+</p>
+
+---
+
+ICM geeft uw AI-agent een echt geheugen — geen notitietool, geen contextbeheerder, maar een **geheugen**.
+
+```
+                       ICM (Infinite Context Memory)
+            ┌──────────────────────┬─────────────────────────┐
+            │   MEMORIES (Topics)  │   MEMOIRS (Knowledge)   │
+            │                      │                         │
+            │  Episodisch, tijdel. │  Permanent, gestructur. │
+            │                      │                         │
+            │  ┌───┐ ┌───┐ ┌───┐  │    ┌───┐               │
+            │  │ m │ │ m │ │ m │  │    │ C │──depends_on──┐ │
+            │  └─┬─┘ └─┬─┘ └─┬─┘  │    └───┘              │ │
+            │    │decay │     │    │      │ refines      ┌─▼─┐│
+            │    ▼      ▼     ▼    │    ┌─▼─┐            │ C ││
+            │  gewicht neemt af    │    │ C │──part_of──>└───┘│
+            │  over tijd tenzij    │    └───┘                 │
+            │  benaderd/kritiek    │  Concepten + Relaties    │
+            ├──────────────────────┴─────────────────────────┤
+            │             SQLite + FTS5 + sqlite-vec          │
+            │        Hybride zoekopdracht: BM25 (30%) + cosinus (70%) │
+            └─────────────────────────────────────────────────┘
+```
+
+**Twee geheugenmodellen:**
+
+- **Memories** — opslaan/ophalen met tijdelijk verval op basis van belang. Kritieke herinneringen vervagen nooit, herinneringen met lage prioriteit vervagen vanzelf. Filter op onderwerp of trefwoord.
+- **Memoirs** — permanente kennisgrafen. Concepten gekoppeld door getypeerde relaties (`depends_on`, `contradicts`, `superseded_by`, ...). Filter op label.
+- **Feedback** — correcies vastleggen wanneer AI-voorspellingen fout zijn. Zoek eerdere fouten op voordat nieuwe voorspellingen worden gedaan. Gesloten-lus leren.
+
+## Installatie
+
+```bash
+# Homebrew (macOS / Linux)
+brew tap rtk-ai/tap && brew install icm
+
+# Snelle installatie
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+
+# Vanuit broncode
+cargo install --path crates/icm-cli
+```
+
+## Instelling
+
+```bash
+# Automatisch detecteren en alle ondersteunde tools configureren
+icm init
+```
+
+Configureert **14 tools** in één opdracht:
+
+| Tool | Configuratiebestand | Formaat |
+|------|---------------------|---------|
+| Claude Code | `~/.claude.json` | JSON |
+| Claude Desktop | `~/Library/.../claude_desktop_config.json` | JSON |
+| Cursor | `~/.cursor/mcp.json` | JSON |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON |
+| VS Code / Copilot | `~/Library/.../Code/User/mcp.json` | JSON |
+| Gemini Code Assist | `~/.gemini/settings.json` | JSON |
+| Zed | `~/.zed/settings.json` | JSON |
+| Amp | `~/.config/amp/settings.json` | JSON |
+| Amazon Q | `~/.aws/amazonq/mcp.json` | JSON |
+| Cline | VS Code globalStorage | JSON |
+| Roo Code | VS Code globalStorage | JSON |
+| Kilo Code | VS Code globalStorage | JSON |
+| OpenAI Codex CLI | `~/.codex/config.toml` | TOML |
+| OpenCode | `~/.config/opencode/opencode.json` | JSON |
+
+Of handmatig:
+
+```bash
+# Claude Code
+claude mcp add icm -- icm serve
+
+# Compacte modus (kortere antwoorden, bespaart tokens)
+claude mcp add icm -- icm serve --compact
+
+# Elke MCP-client: command = "icm", args = ["serve"]
+```
+
+### Skills / regels
+
+```bash
+icm init --mode skill
+```
+
+Installeert slash-commando's en regels voor Claude Code (`/recall`, `/remember`), Cursor (`.mdc`-regel), Roo Code (`.md`-regel) en Amp (`/icm-recall`, `/icm-remember`).
+
+### Hooks (Claude Code)
+
+```bash
+icm init --mode hook
+```
+
+Installeert alle 3 extractielagen als Claude Code-hooks:
+
+**Claude Code**-hooks:
+
+| Hook | Gebeurtenis | Wat het doet |
+|------|-------------|--------------|
+| `icm hook pre` | PreToolUse | Automatisch `icm` CLI-opdrachten toestaan (geen toestemmingsprompt) |
+| `icm hook post` | PostToolUse | Feiten extraheren uit tool-uitvoer elke 15 aanroepen |
+| `icm hook compact` | PreCompact | Herinneringen extraheren uit transcript vóór contextcompressie |
+| `icm hook prompt` | UserPromptSubmit | Opgehaalde context injecteren aan het begin van elke prompt |
+
+**OpenCode**-plugin (automatisch geïnstalleerd naar `~/.config/opencode/plugins/icm.js`):
+
+| OpenCode-gebeurtenis | ICM-laag | Wat het doet |
+|----------------------|----------|--------------|
+| `tool.execute.after` | Laag 0 | Feiten extraheren uit tool-uitvoer |
+| `experimental.session.compacting` | Laag 1 | Extraheren uit gesprek vóór compactie |
+| `session.created` | Laag 2 | Context ophalen bij start van sessie |
+
+## CLI versus MCP
+
+ICM kan worden gebruikt via CLI (`icm`-opdrachten) of MCP-server (`icm serve`). Beide hebben toegang tot dezelfde database.
+
+| | CLI | MCP |
+|---|-----|-----|
+| **Latentie** | ~30ms (direct binair bestand) | ~50ms (JSON-RPC stdio) |
+| **Tokenkosten** | 0 (hook-gebaseerd, onzichtbaar) | ~20-50 tokens/aanroep (tool-schema) |
+| **Instelling** | `icm init --mode hook` | `icm init --mode mcp` |
+| **Werkt met** | Claude Code, OpenCode (via hooks/plugins) | Alle 14 MCP-compatibele tools |
+| **Automatische extractie** | Ja (hooks activeren `icm extract`) | Ja (MCP-tools roepen store aan) |
+| **Het beste voor** | Geavanceerde gebruikers, tokenbesparing | Universele compatibiliteit |
+
+## CLI
+
+### Memories (episodisch, met verval)
+
+```bash
+# Opslaan
+icm store -t "mijn-project" -c "Gebruik PostgreSQL voor de hoofd-DB" -i high -k "db,postgres"
+
+# Ophalen
+icm recall "databasekeuze"
+icm recall "auth-instelling" --topic "mijn-project" --limit 10
+icm recall "architectuur" --keyword "postgres"
+
+# Beheren
+icm forget <memory-id>
+icm consolidate --topic "mijn-project"
+icm topics
+icm stats
+
+# Feiten extraheren uit tekst (regelgebaseerd, geen LLM-kosten)
+echo "The parser uses Pratt algorithm" | icm extract -p mijn-project
+```
+
+### Memoirs (permanente kennisgrafen)
+
+```bash
+# Een memoir aanmaken
+icm memoir create -n "systeem-architectuur" -d "Ontwerpbeslissingen voor het systeem"
+
+# Concepten toevoegen met labels
+icm memoir add-concept -m "systeem-architectuur" -n "auth-service" \
+  -d "Verwerkt JWT-tokens en OAuth2-stromen" -l "domain:auth,type:service"
+
+# Concepten koppelen
+icm memoir link -m "systeem-architectuur" --from "api-gateway" --to "auth-service" -r depends-on
+
+# Zoeken met labelfilter
+icm memoir search -m "systeem-architectuur" "authenticatie"
+icm memoir search -m "systeem-architectuur" "service" --label "domain:auth"
+
+# Buurt inspecteren
+icm memoir inspect -m "systeem-architectuur" "auth-service" -D 2
+
+# Graaf exporteren (formaten: json, dot, ascii, ai)
+icm memoir export -m "systeem-architectuur" -f ascii   # Lijntekening met betrouwbaarheidsbalken
+icm memoir export -m "systeem-architectuur" -f dot      # Graphviz DOT (kleur = betrouwbaarheidsniveau)
+icm memoir export -m "systeem-architectuur" -f ai       # Markdown geoptimaliseerd voor LLM-context
+icm memoir export -m "systeem-architectuur" -f json     # Gestructureerde JSON met alle metadata
+
+# SVG-visualisatie genereren
+icm memoir export -m "systeem-architectuur" -f dot | dot -Tsvg > graph.svg
+```
+
+## MCP-tools (22)
+
+### Geheugentools
+
+| Tool | Beschrijving |
+|------|--------------|
+| `icm_memory_store` | Opslaan met automatische deduplicatie (>85% gelijkenis → bijwerken in plaats van dupliceren) |
+| `icm_memory_recall` | Zoeken op query, filteren op onderwerp en/of trefwoord |
+| `icm_memory_update` | Een herinnering ter plaatse bewerken (inhoud, belang, trefwoorden) |
+| `icm_memory_forget` | Een herinnering verwijderen op ID |
+| `icm_memory_consolidate` | Alle herinneringen van een onderwerp samenvoegen tot één samenvatting |
+| `icm_memory_list_topics` | Alle onderwerpen met aantallen weergeven |
+| `icm_memory_stats` | Globale geheugenstatistieken |
+| `icm_memory_health` | Hygiëne-audit per onderwerp (veroudering, consolidatiebehoeften) |
+| `icm_memory_embed_all` | Embeddings aanvullen voor vectorzoekopdrachten |
+
+### Memoir-tools (kennisgrafen)
+
+| Tool | Beschrijving |
+|------|--------------|
+| `icm_memoir_create` | Een nieuw memoir aanmaken (kenniscontainer) |
+| `icm_memoir_list` | Alle memoirs weergeven |
+| `icm_memoir_show` | Memoir-details en alle concepten weergeven |
+| `icm_memoir_add_concept` | Een concept toevoegen met labels |
+| `icm_memoir_refine` | De definitie van een concept bijwerken |
+| `icm_memoir_search` | Volledige tekst zoeken, optioneel gefilterd op label |
+| `icm_memoir_search_all` | Zoeken in alle memoirs |
+| `icm_memoir_link` | Getypeerde relatie aanmaken tussen concepten |
+| `icm_memoir_inspect` | Concept en grafiekbuurt inspecteren (BFS) |
+| `icm_memoir_export` | Graaf exporteren (json, dot, ascii, ai) met betrouwbaarheidsniveaus |
+
+### Feedback-tools (leren van fouten)
+
+| Tool | Beschrijving |
+|------|--------------|
+| `icm_feedback_record` | Een correctie vastleggen wanneer een AI-voorspelling fout was |
+| `icm_feedback_search` | Eerdere correcties zoeken om toekomstige voorspellingen te informeren |
+| `icm_feedback_stats` | Feedbackstatistieken: totaal aantal, uitsplitsing per onderwerp, meest toegepast |
+
+### Relatietypen
+
+`part_of` · `depends_on` · `related_to` · `contradicts` · `refines` · `alternative_to` · `caused_by` · `instance_of` · `superseded_by`
+
+## Hoe het werkt
+
+### Dubbel geheugenmodel
+
+**Episodisch geheugen (Onderwerpen)** legt beslissingen, fouten en voorkeuren vast. Elke herinnering heeft een gewicht dat na verloop van tijd vervalt op basis van belang:
+
+| Belang | Verval | Verwijdering | Gedrag |
+|--------|--------|--------------|--------|
+| `critical` | geen | nooit | Nooit vergeten, nooit verwijderd |
+| `high` | langzaam (0,5x snelheid) | nooit | Vervagt langzaam, nooit automatisch verwijderd |
+| `medium` | normaal | ja | Standaard verval, verwijderd wanneer gewicht < drempelwaarde |
+| `low` | snel (2x snelheid) | ja | Snel vergeten |
+
+Verval is **toegangsbewust**: vaak opgehaalde herinneringen vervallen langzamer (`decay / (1 + access_count × 0.1)`). Automatisch toegepast bij ophalen (als >24u verstreken sinds laatste verval).
+
+**Geheugen­hygiëne** is ingebouwd:
+- **Automatische deduplicatie**: inhoud opslaan die >85% vergelijkbaar is met een bestaande herinnering in hetzelfde onderwerp werkt deze bij in plaats van een duplicaat aan te maken
+- **Consolidatiehints**: wanneer een onderwerp meer dan 7 vermeldingen heeft, waarschuwt `icm_memory_store` de aanroeper om te consolideren
+- **Hygiëne-audit**: `icm_memory_health` rapporteert per onderwerp het aantal vermeldingen, het gemiddelde gewicht, verouderde vermeldingen en consolidatiebehoeften
+- **Geen stille gegevensverlies**: kritieke herinneringen en herinneringen met hoog belang worden nooit automatisch verwijderd
+
+**Semantisch geheugen (Memoirs)** legt gestructureerde kennis vast als een graaf. Concepten zijn permanent — ze worden verfijnd, nooit afgebroken. Gebruik `superseded_by` om verouderde feiten te markeren in plaats van ze te verwijderen.
+
+### Hybride zoeken
+
+Met embeddings ingeschakeld gebruikt ICM hybride zoeken:
+- **FTS5 BM25** (30%) — volledige tekst trefwoordmatch
+- **Cosinus-gelijkenis** (70%) — semantisch vectorzoeken via sqlite-vec
+
+Standaardmodel: `intfloat/multilingual-e5-base` (768d, 100+ talen). Configureerbaar in uw [configuratiebestand](#configuratie):
+
+```toml
+[embeddings]
+# enabled = false                          # Volledig uitschakelen (geen model downloaden)
+model = "intfloat/multilingual-e5-base"    # 768d, meertalig (standaard)
+# model = "intfloat/multilingual-e5-small" # 384d, meertalig (lichter)
+# model = "intfloat/multilingual-e5-large" # 1024d, meertalig (beste nauwkeurigheid)
+# model = "Xenova/bge-small-en-v1.5"      # 384d, alleen Engels (snelste)
+# model = "jinaai/jina-embeddings-v2-base-code"  # 768d, geoptimaliseerd voor code
+```
+
+Om het downloaden van het embedding-model volledig over te slaan, gebruik een van deze:
+```bash
+icm --no-embeddings serve          # CLI-vlag
+ICM_NO_EMBEDDINGS=1 icm serve     # Omgevingsvariabele
+```
+Of stel `enabled = false` in in uw configuratiebestand. ICM valt terug op FTS5-trefwoordzoeken (werkt nog steeds, maar zonder semantische matching).
+
+Het wijzigen van het model maakt de vectorindex automatisch opnieuw aan (bestaande embeddings worden gewist en kunnen opnieuw worden gegenereerd met `icm_memory_embed_all`).
+
+### Opslag
+
+Één SQLite-bestand. Geen externe diensten, geen netwerkafhankelijkheid.
+
+```
+~/Library/Application Support/dev.icm.icm/memories.db                    # macOS
+~/.local/share/dev.icm.icm/memories.db                                   # Linux
+C:\Users\<user>\AppData\Local\icm\icm\data\memories.db                   # Windows
+```
+
+### Configuratie
+
+```bash
+icm config                    # Actieve configuratie weergeven
+```
+
+Locatie van het configuratiebestand (platformspecifiek, of `$ICM_CONFIG`):
+
+```
+~/Library/Application Support/dev.icm.icm/config.toml                    # macOS
+~/.config/icm/config.toml                                                # Linux
+C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml              # Windows
+```
+
+Zie [config/default.toml](config/default.toml) voor alle opties.
+
+## Automatische extractie
+
+ICM extraheert herinneringen automatisch via drie lagen:
+
+```
+  Laag 0: Patroonhooks             Laag 1: PreCompact            Laag 2: UserPromptSubmit
+  (geen LLM-kosten)                (geen LLM-kosten)             (geen LLM-kosten)
+  ┌──────────────────┐                ┌──────────────────┐          ┌──────────────────┐
+  │ PostToolUse-hook  │                │ PreCompact-hook   │          │ UserPromptSubmit  │
+  │                   │                │                   │          │                   │
+  │ • Bash-fouten     │                │ Context staat op  │          │ Gebruiker stuurt  │
+  │ • git-commits     │                │ punt gecomprimeerd│          │ prompt → icm      │
+  │ • config-wijzig.  │                │ te worden →       │          │ recall → context  │
+  │ • beslissingen    │                │ herinneringen     │          │ injecteren        │
+  │ • voorkeuren      │                │ extraheren uit    │          │                   │
+  │ • lessen          │                │ transcript vóór   │          │ Agent begint met  │
+  │ • beperkingen     │                │ ze voor altijd    │          │ relevante         │
+  │                   │                │ verloren gaan     │          │ herinneringen     │
+  │ Regelgebaseerd,   │                │                   │          │ al geladen        │
+  │ geen LLM          │                │ Zelfde patronen + │          │                   │
+  └──────────────────┘                │ --store-raw fallbk│          └──────────────────┘
+                                      └──────────────────┘
+```
+
+| Laag | Status | LLM-kosten | Hook-opdracht | Beschrijving |
+|------|--------|------------|---------------|--------------|
+| Laag 0 | Geïmplementeerd | 0 | `icm hook post` | Regelgebaseerde trefwoordextractie uit tool-uitvoer |
+| Laag 1 | Geïmplementeerd | 0 | `icm hook compact` | Extraheren uit transcript vóór contextcompressie |
+| Laag 2 | Geïmplementeerd | 0 | `icm hook prompt` | Opgehaalde herinneringen injecteren bij elke gebruikersprompt |
+
+Alle 3 lagen worden automatisch geïnstalleerd door `icm init --mode hook`.
+
+### Vergelijking met alternatieven
+
+| Systeem | Methode | LLM-kosten | Latentie | Legt compactie vast? |
+|---------|---------|------------|----------|----------------------|
+| **ICM** | 3-laags extractie | 0 tot ~500 tok/sessie | 0ms | **Ja (PreCompact)** |
+| Mem0 | 2 LLM-aanroepen/bericht | ~2k tok/bericht | 200-2000ms | Nee |
+| claude-mem | PostToolUse + async | ~1-5k tok/sessie | 8ms hook | Nee |
+| MemGPT/Letta | Agent beheert zichzelf | 0 marginaal | 0ms | Nee |
+| DiffMem | Git-gebaseerde diffs | 0 | 0ms | Nee |
+
+## Benchmarks
+
+### Opslagprestaties
+
+```
+ICM Benchmark (1000 memories, 384d embeddings)
+──────────────────────────────────────────────────────────
+Store (no embeddings)      1000 ops      34.2 ms      34.2 µs/op
+Store (with embeddings)    1000 ops      51.6 ms      51.6 µs/op
+FTS5 search                 100 ops       4.7 ms      46.6 µs/op
+Vector search (KNN)         100 ops      59.0 ms     590.0 µs/op
+Hybrid search               100 ops      95.1 ms     951.1 µs/op
+Decay (batch)                 1 ops       5.8 ms       5.8 ms/op
+──────────────────────────────────────────────────────────
+```
+
+Apple M1 Pro, in-memory SQLite, enkeldraads. `icm bench --count 1000`
+
+### Agent-efficiëntie
+
+Meersessie-workflow met een echt Rust-project (12 bestanden, ~550 regels). Sessie 2 en later tonen de grootste winsten naarmate ICM ophaalt in plaats van bestanden opnieuw te lezen.
+
+```
+ICM Agent Benchmark (10 sessions, model: haiku, 3 runs averaged)
+══════════════════════════════════════════════════════════════════
+                            Without ICM         With ICM      Delta
+Session 2 (recall)
+  Turns                             5.7              4.0       -29%
+  Context (input)                 99.9k            67.5k       -32%
+  Cost                          $0.0298          $0.0249       -17%
+
+Session 3 (recall)
+  Turns                             3.3              2.0       -40%
+  Context (input)                 74.7k            41.6k       -44%
+  Cost                          $0.0249          $0.0194       -22%
+══════════════════════════════════════════════════════════════════
+```
+
+`icm bench-agent --sessions 10 --model haiku`
+
+### Kennisbehoud
+
+Agent haalt specifieke feiten op uit een technisch document in meerdere sessies. Sessie 1 leest en onthoudt; sessies 2 en later beantwoorden 10 feitelijke vragen **zonder** de brontekst.
+
+```
+ICM Recall Benchmark (10 questions, model: haiku, 5 runs averaged)
+══════════════════════════════════════════════════════════════════════
+                                               No ICM     With ICM
+──────────────────────────────────────────────────────────────────────
+Average score                                      5%          68%
+Questions passed                                 0/10         5/10
+══════════════════════════════════════════════════════════════════════
+```
+
+`icm bench-recall --model haiku`
+
+### Lokale LLM's (ollama)
+
+Dezelfde test met lokale modellen — pure contextinjectie, geen tool-gebruik vereist.
+
+```
+Model               Params   No ICM   With ICM     Delta
+─────────────────────────────────────────────────────────
+qwen2.5:14b           14B       4%       97%       +93%
+mistral:7b             7B       4%       93%       +89%
+llama3.1:8b            8B       4%       93%       +89%
+qwen2.5:7b             7B       4%       90%       +86%
+phi4:14b              14B       6%       79%       +73%
+llama3.2:3b            3B       0%       76%       +76%
+gemma2:9b              9B       4%       76%       +72%
+qwen2.5:3b             3B       2%       58%       +56%
+─────────────────────────────────────────────────────────
+```
+
+`scripts/bench-ollama.sh qwen2.5:14b`
+
+### Testprotocol
+
+Alle benchmarks gebruiken **echte API-aanroepen** — geen mocks, geen gesimuleerde antwoorden, geen gecachede antwoorden.
+
+- **Agent-benchmark**: Maakt een echt Rust-project aan in een tijdelijke map. Voert N sessies uit met `claude -p --output-format json`. Zonder ICM: lege MCP-configuratie. Met ICM: echte MCP-server + automatische extractie + contextinjectie.
+- **Kennisbehoud**: Gebruikt een fictief technisch document (het "Meridian Protocol"). Beoordeelt antwoorden op trefwoordmatch met verwachte feiten. Time-out van 120s per aanroep.
+- **Isolatie**: Elke run gebruikt zijn eigen tijdelijke map en verse SQLite-database. Geen sessiepersistentie.
+
+## Documentatie
+
+| Document | Beschrijving |
+|----------|--------------|
+| [Technische architectuur](docs/architecture.md) | Crate-structuur, zoekpijplijn, vervalmodel, sqlite-vec-integratie, testen |
+| [Gebruikersgids](docs/guide.md) | Installatie, onderwerporganisatie, consolidatie, extractie, probleemoplossing |
+| [Productoverzicht](docs/product.md) | Gebruiksscenario's, benchmarks, vergelijking met alternatieven |
+
+## Licentie
+
+[Source-Available](LICENSE) — Gratis voor particulieren en teams van maximaal 20 personen. Ondernemingslicentie vereist voor grotere organisaties. Contact: license@rtk.ai

--- a/README_pl.md
+++ b/README_pl.md
@@ -1,0 +1,454 @@
+[English](README.md) | [Français](README_fr.md) | [Español](README_es.md) | [Deutsch](README_de.md) | [Italiano](README_it.md) | [Português](README_pt.md) | [Nederlands](README_nl.md) | **Polski** | [Русский](README_ru.md) | [日本語](README_ja.md) | [中文](README_zh.md) | [العربية](README_ar.md) | [한국어](README_ko.md)
+
+<p align="center">
+  <img src="assets/banner.png" alt="ICM — Infinite Context Memory" width="600">
+</p>
+
+<h1 align="center">ICM</h1>
+
+<p align="center">
+  Trwała pamięć dla agentów AI. Pojedynczy plik binarny, zero zależności, natywna obsługa MCP.
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/icm/actions/workflows/ci.yml"><img src="https://github.com/rtk-ai/icm/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/icm/releases/latest"><img src="https://img.shields.io/github/v/release/rtk-ai/icm?color=purple" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Source--Available-orange.svg" alt="Source-Available"></a>
+</p>
+
+---
+
+ICM daje Twojemu agentowi AI prawdziwą pamięć — nie narzędzie do notatek, nie menedżer kontekstu, lecz **pamięć**.
+
+```
+                       ICM (Infinite Context Memory)
+            ┌──────────────────────┬─────────────────────────┐
+            │   MEMORIES (Topics)  │   MEMOIRS (Knowledge)   │
+            │                      │                         │
+            │  Epizodyczna, czaso. │  Trwała, ustrukturyz.   │
+            │                      │                         │
+            │  ┌───┐ ┌───┐ ┌───┐  │    ┌───┐               │
+            │  │ m │ │ m │ │ m │  │    │ C │──depends_on──┐ │
+            │  └─┬─┘ └─┬─┘ └─┬─┘  │    └───┘              │ │
+            │    │decay │     │    │      │ refines      ┌─▼─┐│
+            │    ▼      ▼     ▼    │    ┌─▼─┐            │ C ││
+            │  waga maleje         │    │ C │──part_of──>└───┘│
+            │  z czasem, chyba że  │    └───┘                 │
+            │  jest dostępna/kryt. │  Koncepcje + Relacje     │
+            ├──────────────────────┴─────────────────────────┤
+            │             SQLite + FTS5 + sqlite-vec          │
+            │        Wyszukiwanie hybrydowe: BM25 (30%) + cosine (70%) │
+            └─────────────────────────────────────────────────┘
+```
+
+**Dwa modele pamięci:**
+
+- **Memories** — przechowywanie/odwoływanie z temporalnym zanikaniem według ważności. Krytyczne wspomnienia nigdy nie zanikają, te o niskim priorytecie zanikają naturalnie. Filtrowanie według tematu lub słowa kluczowego.
+- **Memoirs** — trwałe grafy wiedzy. Koncepcje powiązane typowanymi relacjami (`depends_on`, `contradicts`, `superseded_by`, ...). Filtrowanie według etykiety.
+- **Feedback** — rejestrowanie korekt, gdy przewidywania AI są błędne. Przeszukiwanie przeszłych błędów przed dokonywaniem nowych przewidywań. Nauka w zamkniętej pętli.
+
+## Instalacja
+
+```bash
+# Homebrew (macOS / Linux)
+brew tap rtk-ai/tap && brew install icm
+
+# Szybka instalacja
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+
+# Ze źródeł
+cargo install --path crates/icm-cli
+```
+
+## Konfiguracja
+
+```bash
+# Automatyczne wykrywanie i konfiguracja wszystkich obsługiwanych narzędzi
+icm init
+```
+
+Konfiguruje **14 narzędzi** jednym poleceniem:
+
+| Narzędzie | Plik konfiguracyjny | Format |
+|-----------|---------------------|--------|
+| Claude Code | `~/.claude.json` | JSON |
+| Claude Desktop | `~/Library/.../claude_desktop_config.json` | JSON |
+| Cursor | `~/.cursor/mcp.json` | JSON |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON |
+| VS Code / Copilot | `~/Library/.../Code/User/mcp.json` | JSON |
+| Gemini Code Assist | `~/.gemini/settings.json` | JSON |
+| Zed | `~/.zed/settings.json` | JSON |
+| Amp | `~/.config/amp/settings.json` | JSON |
+| Amazon Q | `~/.aws/amazonq/mcp.json` | JSON |
+| Cline | VS Code globalStorage | JSON |
+| Roo Code | VS Code globalStorage | JSON |
+| Kilo Code | VS Code globalStorage | JSON |
+| OpenAI Codex CLI | `~/.codex/config.toml` | TOML |
+| OpenCode | `~/.config/opencode/opencode.json` | JSON |
+
+Lub ręcznie:
+
+```bash
+# Claude Code
+claude mcp add icm -- icm serve
+
+# Tryb kompaktowy (krótsze odpowiedzi, oszczędność tokenów)
+claude mcp add icm -- icm serve --compact
+
+# Dowolny klient MCP: command = "icm", args = ["serve"]
+```
+
+### Umiejętności / reguły
+
+```bash
+icm init --mode skill
+```
+
+Instaluje polecenia slash i reguły dla Claude Code (`/recall`, `/remember`), Cursor (reguła `.mdc`), Roo Code (reguła `.md`) oraz Amp (`/icm-recall`, `/icm-remember`).
+
+### Hooki (Claude Code)
+
+```bash
+icm init --mode hook
+```
+
+Instaluje wszystkie 3 warstwy ekstrakcji jako hooki Claude Code:
+
+**Hooki Claude Code:**
+
+| Hook | Zdarzenie | Co robi |
+|------|-----------|---------|
+| `icm hook pre` | PreToolUse | Automatyczne zezwalanie na polecenia CLI `icm` (bez monitu o uprawnienia) |
+| `icm hook post` | PostToolUse | Ekstrakcja faktów z wyjścia narzędzia co 15 wywołań |
+| `icm hook compact` | PreCompact | Ekstrakcja wspomnień z transkryptu przed kompresją kontekstu |
+| `icm hook prompt` | UserPromptSubmit | Wstrzykiwanie przypomnianego kontekstu na początku każdego monitu |
+
+**Wtyczka OpenCode** (automatycznie instalowana do `~/.config/opencode/plugins/icm.js`):
+
+| Zdarzenie OpenCode | Warstwa ICM | Co robi |
+|--------------------|-------------|---------|
+| `tool.execute.after` | Warstwa 0 | Ekstrakcja faktów z wyjścia narzędzia |
+| `experimental.session.compacting` | Warstwa 1 | Ekstrakcja z rozmowy przed kompakcją |
+| `session.created` | Warstwa 2 | Przywoływanie kontekstu na początku sesji |
+
+## CLI vs MCP
+
+ICM może być używany przez CLI (polecenia `icm`) lub serwer MCP (`icm serve`). Oba sposoby korzystają z tej samej bazy danych.
+
+| | CLI | MCP |
+|---|-----|-----|
+| **Opóźnienie** | ~30ms (bezpośredni plik binarny) | ~50ms (JSON-RPC stdio) |
+| **Koszt tokenów** | 0 (oparte na hookach, niewidoczne) | ~20-50 tokenów/wywołanie (schemat narzędzia) |
+| **Konfiguracja** | `icm init --mode hook` | `icm init --mode mcp` |
+| **Współpracuje z** | Claude Code, OpenCode (przez hooki/wtyczki) | Wszystkie 14 narzędzi kompatybilnych z MCP |
+| **Automatyczna ekstrakcja** | Tak (hooki wywołują `icm extract`) | Tak (narzędzia MCP wywołują store) |
+| **Najlepsze dla** | Zaawansowanych użytkowników, oszczędności tokenów | Uniwersalna kompatybilność |
+
+## CLI
+
+### Memories (epizodyczne, z zanikaniem)
+
+```bash
+# Przechowywanie
+icm store -t "mój-projekt" -c "Użyj PostgreSQL jako głównej bazy danych" -i high -k "db,postgres"
+
+# Przywoływanie
+icm recall "wybór bazy danych"
+icm recall "konfiguracja uwierzytelniania" --topic "mój-projekt" --limit 10
+icm recall "architektura" --keyword "postgres"
+
+# Zarządzanie
+icm forget <memory-id>
+icm consolidate --topic "mój-projekt"
+icm topics
+icm stats
+
+# Ekstrakcja faktów z tekstu (regułowa, zero kosztów LLM)
+echo "Parser używa algorytmu Pratt" | icm extract -p mój-projekt
+```
+
+### Memoirs (trwałe grafy wiedzy)
+
+```bash
+# Tworzenie wspomnienia
+icm memoir create -n "architektura-systemu" -d "Decyzje dotyczące projektu systemu"
+
+# Dodawanie koncepcji z etykietami
+icm memoir add-concept -m "architektura-systemu" -n "usługa-uwierzytelniania" \
+  -d "Obsługuje tokeny JWT i przepływy OAuth2" -l "domain:auth,type:service"
+
+# Łączenie koncepcji
+icm memoir link -m "architektura-systemu" --from "brama-api" --to "usługa-uwierzytelniania" -r depends-on
+
+# Wyszukiwanie z filtrem etykiet
+icm memoir search -m "architektura-systemu" "uwierzytelnianie"
+icm memoir search -m "architektura-systemu" "usługa" --label "domain:auth"
+
+# Inspekcja sąsiedztwa
+icm memoir inspect -m "architektura-systemu" "usługa-uwierzytelniania" -D 2
+
+# Eksport grafu (formaty: json, dot, ascii, ai)
+icm memoir export -m "architektura-systemu" -f ascii   # Ramki z paskami pewności
+icm memoir export -m "architektura-systemu" -f dot      # Graphviz DOT (kolor = poziom pewności)
+icm memoir export -m "architektura-systemu" -f ai       # Markdown zoptymalizowany dla kontekstu LLM
+icm memoir export -m "architektura-systemu" -f json     # Strukturalny JSON ze wszystkimi metadanymi
+
+# Generowanie wizualizacji SVG
+icm memoir export -m "architektura-systemu" -f dot | dot -Tsvg > graph.svg
+```
+
+## Narzędzia MCP (22)
+
+### Narzędzia pamięci
+
+| Narzędzie | Opis |
+|-----------|------|
+| `icm_memory_store` | Przechowywanie z automatyczną deduplikacją (podobieństwo >85% → aktualizacja zamiast duplikatu) |
+| `icm_memory_recall` | Wyszukiwanie według zapytania, filtrowanie według tematu i/lub słowa kluczowego |
+| `icm_memory_update` | Edycja wspomnienia w miejscu (treść, ważność, słowa kluczowe) |
+| `icm_memory_forget` | Usuwanie wspomnienia według ID |
+| `icm_memory_consolidate` | Scalanie wszystkich wspomnień tematu w jedno podsumowanie |
+| `icm_memory_list_topics` | Lista wszystkich tematów z liczbą wpisów |
+| `icm_memory_stats` | Globalne statystyki pamięci |
+| `icm_memory_health` | Audyt higieny według tematu (nieaktualność, potrzeba konsolidacji) |
+| `icm_memory_embed_all` | Uzupełnianie osadzeń dla wyszukiwania wektorowego |
+
+### Narzędzia Memoir (grafy wiedzy)
+
+| Narzędzie | Opis |
+|-----------|------|
+| `icm_memoir_create` | Tworzenie nowego wspomnienia (kontener wiedzy) |
+| `icm_memoir_list` | Lista wszystkich wspomnień |
+| `icm_memoir_show` | Wyświetlanie szczegółów wspomnienia i wszystkich koncepcji |
+| `icm_memoir_add_concept` | Dodawanie koncepcji z etykietami |
+| `icm_memoir_refine` | Aktualizacja definicji koncepcji |
+| `icm_memoir_search` | Wyszukiwanie pełnotekstowe, opcjonalnie filtrowane według etykiety |
+| `icm_memoir_search_all` | Wyszukiwanie we wszystkich wspomnieniach |
+| `icm_memoir_link` | Tworzenie typowanej relacji między koncepcjami |
+| `icm_memoir_inspect` | Inspekcja koncepcji i sąsiedztwa grafu (BFS) |
+| `icm_memoir_export` | Eksport grafu (json, dot, ascii, ai) z poziomami pewności |
+
+### Narzędzia Feedback (nauka na błędach)
+
+| Narzędzie | Opis |
+|-----------|------|
+| `icm_feedback_record` | Rejestrowanie korekty, gdy przewidywanie AI było błędne |
+| `icm_feedback_search` | Wyszukiwanie przeszłych korekt w celu informowania przyszłych przewidywań |
+| `icm_feedback_stats` | Statystyki informacji zwrotnych: łączna liczba, podział według tematu, najczęściej stosowane |
+
+### Typy relacji
+
+`part_of` · `depends_on` · `related_to` · `contradicts` · `refines` · `alternative_to` · `caused_by` · `instance_of` · `superseded_by`
+
+## Jak to działa
+
+### Dualny model pamięci
+
+**Pamięć epizodyczna (Topics)** rejestruje decyzje, błędy, preferencje. Każde wspomnienie ma wagę, która zanika z czasem w zależności od ważności:
+
+| Ważność | Zanikanie | Przycinanie | Zachowanie |
+|---------|-----------|-------------|------------|
+| `critical` | brak | nigdy | Nigdy nie zapomniane, nigdy nie przycinane |
+| `high` | powolne (0,5x szybkości) | nigdy | Zanika powoli, nigdy nie usuwane automatycznie |
+| `medium` | normalne | tak | Standardowe zanikanie, przycinane gdy waga < próg |
+| `low` | szybkie (2x szybkości) | tak | Szybko zapomniane |
+
+Zanikanie jest **świadome dostępu**: często przywoływane wspomnienia zanikają wolniej (`decay / (1 + access_count × 0.1)`). Stosowane automatycznie przy przywoływaniu (jeśli >24h od ostatniego zanikania).
+
+**Higiena pamięci** jest wbudowana:
+- **Automatyczna deduplikacja**: przechowywanie treści o podobieństwie >85% do istniejącego wspomnienia w tym samym temacie aktualizuje je zamiast tworzyć duplikat
+- **Wskazówki konsolidacji**: gdy temat przekracza 7 wpisów, `icm_memory_store` ostrzega rozmówcę o potrzebie konsolidacji
+- **Audyt zdrowia**: `icm_memory_health` raportuje liczbę wpisów na temat, średnią wagę, nieaktualne wpisy i potrzeby konsolidacji
+- **Bez cichej utraty danych**: wspomnienia krytyczne i o wysokiej ważności nigdy nie są automatycznie przycinane
+
+**Pamięć semantyczna (Memoirs)** rejestruje ustrukturyzowaną wiedzę jako graf. Koncepcje są trwałe — są udoskonalane, nigdy nie zanikają. Użyj `superseded_by` do oznaczania przestarzałych faktów zamiast ich usuwania.
+
+### Wyszukiwanie hybrydowe
+
+Przy włączonych osadzeniach ICM używa wyszukiwania hybrydowego:
+- **FTS5 BM25** (30%) — dopasowywanie słów kluczowych pełnotekstowe
+- **Podobieństwo kosinusowe** (70%) — semantyczne wyszukiwanie wektorowe przez sqlite-vec
+
+Domyślny model: `intfloat/multilingual-e5-base` (768d, ponad 100 języków). Konfigurowalny w [pliku konfiguracyjnym](#konfiguracja):
+
+```toml
+[embeddings]
+# enabled = false                          # Wyłącz całkowicie (bez pobierania modelu)
+model = "intfloat/multilingual-e5-base"    # 768d, wielojęzyczny (domyślny)
+# model = "intfloat/multilingual-e5-small" # 384d, wielojęzyczny (lżejszy)
+# model = "intfloat/multilingual-e5-large" # 1024d, wielojęzyczny (najlepsza dokładność)
+# model = "Xenova/bge-small-en-v1.5"      # 384d, tylko angielski (najszybszy)
+# model = "jinaai/jina-embeddings-v2-base-code"  # 768d, zoptymalizowany pod kod
+```
+
+Aby całkowicie pominąć pobieranie modelu osadzenia, użyj jednego z poniższych:
+```bash
+icm --no-embeddings serve          # Flaga CLI
+ICM_NO_EMBEDDINGS=1 icm serve     # Zmienna środowiskowa
+```
+Lub ustaw `enabled = false` w pliku konfiguracyjnym. ICM przełączy się na wyszukiwanie słów kluczowych FTS5 (nadal działa, tylko bez dopasowywania semantycznego).
+
+Zmiana modelu automatycznie odtwarza indeks wektorowy (istniejące osadzenia są czyszczone i można je regenerować za pomocą `icm_memory_embed_all`).
+
+### Przechowywanie
+
+Pojedynczy plik SQLite. Brak zewnętrznych usług, brak zależności sieciowych.
+
+```
+~/Library/Application Support/dev.icm.icm/memories.db                    # macOS
+~/.local/share/dev.icm.icm/memories.db                                   # Linux
+C:\Users\<user>\AppData\Local\icm\icm\data\memories.db                   # Windows
+```
+
+### Konfiguracja
+
+```bash
+icm config                    # Wyświetl aktywną konfigurację
+```
+
+Lokalizacja pliku konfiguracyjnego (zależna od platformy lub `$ICM_CONFIG`):
+
+```
+~/Library/Application Support/dev.icm.icm/config.toml                    # macOS
+~/.config/icm/config.toml                                                # Linux
+C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml              # Windows
+```
+
+Zobacz [config/default.toml](config/default.toml) dla wszystkich opcji.
+
+## Automatyczna ekstrakcja
+
+ICM automatycznie wyodrębnia wspomnienia przez trzy warstwy:
+
+```
+  Warstwa 0: Hooki wzorców      Warstwa 1: PreCompact         Warstwa 2: UserPromptSubmit
+  (zero kosztów LLM)            (zero kosztów LLM)            (zero kosztów LLM)
+  ┌──────────────────┐          ┌──────────────────┐          ┌──────────────────┐
+  │ Hook PostToolUse  │          │ Hook PreCompact   │          │ UserPromptSubmit  │
+  │                   │          │                   │          │                   │
+  │ • Błędy Bash      │          │ Kontekst ma być   │          │ Użytkownik wysyła │
+  │ • Commity git     │          │ skompresowany →   │          │ monit → icm recall│
+  │ • Zmiany config   │          │ wyodrębniaj       │          │ → wstrzyknij kont.│
+  │ • Decyzje         │          │ wspomnienia       │          │                   │
+  │ • Preferencje     │          │ z transkryptu     │          │ Agent zaczyna z   │
+  │ • Wnioski         │          │ zanim zostaną     │          │ załadowanymi      │
+  │ • Ograniczenia    │          │ utracone na zawsze│          │ odpowiednimi      │
+  │                   │          │                   │          │ wspomnieniami     │
+  │ Regułowe, bez LLM │          │ Te same wzorce +  │          │                   │
+  └──────────────────┘          │ --store-raw fallbk│          └──────────────────┘
+                                 └──────────────────┘
+```
+
+| Warstwa | Status | Koszt LLM | Polecenie hooka | Opis |
+|---------|--------|-----------|-----------------|------|
+| Warstwa 0 | Zaimplementowana | 0 | `icm hook post` | Regułowa ekstrakcja słów kluczowych z wyjścia narzędzia |
+| Warstwa 1 | Zaimplementowana | 0 | `icm hook compact` | Ekstrakcja z transkryptu przed kompresją kontekstu |
+| Warstwa 2 | Zaimplementowana | 0 | `icm hook prompt` | Wstrzykiwanie przywoływanych wspomnień przy każdym monicie użytkownika |
+
+Wszystkie 3 warstwy są instalowane automatycznie przez `icm init --mode hook`.
+
+### Porównanie z alternatywami
+
+| System | Metoda | Koszt LLM | Opóźnienie | Rejestruje kompakcję? |
+|--------|--------|-----------|------------|----------------------|
+| **ICM** | Ekstrakcja 3-warstwowa | 0 do ~500 tok/sesję | 0ms | **Tak (PreCompact)** |
+| Mem0 | 2 wywołania LLM/wiadomość | ~2k tok/wiadomość | 200-2000ms | Nie |
+| claude-mem | PostToolUse + async | ~1-5k tok/sesję | 8ms hook | Nie |
+| MemGPT/Letta | Agent zarządza samodzielnie | 0 marginalnie | 0ms | Nie |
+| DiffMem | Diffs oparte na Git | 0 | 0ms | Nie |
+
+## Benchmarki
+
+### Wydajność przechowywania
+
+```
+ICM Benchmark (1000 wspomnień, osadzenia 384d)
+──────────────────────────────────────────────────────────
+Store (bez osadzeń)        1000 ops      34,2 ms      34,2 µs/op
+Store (z osadzeniami)      1000 ops      51,6 ms      51,6 µs/op
+Wyszukiwanie FTS5           100 ops       4,7 ms      46,6 µs/op
+Wyszukiwanie wektorowe (KNN) 100 ops     59,0 ms     590,0 µs/op
+Wyszukiwanie hybrydowe      100 ops      95,1 ms     951,1 µs/op
+Zanikanie (wsadowe)           1 ops       5,8 ms       5,8 ms/op
+──────────────────────────────────────────────────────────
+```
+
+Apple M1 Pro, SQLite w pamięci, jednowątkowy. `icm bench --count 1000`
+
+### Efektywność agenta
+
+Wielosesyjny przepływ pracy z prawdziwym projektem Rust (12 plików, ~550 linii). Sesje 2+ pokazują największe zyski, gdy ICM przywołuje zamiast ponownie czytać pliki.
+
+```
+ICM Agent Benchmark (10 sesji, model: haiku, uśrednione 3 przebiegi)
+══════════════════════════════════════════════════════════════════
+                            Bez ICM          Z ICM       Delta
+Sesja 2 (przywoływanie)
+  Tury                              5,7              4,0       -29%
+  Kontekst (wejście)              99,9k            67,5k       -32%
+  Koszt                          $0,0298          $0,0249       -17%
+
+Sesja 3 (przywoływanie)
+  Tury                              3,3              2,0       -40%
+  Kontekst (wejście)              74,7k            41,6k       -44%
+  Koszt                          $0,0249          $0,0194       -22%
+══════════════════════════════════════════════════════════════════
+```
+
+`icm bench-agent --sessions 10 --model haiku`
+
+### Retencja wiedzy
+
+Agent przywołuje konkretne fakty z gęstego dokumentu technicznego między sesjami. Sesja 1 czyta i zapamiętuje; sesje 2+ odpowiadają na 10 pytań faktycznych **bez** tekstu źródłowego.
+
+```
+ICM Recall Benchmark (10 pytań, model: haiku, uśrednione 5 przebiegów)
+══════════════════════════════════════════════════════════════════════
+                                               Bez ICM     Z ICM
+──────────────────────────────────────────────────────────────────────
+Średni wynik                                       5%         68%
+Pytania zaliczone                                0/10        5/10
+══════════════════════════════════════════════════════════════════════
+```
+
+`icm bench-recall --model haiku`
+
+### Lokalne modele LLM (ollama)
+
+Ten sam test z lokalnymi modelami — czyste wstrzykiwanie kontekstu, bez potrzeby użycia narzędzi.
+
+```
+Model               Params   Bez ICM   Z ICM     Delta
+─────────────────────────────────────────────────────────
+qwen2.5:14b           14B       4%       97%       +93%
+mistral:7b             7B       4%       93%       +89%
+llama3.1:8b            8B       4%       93%       +89%
+qwen2.5:7b             7B       4%       90%       +86%
+phi4:14b              14B       6%       79%       +73%
+llama3.2:3b            3B       0%       76%       +76%
+gemma2:9b              9B       4%       76%       +72%
+qwen2.5:3b             3B       2%       58%       +56%
+─────────────────────────────────────────────────────────
+```
+
+`scripts/bench-ollama.sh qwen2.5:14b`
+
+### Protokół testowy
+
+Wszystkie benchmarki używają **prawdziwych wywołań API** — bez atrap, bez symulowanych odpowiedzi, bez buforowanych odpowiedzi.
+
+- **Benchmark agenta**: Tworzy prawdziwy projekt Rust w katalogu tymczasowym. Uruchamia N sesji z `claude -p --output-format json`. Bez ICM: pusta konfiguracja MCP. Z ICM: prawdziwy serwer MCP + automatyczna ekstrakcja + wstrzykiwanie kontekstu.
+- **Retencja wiedzy**: Używa fikcyjnego dokumentu technicznego ("Protokół Meridian"). Ocenia odpowiedzi przez dopasowywanie słów kluczowych do oczekiwanych faktów. Limit 120s na wywołanie.
+- **Izolacja**: Każdy przebieg używa własnego katalogu tymczasowego i świeżej bazy danych SQLite. Brak trwałości sesji.
+
+## Dokumentacja
+
+| Dokument | Opis |
+|----------|------|
+| [Architektura techniczna](docs/architecture.md) | Struktura crate, potok wyszukiwania, model zanikania, integracja sqlite-vec, testowanie |
+| [Przewodnik użytkownika](docs/guide.md) | Instalacja, organizacja tematów, konsolidacja, ekstrakcja, rozwiązywanie problemów |
+| [Przegląd produktu](docs/product.md) | Przypadki użycia, benchmarki, porównanie z alternatywami |
+
+## Licencja
+
+[Source-Available](LICENSE) — Bezpłatna dla osób prywatnych i zespołów liczących ≤ 20 osób. Licencja korporacyjna wymagana dla większych organizacji. Kontakt: license@rtk.ai

--- a/README_pt.md
+++ b/README_pt.md
@@ -1,0 +1,454 @@
+[English](README.md) | [Français](README_fr.md) | [Español](README_es.md) | [Deutsch](README_de.md) | [Italiano](README_it.md) | **Português** | [Nederlands](README_nl.md) | [Polski](README_pl.md) | [Русский](README_ru.md) | [日本語](README_ja.md) | [中文](README_zh.md) | [العربية](README_ar.md) | [한국어](README_ko.md)
+
+<p align="center">
+  <img src="assets/banner.png" alt="ICM — Infinite Context Memory" width="600">
+</p>
+
+<h1 align="center">ICM</h1>
+
+<p align="center">
+  Memória permanente para agentes de IA. Binário único, zero dependências, MCP nativo.
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/icm/actions/workflows/ci.yml"><img src="https://github.com/rtk-ai/icm/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/icm/releases/latest"><img src="https://img.shields.io/github/v/release/rtk-ai/icm?color=purple" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Source--Available-orange.svg" alt="Source-Available"></a>
+</p>
+
+---
+
+O ICM dá ao seu agente de IA uma memória real — não uma ferramenta de anotações, não um gestor de contexto, uma **memória**.
+
+```
+                       ICM (Infinite Context Memory)
+            ┌──────────────────────┬─────────────────────────┐
+            │   MEMORIES (Topics)  │   MEMOIRS (Knowledge)   │
+            │                      │                         │
+            │  Episodic, temporal  │  Permanent, structured  │
+            │                      │                         │
+            │  ┌───┐ ┌───┐ ┌───┐  │    ┌───┐               │
+            │  │ m │ │ m │ │ m │  │    │ C │──depends_on──┐ │
+            │  └─┬─┘ └─┬─┘ └─┬─┘  │    └───┘              │ │
+            │    │decay │     │    │      │ refines      ┌─▼─┐│
+            │    ▼      ▼     ▼    │    ┌─▼─┐            │ C ││
+            │  weight decreases    │    │ C │──part_of──>└───┘│
+            │  over time unless    │    └───┘                 │
+            │  accessed/critical   │  Concepts + Relations    │
+            ├──────────────────────┴─────────────────────────┤
+            │             SQLite + FTS5 + sqlite-vec          │
+            │        Hybrid search: BM25 (30%) + cosine (70%) │
+            └─────────────────────────────────────────────────┘
+```
+
+**Dois modelos de memória:**
+
+- **Memórias** — armazenar/recuperar com decaimento temporal por importância. Memórias críticas nunca desaparecem, as de baixa importância decaem naturalmente. Filtrar por tópico ou palavra-chave.
+- **Memórias Permanentes** — grafos de conhecimento permanentes. Conceitos ligados por relações tipadas (`depends_on`, `contradicts`, `superseded_by`, ...). Filtrar por etiqueta.
+- **Feedback** — registar correções quando as previsões da IA estão erradas. Pesquisar erros passados antes de fazer novas previsões. Aprendizagem em ciclo fechado.
+
+## Instalação
+
+```bash
+# Homebrew (macOS / Linux)
+brew tap rtk-ai/tap && brew install icm
+
+# Instalação rápida
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+
+# A partir do código-fonte
+cargo install --path crates/icm-cli
+```
+
+## Configuração
+
+```bash
+# Detetar e configurar automaticamente todas as ferramentas suportadas
+icm init
+```
+
+Configura **14 ferramentas** com um único comando:
+
+| Ferramenta | Ficheiro de configuração | Formato |
+|-----------|--------------------------|---------|
+| Claude Code | `~/.claude.json` | JSON |
+| Claude Desktop | `~/Library/.../claude_desktop_config.json` | JSON |
+| Cursor | `~/.cursor/mcp.json` | JSON |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON |
+| VS Code / Copilot | `~/Library/.../Code/User/mcp.json` | JSON |
+| Gemini Code Assist | `~/.gemini/settings.json` | JSON |
+| Zed | `~/.zed/settings.json` | JSON |
+| Amp | `~/.config/amp/settings.json` | JSON |
+| Amazon Q | `~/.aws/amazonq/mcp.json` | JSON |
+| Cline | VS Code globalStorage | JSON |
+| Roo Code | VS Code globalStorage | JSON |
+| Kilo Code | VS Code globalStorage | JSON |
+| OpenAI Codex CLI | `~/.codex/config.toml` | TOML |
+| OpenCode | `~/.config/opencode/opencode.json` | JSON |
+
+Ou manualmente:
+
+```bash
+# Claude Code
+claude mcp add icm -- icm serve
+
+# Modo compacto (respostas mais curtas, poupa tokens)
+claude mcp add icm -- icm serve --compact
+
+# Qualquer cliente MCP: command = "icm", args = ["serve"]
+```
+
+### Skills / regras
+
+```bash
+icm init --mode skill
+```
+
+Instala comandos slash e regras para Claude Code (`/recall`, `/remember`), Cursor (regra `.mdc`), Roo Code (regra `.md`), e Amp (`/icm-recall`, `/icm-remember`).
+
+### Hooks (Claude Code)
+
+```bash
+icm init --mode hook
+```
+
+Instala todas as 3 camadas de extração como hooks do Claude Code:
+
+**Hooks do Claude Code**:
+
+| Hook | Evento | O que faz |
+|------|--------|-----------|
+| `icm hook pre` | PreToolUse | Autorizar automaticamente comandos CLI `icm` (sem pedido de permissão) |
+| `icm hook post` | PostToolUse | Extrair factos da saída de ferramentas a cada 15 chamadas |
+| `icm hook compact` | PreCompact | Extrair memórias do transcript antes da compressão de contexto |
+| `icm hook prompt` | UserPromptSubmit | Injetar contexto recuperado no início de cada prompt |
+
+**Plugin OpenCode** (instalado automaticamente em `~/.config/opencode/plugins/icm.js`):
+
+| Evento OpenCode | Camada ICM | O que faz |
+|----------------|------------|-----------|
+| `tool.execute.after` | Camada 0 | Extrair factos da saída de ferramentas |
+| `experimental.session.compacting` | Camada 1 | Extrair da conversa antes da compactação |
+| `session.created` | Camada 2 | Recuperar contexto no início da sessão |
+
+## CLI vs MCP
+
+O ICM pode ser utilizado via CLI (comandos `icm`) ou servidor MCP (`icm serve`). Ambos acedem à mesma base de dados.
+
+| | CLI | MCP |
+|---|-----|-----|
+| **Latência** | ~30ms (binário direto) | ~50ms (JSON-RPC stdio) |
+| **Custo em tokens** | 0 (baseado em hooks, invisível) | ~20-50 tokens/chamada (esquema de ferramenta) |
+| **Configuração** | `icm init --mode hook` | `icm init --mode mcp` |
+| **Funciona com** | Claude Code, OpenCode (via hooks/plugins) | Todas as 14 ferramentas compatíveis com MCP |
+| **Extração automática** | Sim (hooks acionam `icm extract`) | Sim (ferramentas MCP chamam store) |
+| **Melhor para** | Utilizadores avançados, poupança de tokens | Compatibilidade universal |
+
+## CLI
+
+### Memórias (episódicas, com decaimento)
+
+```bash
+# Armazenar
+icm store -t "meu-projeto" -c "Usar PostgreSQL para a BD principal" -i high -k "bd,postgres"
+
+# Recuperar
+icm recall "escolha de base de dados"
+icm recall "configuração auth" --topic "meu-projeto" --limit 10
+icm recall "arquitetura" --keyword "postgres"
+
+# Gerir
+icm forget <memory-id>
+icm consolidate --topic "meu-projeto"
+icm topics
+icm stats
+
+# Extrair factos de texto (baseado em regras, custo zero em LLM)
+echo "O parser usa o algoritmo Pratt" | icm extract -p meu-projeto
+```
+
+### Memórias Permanentes (grafos de conhecimento permanentes)
+
+```bash
+# Criar uma memória permanente
+icm memoir create -n "system-architecture" -d "Decisões de design do sistema"
+
+# Adicionar conceitos com etiquetas
+icm memoir add-concept -m "system-architecture" -n "auth-service" \
+  -d "Gere tokens JWT e fluxos OAuth2" -l "domain:auth,type:service"
+
+# Ligar conceitos
+icm memoir link -m "system-architecture" --from "api-gateway" --to "auth-service" -r depends-on
+
+# Pesquisar com filtro de etiqueta
+icm memoir search -m "system-architecture" "autenticação"
+icm memoir search -m "system-architecture" "service" --label "domain:auth"
+
+# Inspecionar vizinhança
+icm memoir inspect -m "system-architecture" "auth-service" -D 2
+
+# Exportar grafo (formatos: json, dot, ascii, ai)
+icm memoir export -m "system-architecture" -f ascii   # Caixas com barras de confiança
+icm memoir export -m "system-architecture" -f dot      # Graphviz DOT (cor = nível de confiança)
+icm memoir export -m "system-architecture" -f ai       # Markdown otimizado para contexto LLM
+icm memoir export -m "system-architecture" -f json     # JSON estruturado com todos os metadados
+
+# Gerar visualização SVG
+icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
+```
+
+## Ferramentas MCP (22)
+
+### Ferramentas de memória
+
+| Ferramenta | Descrição |
+|-----------|-----------|
+| `icm_memory_store` | Armazenar com deduplicação automática (>85% de similaridade → atualizar em vez de duplicar) |
+| `icm_memory_recall` | Pesquisar por consulta, filtrar por tópico e/ou palavra-chave |
+| `icm_memory_update` | Editar uma memória no local (conteúdo, importância, palavras-chave) |
+| `icm_memory_forget` | Apagar uma memória por ID |
+| `icm_memory_consolidate` | Fundir todas as memórias de um tópico num único resumo |
+| `icm_memory_list_topics` | Listar todos os tópicos com contagens |
+| `icm_memory_stats` | Estatísticas globais de memória |
+| `icm_memory_health` | Auditoria de higiene por tópico (antiguidade, necessidades de consolidação) |
+| `icm_memory_embed_all` | Preencher embeddings retroativamente para pesquisa vetorial |
+
+### Ferramentas de memórias permanentes (grafos de conhecimento)
+
+| Ferramenta | Descrição |
+|-----------|-----------|
+| `icm_memoir_create` | Criar uma nova memória permanente (contentor de conhecimento) |
+| `icm_memoir_list` | Listar todas as memórias permanentes |
+| `icm_memoir_show` | Mostrar detalhes e todos os conceitos de uma memória permanente |
+| `icm_memoir_add_concept` | Adicionar um conceito com etiquetas |
+| `icm_memoir_refine` | Atualizar a definição de um conceito |
+| `icm_memoir_search` | Pesquisa de texto completo, opcionalmente filtrada por etiqueta |
+| `icm_memoir_search_all` | Pesquisar em todas as memórias permanentes |
+| `icm_memoir_link` | Criar relação tipada entre conceitos |
+| `icm_memoir_inspect` | Inspecionar conceito e vizinhança do grafo (BFS) |
+| `icm_memoir_export` | Exportar grafo (json, dot, ascii, ai) com níveis de confiança |
+
+### Ferramentas de feedback (aprender com os erros)
+
+| Ferramenta | Descrição |
+|-----------|-----------|
+| `icm_feedback_record` | Registar uma correção quando uma previsão da IA estava errada |
+| `icm_feedback_search` | Pesquisar correções passadas para informar previsões futuras |
+| `icm_feedback_stats` | Estatísticas de feedback: contagem total, distribuição por tópico, mais aplicadas |
+
+### Tipos de relação
+
+`part_of` · `depends_on` · `related_to` · `contradicts` · `refines` · `alternative_to` · `caused_by` · `instance_of` · `superseded_by`
+
+## Como funciona
+
+### Modelo de memória dual
+
+**Memória episódica (Tópicos)** captura decisões, erros, preferências. Cada memória tem um peso que decai com o tempo com base na importância:
+
+| Importância | Decaimento | Pruning | Comportamento |
+|------------|------------|---------|---------------|
+| `critical` | nenhum | nunca | Nunca esquecida, nunca removida |
+| `high` | lento (0.5x taxa) | nunca | Desvanece lentamente, nunca auto-eliminada |
+| `medium` | normal | sim | Decaimento padrão, removida quando peso < limiar |
+| `low` | rápido (2x taxa) | sim | Esquecida rapidamente |
+
+O decaimento é **consciente do acesso**: memórias frequentemente recuperadas decaem mais lentamente (`decay / (1 + access_count × 0.1)`). Aplicado automaticamente na recuperação (se >24h desde o último decaimento).
+
+**A higiene de memória** está incorporada:
+- **Deduplicação automática**: armazenar conteúdo >85% similar a uma memória existente no mesmo tópico atualiza-a em vez de criar um duplicado
+- **Dicas de consolidação**: quando um tópico ultrapassa 7 entradas, `icm_memory_store` avisa o chamador para consolidar
+- **Auditoria de saúde**: `icm_memory_health` reporta contagem de entradas por tópico, peso médio, entradas obsoletas e necessidades de consolidação
+- **Sem perda silenciosa de dados**: memórias críticas e de alta importância nunca são removidas automaticamente
+
+**Memória semântica (Memórias Permanentes)** captura conhecimento estruturado como um grafo. Os conceitos são permanentes — são refinados, nunca decaem. Use `superseded_by` para marcar factos obsoletos em vez de os eliminar.
+
+### Pesquisa híbrida
+
+Com embeddings ativados, o ICM utiliza pesquisa híbrida:
+- **FTS5 BM25** (30%) — correspondência de palavras-chave em texto completo
+- **Similaridade cosseno** (70%) — pesquisa vetorial semântica via sqlite-vec
+
+Modelo padrão: `intfloat/multilingual-e5-base` (768d, mais de 100 idiomas). Configurável no seu [ficheiro de configuração](#configuração):
+
+```toml
+[embeddings]
+# enabled = false                          # Desativar completamente (sem download do modelo)
+model = "intfloat/multilingual-e5-base"    # 768d, multilíngue (padrão)
+# model = "intfloat/multilingual-e5-small" # 384d, multilíngue (mais leve)
+# model = "intfloat/multilingual-e5-large" # 1024d, multilíngue (melhor precisão)
+# model = "Xenova/bge-small-en-v1.5"      # 384d, apenas inglês (mais rápido)
+# model = "jinaai/jina-embeddings-v2-base-code"  # 768d, otimizado para código
+```
+
+Para ignorar completamente o download do modelo de embeddings, use um destes:
+```bash
+icm --no-embeddings serve          # Flag CLI
+ICM_NO_EMBEDDINGS=1 icm serve     # Variável de ambiente
+```
+Ou defina `enabled = false` no seu ficheiro de configuração. O ICM recorrerá à pesquisa por palavras-chave FTS5 (ainda funciona, apenas sem correspondência semântica).
+
+Alterar o modelo recria automaticamente o índice vetorial (os embeddings existentes são limpos e podem ser regenerados com `icm_memory_embed_all`).
+
+### Armazenamento
+
+Ficheiro SQLite único. Sem serviços externos, sem dependência de rede.
+
+```
+~/Library/Application Support/dev.icm.icm/memories.db                    # macOS
+~/.local/share/dev.icm.icm/memories.db                                   # Linux
+C:\Users\<user>\AppData\Local\icm\icm\data\memories.db                   # Windows
+```
+
+### Configuração
+
+```bash
+icm config                    # Mostrar configuração ativa
+```
+
+Localização do ficheiro de configuração (específico por plataforma, ou `$ICM_CONFIG`):
+
+```
+~/Library/Application Support/dev.icm.icm/config.toml                    # macOS
+~/.config/icm/config.toml                                                # Linux
+C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml              # Windows
+```
+
+Consulte [config/default.toml](config/default.toml) para todas as opções.
+
+## Extração automática
+
+O ICM extrai memórias automaticamente através de três camadas:
+
+```
+  Camada 0: Hooks de padrões     Camada 1: PreCompact          Camada 2: UserPromptSubmit
+  (custo zero em LLM)            (custo zero em LLM)           (custo zero em LLM)
+  ┌──────────────────┐                ┌──────────────────┐          ┌──────────────────┐
+  │ Hook PostToolUse  │                │ Hook PreCompact   │          │ UserPromptSubmit  │
+  │                   │                │                   │          │                   │
+  │ • Erros Bash      │                │ Contexto prestes  │          │ Utilizador envia  │
+  │ • commits git     │                │ a ser comprimido→ │          │ prompt → icm      │
+  │ • mudanças config │                │ extrair memórias  │          │ recall → injetar  │
+  │ • decisões        │                │ do transcript     │          │ contexto          │
+  │ • preferências    │                │ antes de serem    │          │                   │
+  │ • aprendizagens   │                │ perdidas para     │          │ Agente inicia com │
+  │ • restrições      │                │ sempre            │          │ memórias relevantes│
+  │                   │                │                   │          │ já carregadas     │
+  │ Baseado em regras,│                │ Mesmos padrões +  │          │                   │
+  │ sem LLM           │                │ --store-raw fallbk│          │                   │
+  └──────────────────┘                └──────────────────┘          └──────────────────┘
+```
+
+| Camada | Estado | Custo LLM | Comando hook | Descrição |
+|--------|--------|-----------|--------------|-----------|
+| Camada 0 | Implementada | 0 | `icm hook post` | Extração de palavras-chave baseada em regras da saída de ferramentas |
+| Camada 1 | Implementada | 0 | `icm hook compact` | Extrair do transcript antes da compressão de contexto |
+| Camada 2 | Implementada | 0 | `icm hook prompt` | Injetar memórias recuperadas em cada prompt do utilizador |
+
+As 3 camadas são instaladas automaticamente por `icm init --mode hook`.
+
+### Comparação com alternativas
+
+| Sistema | Método | Custo LLM | Latência | Captura compactação? |
+|---------|--------|-----------|----------|---------------------|
+| **ICM** | Extração em 3 camadas | 0 a ~500 tok/sessão | 0ms | **Sim (PreCompact)** |
+| Mem0 | 2 chamadas LLM/mensagem | ~2k tok/mensagem | 200-2000ms | Não |
+| claude-mem | PostToolUse + async | ~1-5k tok/sessão | 8ms hook | Não |
+| MemGPT/Letta | Agente auto-gere | 0 marginal | 0ms | Não |
+| DiffMem | Diffs baseados em Git | 0 | 0ms | Não |
+
+## Benchmarks
+
+### Desempenho de armazenamento
+
+```
+ICM Benchmark (1000 memories, 384d embeddings)
+──────────────────────────────────────────────────────────
+Store (no embeddings)      1000 ops      34.2 ms      34.2 µs/op
+Store (with embeddings)    1000 ops      51.6 ms      51.6 µs/op
+FTS5 search                 100 ops       4.7 ms      46.6 µs/op
+Vector search (KNN)         100 ops      59.0 ms     590.0 µs/op
+Hybrid search               100 ops      95.1 ms     951.1 µs/op
+Decay (batch)                 1 ops       5.8 ms       5.8 ms/op
+──────────────────────────────────────────────────────────
+```
+
+Apple M1 Pro, SQLite em memória, single-threaded. `icm bench --count 1000`
+
+### Eficiência do agente
+
+Fluxo de trabalho multi-sessão com um projeto Rust real (12 ficheiros, ~550 linhas). As sessões 2+ mostram os maiores ganhos à medida que o ICM recupera em vez de reler ficheiros.
+
+```
+ICM Agent Benchmark (10 sessions, model: haiku, 3 runs averaged)
+══════════════════════════════════════════════════════════════════
+                            Without ICM         With ICM      Delta
+Session 2 (recall)
+  Turns                             5.7              4.0       -29%
+  Context (input)                 99.9k            67.5k       -32%
+  Cost                          $0.0298          $0.0249       -17%
+
+Session 3 (recall)
+  Turns                             3.3              2.0       -40%
+  Context (input)                 74.7k            41.6k       -44%
+  Cost                          $0.0249          $0.0194       -22%
+══════════════════════════════════════════════════════════════════
+```
+
+`icm bench-agent --sessions 10 --model haiku`
+
+### Retenção de conhecimento
+
+O agente recupera factos específicos de um documento técnico denso ao longo de sessões. A sessão 1 lê e memoriza; as sessões 2+ respondem a 10 perguntas factuais **sem** o texto de origem.
+
+```
+ICM Recall Benchmark (10 questions, model: haiku, 5 runs averaged)
+══════════════════════════════════════════════════════════════════════
+                                               No ICM     With ICM
+──────────────────────────────────────────────────────────────────────
+Average score                                      5%          68%
+Questions passed                                 0/10         5/10
+══════════════════════════════════════════════════════════════════════
+```
+
+`icm bench-recall --model haiku`
+
+### LLMs locais (ollama)
+
+Mesmo teste com modelos locais — injeção de contexto puro, sem necessidade de uso de ferramentas.
+
+```
+Model               Params   No ICM   With ICM     Delta
+─────────────────────────────────────────────────────────
+qwen2.5:14b           14B       4%       97%       +93%
+mistral:7b             7B       4%       93%       +89%
+llama3.1:8b            8B       4%       93%       +89%
+qwen2.5:7b             7B       4%       90%       +86%
+phi4:14b              14B       6%       79%       +73%
+llama3.2:3b            3B       0%       76%       +76%
+gemma2:9b              9B       4%       76%       +72%
+qwen2.5:3b             3B       2%       58%       +56%
+─────────────────────────────────────────────────────────
+```
+
+`scripts/bench-ollama.sh qwen2.5:14b`
+
+### Protocolo de teste
+
+Todos os benchmarks utilizam **chamadas API reais** — sem mocks, sem respostas simuladas, sem respostas em cache.
+
+- **Benchmark de agente**: Cria um projeto Rust real num diretório temporário. Executa N sessões com `claude -p --output-format json`. Sem ICM: configuração MCP vazia. Com ICM: servidor MCP real + extração automática + injeção de contexto.
+- **Retenção de conhecimento**: Utiliza um documento técnico fictício (o "Protocolo Meridian"). Pontua as respostas por correspondência de palavras-chave com factos esperados. Timeout de 120s por invocação.
+- **Isolamento**: Cada execução utiliza o seu próprio diretório temporário e uma BD SQLite nova. Sem persistência de sessão.
+
+## Documentação
+
+| Documento | Descrição |
+|-----------|-----------|
+| [Arquitetura Técnica](docs/architecture.md) | Estrutura de crates, pipeline de pesquisa, modelo de decaimento, integração sqlite-vec, testes |
+| [Guia do Utilizador](docs/guide.md) | Instalação, organização de tópicos, consolidação, extração, resolução de problemas |
+| [Visão Geral do Produto](docs/product.md) | Casos de uso, benchmarks, comparação com alternativas |
+
+## Licença
+
+[Source-Available](LICENSE) — Gratuito para indivíduos e equipas ≤ 20 pessoas. Licença empresarial necessária para organizações maiores. Contacto: license@rtk.ai

--- a/README_ru.md
+++ b/README_ru.md
@@ -1,0 +1,453 @@
+[English](README.md) | [Français](README_fr.md) | [Español](README_es.md) | [Deutsch](README_de.md) | [Italiano](README_it.md) | [Português](README_pt.md) | [Nederlands](README_nl.md) | [Polski](README_pl.md) | **Русский** | [日本語](README_ja.md) | [中文](README_zh.md) | [العربية](README_ar.md) | [한국어](README_ko.md)
+
+<p align="center">
+  <img src="assets/banner.png" alt="ICM — Infinite Context Memory" width="600">
+</p>
+
+<h1 align="center">ICM</h1>
+
+<p align="center">
+  Постоянная память для ИИ-агентов. Один бинарный файл, без зависимостей, нативная поддержка MCP.
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/icm/actions/workflows/ci.yml"><img src="https://github.com/rtk-ai/icm/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/icm/releases/latest"><img src="https://img.shields.io/github/v/release/rtk-ai/icm?color=purple" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Source--Available-orange.svg" alt="Source-Available"></a>
+</p>
+
+---
+
+ICM даёт вашему ИИ-агенту настоящую память — не инструмент для заметок, не менеджер контекста, а **память**.
+
+```
+                       ICM (Infinite Context Memory)
+            ┌──────────────────────┬─────────────────────────┐
+            │   MEMORIES (Topics)  │   MEMOIRS (Knowledge)   │
+            │                      │                         │
+            │  Episodic, temporal  │  Permanent, structured  │
+            │                      │                         │
+            │  ┌───┐ ┌───┐ ┌───┐  │    ┌───┐               │
+            │  │ m │ │ m │ │ m │  │    │ C │──depends_on──┐ │
+            │  └─┬─┘ └─┬─┘ └─┬─┘  │    └───┘              │ │
+            │    │decay │     │    │      │ refines      ┌─▼─┐│
+            │    ▼      ▼     ▼    │    ┌─▼─┐            │ C ││
+            │  weight decreases    │    │ C │──part_of──>└───┘│
+            │  over time unless    │    └───┘                 │
+            │  accessed/critical   │  Concepts + Relations    │
+            ├──────────────────────┴─────────────────────────┤
+            │             SQLite + FTS5 + sqlite-vec          │
+            │        Hybrid search: BM25 (30%) + cosine (70%) │
+            └─────────────────────────────────────────────────┘
+```
+
+**Две модели памяти:**
+
+- **Memories** — хранение и извлечение с временным затуханием по важности. Критические воспоминания не исчезают никогда, маловажные затухают естественным образом. Фильтрация по теме или ключевому слову.
+- **Memoirs** — постоянные графы знаний. Концепции связаны типизированными отношениями (`depends_on`, `contradicts`, `superseded_by`, ...). Фильтрация по метке.
+- **Feedback** — запись исправлений при ошибочных предсказаниях ИИ. Поиск прошлых ошибок перед новыми предсказаниями. Обучение с замкнутым циклом.
+
+## Установка
+
+```bash
+# Homebrew (macOS / Linux)
+brew tap rtk-ai/tap && brew install icm
+
+# Быстрая установка
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+
+# Из исходного кода
+cargo install --path crates/icm-cli
+```
+
+## Настройка
+
+```bash
+# Автоматическое обнаружение и настройка всех поддерживаемых инструментов
+icm init
+```
+
+Настраивает **14 инструментов** одной командой:
+
+| Инструмент | Файл конфигурации | Формат |
+|------------|-------------------|--------|
+| Claude Code | `~/.claude.json` | JSON |
+| Claude Desktop | `~/Library/.../claude_desktop_config.json` | JSON |
+| Cursor | `~/.cursor/mcp.json` | JSON |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON |
+| VS Code / Copilot | `~/Library/.../Code/User/mcp.json` | JSON |
+| Gemini Code Assist | `~/.gemini/settings.json` | JSON |
+| Zed | `~/.zed/settings.json` | JSON |
+| Amp | `~/.config/amp/settings.json` | JSON |
+| Amazon Q | `~/.aws/amazonq/mcp.json` | JSON |
+| Cline | VS Code globalStorage | JSON |
+| Roo Code | VS Code globalStorage | JSON |
+| Kilo Code | VS Code globalStorage | JSON |
+| OpenAI Codex CLI | `~/.codex/config.toml` | TOML |
+| OpenCode | `~/.config/opencode/opencode.json` | JSON |
+
+Или вручную:
+
+```bash
+# Claude Code
+claude mcp add icm -- icm serve
+
+# Компактный режим (более короткие ответы, экономия токенов)
+claude mcp add icm -- icm serve --compact
+
+# Любой MCP-клиент: command = "icm", args = ["serve"]
+```
+
+### Навыки / правила
+
+```bash
+icm init --mode skill
+```
+
+Устанавливает слэш-команды и правила для Claude Code (`/recall`, `/remember`), Cursor (правило `.mdc`), Roo Code (правило `.md`) и Amp (`/icm-recall`, `/icm-remember`).
+
+### Хуки (Claude Code)
+
+```bash
+icm init --mode hook
+```
+
+Устанавливает все 3 слоя извлечения в виде хуков Claude Code:
+
+**Хуки Claude Code:**
+
+| Хук | Событие | Действие |
+|-----|---------|----------|
+| `icm hook pre` | PreToolUse | Автоматическое разрешение команд `icm` CLI (без запроса подтверждения) |
+| `icm hook post` | PostToolUse | Извлечение фактов из вывода инструмента каждые 15 вызовов |
+| `icm hook compact` | PreCompact | Извлечение воспоминаний из транскрипта перед сжатием контекста |
+| `icm hook prompt` | UserPromptSubmit | Внедрение извлечённого контекста в начало каждого запроса |
+
+**Плагин OpenCode** (автоматически устанавливается в `~/.config/opencode/plugins/icm.js`):
+
+| Событие OpenCode | Слой ICM | Действие |
+|-----------------|----------|----------|
+| `tool.execute.after` | Layer 0 | Извлечение фактов из вывода инструмента |
+| `experimental.session.compacting` | Layer 1 | Извлечение из разговора перед сжатием |
+| `session.created` | Layer 2 | Загрузка контекста при старте сессии |
+
+## CLI vs MCP
+
+ICM можно использовать через CLI (команды `icm`) или MCP-сервер (`icm serve`). Оба варианта работают с одной и той же базой данных.
+
+| | CLI | MCP |
+|---|-----|-----|
+| **Задержка** | ~30ms (прямой бинарный файл) | ~50ms (JSON-RPC stdio) |
+| **Стоимость токенов** | 0 (на основе хуков, невидимо) | ~20-50 токенов/вызов (схема инструмента) |
+| **Настройка** | `icm init --mode hook` | `icm init --mode mcp` |
+| **Работает с** | Claude Code, OpenCode (через хуки/плагины) | Все 14 MCP-совместимых инструментов |
+| **Авто-извлечение** | Да (хуки запускают `icm extract`) | Да (MCP-инструменты вызывают store) |
+| **Лучше для** | Опытных пользователей, экономия токенов | Универсальная совместимость |
+
+## CLI
+
+### Memories (эпизодические, с затуханием)
+
+```bash
+# Сохранение
+icm store -t "my-project" -c "Use PostgreSQL for the main DB" -i high -k "db,postgres"
+
+# Поиск
+icm recall "database choice"
+icm recall "auth setup" --topic "my-project" --limit 10
+icm recall "architecture" --keyword "postgres"
+
+# Управление
+icm forget <memory-id>
+icm consolidate --topic "my-project"
+icm topics
+icm stats
+
+# Извлечение фактов из текста (на основе правил, без затрат на LLM)
+echo "The parser uses Pratt algorithm" | icm extract -p my-project
+```
+
+### Memoirs (постоянные графы знаний)
+
+```bash
+# Создание memoir
+icm memoir create -n "system-architecture" -d "System design decisions"
+
+# Добавление концепций с метками
+icm memoir add-concept -m "system-architecture" -n "auth-service" \
+  -d "Handles JWT tokens and OAuth2 flows" -l "domain:auth,type:service"
+
+# Связывание концепций
+icm memoir link -m "system-architecture" --from "api-gateway" --to "auth-service" -r depends-on
+
+# Поиск с фильтром по метке
+icm memoir search -m "system-architecture" "authentication"
+icm memoir search -m "system-architecture" "service" --label "domain:auth"
+
+# Просмотр окрестности
+icm memoir inspect -m "system-architecture" "auth-service" -D 2
+
+# Экспорт графа (форматы: json, dot, ascii, ai)
+icm memoir export -m "system-architecture" -f ascii   # Блочная графика с индикаторами уверенности
+icm memoir export -m "system-architecture" -f dot      # Graphviz DOT (цвет = уровень уверенности)
+icm memoir export -m "system-architecture" -f ai       # Markdown, оптимизированный для контекста LLM
+icm memoir export -m "system-architecture" -f json     # Структурированный JSON со всеми метаданными
+
+# Генерация SVG-визуализации
+icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
+```
+
+## MCP-инструменты (22)
+
+### Инструменты памяти
+
+| Инструмент | Описание |
+|------------|----------|
+| `icm_memory_store` | Сохранение с авто-дедупликацией (сходство >85% → обновление вместо дубликата) |
+| `icm_memory_recall` | Поиск по запросу, фильтрация по теме и/или ключевому слову |
+| `icm_memory_update` | Редактирование воспоминания на месте (содержимое, важность, ключевые слова) |
+| `icm_memory_forget` | Удаление воспоминания по ID |
+| `icm_memory_consolidate` | Объединение всех воспоминаний темы в одно резюме |
+| `icm_memory_list_topics` | Список всех тем с количеством записей |
+| `icm_memory_stats` | Глобальная статистика памяти |
+| `icm_memory_health` | Аудит гигиены по темам (устарелость, необходимость консолидации) |
+| `icm_memory_embed_all` | Заполнение эмбеддингов для векторного поиска |
+
+### Инструменты Memoir (графы знаний)
+
+| Инструмент | Описание |
+|------------|----------|
+| `icm_memoir_create` | Создание нового memoir (контейнер знаний) |
+| `icm_memoir_list` | Список всех memoir |
+| `icm_memoir_show` | Просмотр деталей memoir и всех концепций |
+| `icm_memoir_add_concept` | Добавление концепции с метками |
+| `icm_memoir_refine` | Обновление определения концепции |
+| `icm_memoir_search` | Полнотекстовый поиск, опционально фильтруется по метке |
+| `icm_memoir_search_all` | Поиск по всем memoir |
+| `icm_memoir_link` | Создание типизированного отношения между концепциями |
+| `icm_memoir_inspect` | Просмотр концепции и окрестности графа (BFS) |
+| `icm_memoir_export` | Экспорт графа (json, dot, ascii, ai) с уровнями уверенности |
+
+### Инструменты обратной связи (обучение на ошибках)
+
+| Инструмент | Описание |
+|------------|----------|
+| `icm_feedback_record` | Запись исправления при ошибочном предсказании ИИ |
+| `icm_feedback_search` | Поиск прошлых исправлений для информирования будущих предсказаний |
+| `icm_feedback_stats` | Статистика обратной связи: общее количество, разбивка по темам, наиболее применяемые |
+
+### Типы отношений
+
+`part_of` · `depends_on` · `related_to` · `contradicts` · `refines` · `alternative_to` · `caused_by` · `instance_of` · `superseded_by`
+
+## Принцип работы
+
+### Двойная модель памяти
+
+**Эпизодическая память (Темы)** фиксирует решения, ошибки, предпочтения. Каждое воспоминание имеет вес, который затухает со временем в зависимости от важности:
+
+| Важность | Затухание | Очистка | Поведение |
+|----------|-----------|---------|-----------|
+| `critical` | нет | никогда | Никогда не забывается, никогда не очищается |
+| `high` | медленное (0.5x скорость) | никогда | Затухает медленно, никогда не удаляется автоматически |
+| `medium` | нормальное | да | Стандартное затухание, очищается при весе ниже порога |
+| `low` | быстрое (2x скорость) | да | Быстро забывается |
+
+Затухание **учитывает обращения**: часто извлекаемые воспоминания затухают медленнее (`decay / (1 + access_count × 0.1)`). Применяется автоматически при извлечении (если прошло >24 часов с последнего затухания).
+
+**Гигиена памяти** встроена:
+- **Авто-дедупликация**: сохранение содержимого со сходством >85% с существующим воспоминанием в той же теме обновляет его вместо создания дубликата
+- **Подсказки консолидации**: когда тема превышает 7 записей, `icm_memory_store` предупреждает вызывающую сторону о необходимости консолидации
+- **Аудит состояния**: `icm_memory_health` сообщает количество записей по темам, средний вес, устаревшие записи и необходимость консолидации
+- **Без тихой потери данных**: критические воспоминания и воспоминания высокой важности никогда не очищаются автоматически
+
+**Семантическая память (Memoirs)** фиксирует структурированные знания в виде графа. Концепции постоянны — они уточняются, но не затухают. Используйте `superseded_by` для пометки устаревших фактов вместо их удаления.
+
+### Гибридный поиск
+
+При включённых эмбеддингах ICM использует гибридный поиск:
+- **FTS5 BM25** (30%) — полнотекстовое сопоставление по ключевым словам
+- **Косинусное сходство** (70%) — семантический векторный поиск через sqlite-vec
+
+Модель по умолчанию: `intfloat/multilingual-e5-base` (768d, 100+ языков). Настраивается в [файле конфигурации](#конфигурация):
+
+```toml
+[embeddings]
+# enabled = false                          # Полное отключение (без загрузки модели)
+model = "intfloat/multilingual-e5-base"    # 768d, многоязычная (по умолчанию)
+# model = "intfloat/multilingual-e5-small" # 384d, многоязычная (легче)
+# model = "intfloat/multilingual-e5-large" # 1024d, многоязычная (лучшая точность)
+# model = "Xenova/bge-small-en-v1.5"      # 384d, только английский (быстрее всего)
+# model = "jinaai/jina-embeddings-v2-base-code"  # 768d, оптимизирована для кода
+```
+
+Чтобы полностью пропустить загрузку модели эмбеддингов, используйте любое из следующего:
+```bash
+icm --no-embeddings serve          # Флаг CLI
+ICM_NO_EMBEDDINGS=1 icm serve     # Переменная окружения
+```
+Или установите `enabled = false` в файле конфигурации. ICM перейдёт к ключевому поиску FTS5 (работает, но без семантического сопоставления).
+
+Изменение модели автоматически пересоздаёт векторный индекс (существующие эмбеддинги очищаются и могут быть перегенерированы с помощью `icm_memory_embed_all`).
+
+### Хранилище
+
+Единый файл SQLite. Без внешних сервисов, без сетевых зависимостей.
+
+```
+~/Library/Application Support/dev.icm.icm/memories.db                    # macOS
+~/.local/share/dev.icm.icm/memories.db                                   # Linux
+C:\Users\<user>\AppData\Local\icm\icm\data\memories.db                   # Windows
+```
+
+### Конфигурация
+
+```bash
+icm config                    # Показать активную конфигурацию
+```
+
+Расположение файла конфигурации (зависит от платформы или `$ICM_CONFIG`):
+
+```
+~/Library/Application Support/dev.icm.icm/config.toml                    # macOS
+~/.config/icm/config.toml                                                # Linux
+C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml              # Windows
+```
+
+Смотрите [config/default.toml](config/default.toml) для всех параметров.
+
+## Авто-извлечение
+
+ICM автоматически извлекает воспоминания через три слоя:
+
+```
+  Layer 0: Pattern hooks              Layer 1: PreCompact           Layer 2: UserPromptSubmit
+  (zero LLM cost)                     (zero LLM cost)               (zero LLM cost)
+  ┌──────────────────┐                ┌──────────────────┐          ┌──────────────────┐
+  │ PostToolUse hook  │                │ PreCompact hook   │          │ UserPromptSubmit  │
+  │                   │                │                   │          │                   │
+  │ • Bash errors     │                │ Context about to  │          │ User sends prompt │
+  │ • git commits     │                │ be compressed →   │          │ → icm recall      │
+  │ • config changes  │                │ extract memories  │          │ → inject context  │
+  │ • decisions       │                │ from transcript   │          │                   │
+  │ • preferences     │                │ before they're    │          │ Agent starts with  │
+  │ • learnings       │                │ lost forever      │          │ relevant memories  │
+  │ • constraints     │                │                   │          │ already loaded     │
+  │                   │                │ Same patterns +   │          │                   │
+  │ Rule-based, no LLM│                │ --store-raw fallbk│          │                   │
+  └──────────────────┘                └──────────────────┘          └──────────────────┘
+```
+
+| Слой | Статус | Стоимость LLM | Команда хука | Описание |
+|------|--------|---------------|-------------|----------|
+| Layer 0 | Реализован | 0 | `icm hook post` | Извлечение по правилам из вывода инструмента |
+| Layer 1 | Реализован | 0 | `icm hook compact` | Извлечение из транскрипта перед сжатием контекста |
+| Layer 2 | Реализован | 0 | `icm hook prompt` | Внедрение извлечённых воспоминаний на каждый запрос пользователя |
+
+Все 3 слоя устанавливаются автоматически командой `icm init --mode hook`.
+
+### Сравнение с альтернативами
+
+| Система | Метод | Стоимость LLM | Задержка | Перехватывает сжатие? |
+|---------|-------|---------------|---------|----------------------|
+| **ICM** | 3-слойное извлечение | 0 до ~500 tok/сессия | 0ms | **Да (PreCompact)** |
+| Mem0 | 2 вызова LLM/сообщение | ~2k tok/сообщение | 200-2000ms | Нет |
+| claude-mem | PostToolUse + async | ~1-5k tok/сессия | 8ms хук | Нет |
+| MemGPT/Letta | Агент управляет сам | 0 доп. | 0ms | Нет |
+| DiffMem | Git-based diffs | 0 | 0ms | Нет |
+
+## Бенчмарки
+
+### Производительность хранилища
+
+```
+ICM Benchmark (1000 memories, 384d embeddings)
+──────────────────────────────────────────────────────────
+Store (no embeddings)      1000 ops      34.2 ms      34.2 µs/op
+Store (with embeddings)    1000 ops      51.6 ms      51.6 µs/op
+FTS5 search                 100 ops       4.7 ms      46.6 µs/op
+Vector search (KNN)         100 ops      59.0 ms     590.0 µs/op
+Hybrid search               100 ops      95.1 ms     951.1 µs/op
+Decay (batch)                 1 ops       5.8 ms       5.8 ms/op
+──────────────────────────────────────────────────────────
+```
+
+Apple M1 Pro, SQLite в памяти, однопоточный режим. `icm bench --count 1000`
+
+### Эффективность агента
+
+Многосессионный рабочий процесс с реальным Rust-проектом (12 файлов, ~550 строк). Сессии 2+ показывают наибольший выигрыш, так как ICM извлекает информацию вместо повторного чтения файлов.
+
+```
+ICM Agent Benchmark (10 sessions, model: haiku, 3 runs averaged)
+══════════════════════════════════════════════════════════════════
+                            Without ICM         With ICM      Delta
+Session 2 (recall)
+  Turns                             5.7              4.0       -29%
+  Context (input)                 99.9k            67.5k       -32%
+  Cost                          $0.0298          $0.0249       -17%
+
+Session 3 (recall)
+  Turns                             3.3              2.0       -40%
+  Context (input)                 74.7k            41.6k       -44%
+  Cost                          $0.0249          $0.0194       -22%
+══════════════════════════════════════════════════════════════════
+```
+
+`icm bench-agent --sessions 10 --model haiku`
+
+### Сохранение знаний
+
+Агент вспоминает конкретные факты из насыщенного технического документа между сессиями. Сессия 1 читает и запоминает; сессии 2+ отвечают на 10 фактических вопросов **без** исходного текста.
+
+```
+ICM Recall Benchmark (10 questions, model: haiku, 5 runs averaged)
+══════════════════════════════════════════════════════════════════════
+                                               No ICM     With ICM
+──────────────────────────────────────────────────────────────────────
+Average score                                      5%          68%
+Questions passed                                 0/10         5/10
+══════════════════════════════════════════════════════════════════════
+```
+
+`icm bench-recall --model haiku`
+
+### Локальные LLM (ollama)
+
+Тот же тест с локальными моделями — чистое внедрение контекста, без необходимости использования инструментов.
+
+```
+Model               Params   No ICM   With ICM     Delta
+─────────────────────────────────────────────────────────
+qwen2.5:14b           14B       4%       97%       +93%
+mistral:7b             7B       4%       93%       +89%
+llama3.1:8b            8B       4%       93%       +89%
+qwen2.5:7b             7B       4%       90%       +86%
+phi4:14b              14B       6%       79%       +73%
+llama3.2:3b            3B       0%       76%       +76%
+gemma2:9b              9B       4%       76%       +72%
+qwen2.5:3b             3B       2%       58%       +56%
+─────────────────────────────────────────────────────────
+```
+
+`scripts/bench-ollama.sh qwen2.5:14b`
+
+### Протокол тестирования
+
+Все бенчмарки используют **реальные API-вызовы** — без заглушек, без симулированных ответов, без кэшированных результатов.
+
+- **Бенчмарк агента**: Создаёт реальный Rust-проект во временной директории. Запускает N сессий с `claude -p --output-format json`. Без ICM: пустая конфигурация MCP. С ICM: реальный MCP-сервер + авто-извлечение + внедрение контекста.
+- **Сохранение знаний**: Использует вымышленный технический документ («Протокол Меридиан»). Оценивает ответы по совпадению ключевых слов с ожидаемыми фактами. Таймаут 120 секунд на вызов.
+- **Изоляция**: Каждый запуск использует собственную временную директорию и чистую базу данных SQLite. Без сохранения между сессиями.
+
+## Документация
+
+| Документ | Описание |
+|----------|----------|
+| [Техническая архитектура](docs/architecture.md) | Структура крейтов, конвейер поиска, модель затухания, интеграция sqlite-vec, тестирование |
+| [Руководство пользователя](docs/guide.md) | Установка, организация тем, консолидация, извлечение, устранение неполадок |
+| [Обзор продукта](docs/product.md) | Сценарии использования, бенчмарки, сравнение с альтернативами |
+
+## Лицензия
+
+[Source-Available](LICENSE) — Бесплатно для физических лиц и команд ≤ 20 человек. Для более крупных организаций требуется корпоративная лицензия. Контакт: license@rtk.ai

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,0 +1,453 @@
+[English](README.md) | [Français](README_fr.md) | [Español](README_es.md) | [Deutsch](README_de.md) | [Italiano](README_it.md) | [Português](README_pt.md) | [Nederlands](README_nl.md) | [Polski](README_pl.md) | [Русский](README_ru.md) | [日本語](README_ja.md) | **中文** | [العربية](README_ar.md) | [한국어](README_ko.md)
+
+<p align="center">
+  <img src="assets/banner.png" alt="ICM — Infinite Context Memory" width="600">
+</p>
+
+<h1 align="center">ICM</h1>
+
+<p align="center">
+  AI 智能体的永久记忆。单一二进制文件，零依赖，原生 MCP 支持。
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/icm/actions/workflows/ci.yml"><img src="https://github.com/rtk-ai/icm/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/icm/releases/latest"><img src="https://img.shields.io/github/v/release/rtk-ai/icm?color=purple" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Source--Available-orange.svg" alt="Source-Available"></a>
+</p>
+
+---
+
+ICM 为您的 AI 智能体提供真正的记忆——不是笔记工具，不是上下文管理器，而是真正的**记忆**。
+
+```
+                       ICM (Infinite Context Memory)
+            ┌──────────────────────┬─────────────────────────┐
+            │   MEMORIES（主题）    │   MEMOIRS（知识）        │
+            │                      │                         │
+            │  情节性，具有时间性   │  永久性，结构化          │
+            │                      │                         │
+            │  ┌───┐ ┌───┐ ┌───┐  │    ┌───┐               │
+            │  │ m │ │ m │ │ m │  │    │ C │──depends_on──┐ │
+            │  └─┬─┘ └─┬─┘ └─┬─┘  │    └───┘              │ │
+            │    │decay │     │    │      │ refines      ┌─▼─┐│
+            │    ▼      ▼     ▼    │    ┌─▼─┐            │ C ││
+            │  权重随时间衰减       │    │ C │──part_of──>└───┘│
+            │  除非被访问或        │    └───┘                 │
+            │  标记为关键          │  概念 + 关系              │
+            ├──────────────────────┴─────────────────────────┤
+            │             SQLite + FTS5 + sqlite-vec          │
+            │        混合搜索：BM25（30%）+ 余弦（70%）        │
+            └─────────────────────────────────────────────────┘
+```
+
+**两种记忆模型：**
+
+- **Memories（记忆）** — 按重要性进行时间衰减的存储与召回。关键记忆永不消逝，低重要性记忆自然衰减。可按主题或关键词过滤。
+- **Memoirs（回忆录）** — 永久知识图谱。概念通过有类型的关系相互连接（`depends_on`、`contradicts`、`superseded_by` 等）。可按标签过滤。
+- **Feedback（反馈）** — 记录 AI 预测错误时的纠正。在做出新预测前搜索过去的错误。闭环学习。
+
+## 安装
+
+```bash
+# Homebrew（macOS / Linux）
+brew tap rtk-ai/tap && brew install icm
+
+# 快速安装
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+
+# 从源码编译
+cargo install --path crates/icm-cli
+```
+
+## 配置
+
+```bash
+# 自动检测并配置所有支持的工具
+icm init
+```
+
+一条命令配置 **14 个工具**：
+
+| 工具 | 配置文件 | 格式 |
+|------|------------|--------|
+| Claude Code | `~/.claude.json` | JSON |
+| Claude Desktop | `~/Library/.../claude_desktop_config.json` | JSON |
+| Cursor | `~/.cursor/mcp.json` | JSON |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON |
+| VS Code / Copilot | `~/Library/.../Code/User/mcp.json` | JSON |
+| Gemini Code Assist | `~/.gemini/settings.json` | JSON |
+| Zed | `~/.zed/settings.json` | JSON |
+| Amp | `~/.config/amp/settings.json` | JSON |
+| Amazon Q | `~/.aws/amazonq/mcp.json` | JSON |
+| Cline | VS Code globalStorage | JSON |
+| Roo Code | VS Code globalStorage | JSON |
+| Kilo Code | VS Code globalStorage | JSON |
+| OpenAI Codex CLI | `~/.codex/config.toml` | TOML |
+| OpenCode | `~/.config/opencode/opencode.json` | JSON |
+
+或手动配置：
+
+```bash
+# Claude Code
+claude mcp add icm -- icm serve
+
+# 紧凑模式（更短的响应，节省 token）
+claude mcp add icm -- icm serve --compact
+
+# 任意 MCP 客户端：command = "icm"，args = ["serve"]
+```
+
+### 技能 / 规则
+
+```bash
+icm init --mode skill
+```
+
+为 Claude Code 安装斜杠命令和规则（`/recall`、`/remember`），为 Cursor 安装（`.mdc` 规则），为 Roo Code 安装（`.md` 规则），为 Amp 安装（`/icm-recall`、`/icm-remember`）。
+
+### 钩子（Claude Code）
+
+```bash
+icm init --mode hook
+```
+
+将所有 3 个提取层作为 Claude Code 钩子安装：
+
+**Claude Code** 钩子：
+
+| 钩子 | 事件 | 功能 |
+|------|-------|-------------|
+| `icm hook pre` | PreToolUse | 自动允许 `icm` CLI 命令（无需权限提示） |
+| `icm hook post` | PostToolUse | 每 15 次调用从工具输出中提取事实 |
+| `icm hook compact` | PreCompact | 在上下文压缩前从对话记录中提取记忆 |
+| `icm hook prompt` | UserPromptSubmit | 在每次提示开始时注入召回的上下文 |
+
+**OpenCode** 插件（自动安装至 `~/.config/opencode/plugins/icm.js`）：
+
+| OpenCode 事件 | ICM 层 | 功能 |
+|---------------|-----------|-------------|
+| `tool.execute.after` | 第 0 层 | 从工具输出中提取事实 |
+| `experimental.session.compacting` | 第 1 层 | 压缩前从对话中提取 |
+| `session.created` | 第 2 层 | 会话开始时召回上下文 |
+
+## CLI 与 MCP 对比
+
+ICM 可通过 CLI（`icm` 命令）或 MCP 服务器（`icm serve`）使用。两者访问同一数据库。
+
+| | CLI | MCP |
+|---|-----|-----|
+| **延迟** | ~30ms（直接二进制） | ~50ms（JSON-RPC stdio） |
+| **Token 开销** | 0（基于钩子，透明） | ~20-50 token/调用（工具 schema） |
+| **配置** | `icm init --mode hook` | `icm init --mode mcp` |
+| **适用工具** | Claude Code、OpenCode（通过钩子/插件） | 全部 14 个兼容 MCP 的工具 |
+| **自动提取** | 是（钩子触发 `icm extract`） | 是（MCP 工具调用 store） |
+| **最适合** | 高级用户，节省 token | 通用兼容性 |
+
+## CLI
+
+### Memories（情节性，带衰减）
+
+```bash
+# 存储
+icm store -t "my-project" -c "Use PostgreSQL for the main DB" -i high -k "db,postgres"
+
+# 召回
+icm recall "database choice"
+icm recall "auth setup" --topic "my-project" --limit 10
+icm recall "architecture" --keyword "postgres"
+
+# 管理
+icm forget <memory-id>
+icm consolidate --topic "my-project"
+icm topics
+icm stats
+
+# 从文本中提取事实（基于规则，零 LLM 开销）
+echo "The parser uses Pratt algorithm" | icm extract -p my-project
+```
+
+### Memoirs（永久知识图谱）
+
+```bash
+# 创建回忆录
+icm memoir create -n "system-architecture" -d "System design decisions"
+
+# 添加带标签的概念
+icm memoir add-concept -m "system-architecture" -n "auth-service" \
+  -d "Handles JWT tokens and OAuth2 flows" -l "domain:auth,type:service"
+
+# 连接概念
+icm memoir link -m "system-architecture" --from "api-gateway" --to "auth-service" -r depends-on
+
+# 按标签过滤搜索
+icm memoir search -m "system-architecture" "authentication"
+icm memoir search -m "system-architecture" "service" --label "domain:auth"
+
+# 检视邻域
+icm memoir inspect -m "system-architecture" "auth-service" -D 2
+
+# 导出图谱（格式：json、dot、ascii、ai）
+icm memoir export -m "system-architecture" -f ascii   # 带置信度条的框图
+icm memoir export -m "system-architecture" -f dot      # Graphviz DOT（颜色 = 置信度）
+icm memoir export -m "system-architecture" -f ai       # 为 LLM 上下文优化的 Markdown
+icm memoir export -m "system-architecture" -f json     # 包含所有元数据的结构化 JSON
+
+# 生成 SVG 可视化
+icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
+```
+
+## MCP 工具（22 个）
+
+### 记忆工具
+
+| 工具 | 描述 |
+|------|-------------|
+| `icm_memory_store` | 存储，自动去重（相似度 >85% → 更新而非重复创建） |
+| `icm_memory_recall` | 按查询搜索，可按主题和/或关键词过滤 |
+| `icm_memory_update` | 就地编辑记忆（内容、重要性、关键词） |
+| `icm_memory_forget` | 按 ID 删除记忆 |
+| `icm_memory_consolidate` | 将某主题的所有记忆合并为一个摘要 |
+| `icm_memory_list_topics` | 列出所有主题及其数量 |
+| `icm_memory_stats` | 全局记忆统计 |
+| `icm_memory_health` | 按主题的健康审计（陈旧度、是否需要整合） |
+| `icm_memory_embed_all` | 为向量搜索补全嵌入向量 |
+
+### 回忆录工具（知识图谱）
+
+| 工具 | 描述 |
+|------|-------------|
+| `icm_memoir_create` | 创建新的回忆录（知识容器） |
+| `icm_memoir_list` | 列出所有回忆录 |
+| `icm_memoir_show` | 显示回忆录详情及所有概念 |
+| `icm_memoir_add_concept` | 添加带标签的概念 |
+| `icm_memoir_refine` | 更新概念的定义 |
+| `icm_memoir_search` | 全文搜索，可选按标签过滤 |
+| `icm_memoir_search_all` | 跨所有回忆录搜索 |
+| `icm_memoir_link` | 在概念之间创建有类型的关系 |
+| `icm_memoir_inspect` | 检视概念及图谱邻域（BFS） |
+| `icm_memoir_export` | 导出图谱（json、dot、ascii、ai），含置信度级别 |
+
+### 反馈工具（从错误中学习）
+
+| 工具 | 描述 |
+|------|-------------|
+| `icm_feedback_record` | 当 AI 预测错误时记录纠正 |
+| `icm_feedback_search` | 搜索过去的纠正以指导未来的预测 |
+| `icm_feedback_stats` | 反馈统计：总数、按主题细分、应用最多的条目 |
+
+### 关系类型
+
+`part_of` · `depends_on` · `related_to` · `contradicts` · `refines` · `alternative_to` · `caused_by` · `instance_of` · `superseded_by`
+
+## 工作原理
+
+### 双重记忆模型
+
+**情节记忆（主题）** 捕获决策、错误、偏好。每条记忆都有一个随时间按重要性衰减的权重：
+
+| 重要性 | 衰减 | 修剪 | 行为 |
+|-----------|-------|-------|----------|
+| `critical` | 无 | 永不 | 永不遗忘，永不修剪 |
+| `high` | 慢（0.5x 速率） | 永不 | 缓慢消退，永不自动删除 |
+| `medium` | 正常 | 是 | 标准衰减，权重低于阈值时修剪 |
+| `low` | 快（2x 速率） | 是 | 迅速遗忘 |
+
+衰减是**访问感知**的：频繁召回的记忆衰减更慢（`decay / (1 + access_count × 0.1)`）。在召回时自动应用（如果距上次衰减超过 24 小时）。
+
+**记忆健康**内置功能：
+- **自动去重**：存储与同主题现有记忆相似度 >85% 的内容时，更新而非创建重复项
+- **整合提示**：当主题超过 7 条记录时，`icm_memory_store` 会提示调用者进行整合
+- **健康审计**：`icm_memory_health` 报告每个主题的条目数、平均权重、陈旧条目及整合需求
+- **无静默数据丢失**：关键和高重要性记忆永不自动修剪
+
+**语义记忆（回忆录）** 将结构化知识捕获为图谱。概念是永久性的——它们被精炼，永不衰减。使用 `superseded_by` 标记过时事实，而不是删除它们。
+
+### 混合搜索
+
+启用嵌入时，ICM 使用混合搜索：
+- **FTS5 BM25**（30%）— 全文关键词匹配
+- **余弦相似度**（70%）— 通过 sqlite-vec 进行语义向量搜索
+
+默认模型：`intfloat/multilingual-e5-base`（768 维，支持 100+ 种语言）。可在[配置文件](#配置)中设置：
+
+```toml
+[embeddings]
+# enabled = false                          # 完全禁用（不下载模型）
+model = "intfloat/multilingual-e5-base"    # 768d，多语言（默认）
+# model = "intfloat/multilingual-e5-small" # 384d，多语言（更轻量）
+# model = "intfloat/multilingual-e5-large" # 1024d，多语言（最高精度）
+# model = "Xenova/bge-small-en-v1.5"      # 384d，仅英文（最快）
+# model = "jinaai/jina-embeddings-v2-base-code"  # 768d，代码优化
+```
+
+若要完全跳过嵌入模型下载，可使用以下任一方式：
+```bash
+icm --no-embeddings serve          # CLI 标志
+ICM_NO_EMBEDDINGS=1 icm serve     # 环境变量
+```
+或在配置文件中设置 `enabled = false`。ICM 将回退到 FTS5 关键词搜索（仍然有效，只是没有语义匹配）。
+
+更换模型会自动重建向量索引（现有嵌入将被清除，可通过 `icm_memory_embed_all` 重新生成）。
+
+### 存储
+
+单一 SQLite 文件。无外部服务，无网络依赖。
+
+```
+~/Library/Application Support/dev.icm.icm/memories.db                    # macOS
+~/.local/share/dev.icm.icm/memories.db                                   # Linux
+C:\Users\<user>\AppData\Local\icm\icm\data\memories.db                   # Windows
+```
+
+### 配置
+
+```bash
+icm config                    # 显示当前配置
+```
+
+配置文件位置（平台特定，或使用 `$ICM_CONFIG`）：
+
+```
+~/Library/Application Support/dev.icm.icm/config.toml                    # macOS
+~/.config/icm/config.toml                                                # Linux
+C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml              # Windows
+```
+
+所有选项请参见 [config/default.toml](config/default.toml)。
+
+## 自动提取
+
+ICM 通过三个层次自动提取记忆：
+
+```
+  第 0 层：模式钩子              第 1 层：PreCompact           第 2 层：UserPromptSubmit
+  （零 LLM 开销）                 （零 LLM 开销）               （零 LLM 开销）
+  ┌──────────────────┐                ┌──────────────────┐          ┌──────────────────┐
+  │ PostToolUse 钩子  │                │ PreCompact 钩子   │          │ UserPromptSubmit  │
+  │                   │                │                   │          │                   │
+  │ • Bash 错误       │                │ 上下文即将被压缩→  │          │ 用户发送提示      │
+  │ • git 提交        │                │ 在压缩前从对话    │          │ → icm recall      │
+  │ • 配置变更        │                │ 记录中提取记忆    │          │ → 注入上下文      │
+  │ • 决策            │                │ 以免永久丢失      │          │                   │
+  │ • 偏好            │                │                   │          │ 智能体启动时      │
+  │ • 学习            │                │ 相同模式 +        │          │ 已加载相关记忆    │
+  │ • 约束            │                │ --store-raw 回退  │          │                   │
+  │                   │                │                   │          │                   │
+  │ 基于规则，无 LLM  │                └──────────────────┘          └──────────────────┘
+  └──────────────────┘
+```
+
+| 层次 | 状态 | LLM 开销 | 钩子命令 | 描述 |
+|-------|--------|----------|-------------|-------------|
+| 第 0 层 | 已实现 | 0 | `icm hook post` | 从工具输出中进行基于规则的关键词提取 |
+| 第 1 层 | 已实现 | 0 | `icm hook compact` | 在上下文压缩前从对话记录中提取 |
+| 第 2 层 | 已实现 | 0 | `icm hook prompt` | 在每次用户提示时注入召回的记忆 |
+
+所有 3 个层次均通过 `icm init --mode hook` 自动安装。
+
+### 与其他方案的对比
+
+| 系统 | 方法 | LLM 开销 | 延迟 | 是否捕获压缩？ |
+|--------|--------|----------|---------|---------------------|
+| **ICM** | 3 层提取 | 0 至 ~500 token/会话 | 0ms | **是（PreCompact）** |
+| Mem0 | 每条消息 2 次 LLM 调用 | ~2k token/消息 | 200-2000ms | 否 |
+| claude-mem | PostToolUse + 异步 | ~1-5k token/会话 | 8ms 钩子 | 否 |
+| MemGPT/Letta | 智能体自管理 | 0 边际成本 | 0ms | 否 |
+| DiffMem | 基于 Git 差异 | 0 | 0ms | 否 |
+
+## 基准测试
+
+### 存储性能
+
+```
+ICM Benchmark (1000 memories, 384d embeddings)
+──────────────────────────────────────────────────────────
+Store (no embeddings)      1000 ops      34.2 ms      34.2 µs/op
+Store (with embeddings)    1000 ops      51.6 ms      51.6 µs/op
+FTS5 search                 100 ops       4.7 ms      46.6 µs/op
+Vector search (KNN)         100 ops      59.0 ms     590.0 µs/op
+Hybrid search               100 ops      95.1 ms     951.1 µs/op
+Decay (batch)                 1 ops       5.8 ms       5.8 ms/op
+──────────────────────────────────────────────────────────
+```
+
+Apple M1 Pro，内存 SQLite，单线程。`icm bench --count 1000`
+
+### 智能体效率
+
+使用真实 Rust 项目（12 个文件，约 550 行）的多会话工作流。第 2 次及之后的会话收益最大，因为 ICM 召回记忆而无需重新读取文件。
+
+```
+ICM Agent Benchmark (10 sessions, model: haiku, 3 runs averaged)
+══════════════════════════════════════════════════════════════════
+                            Without ICM         With ICM      Delta
+Session 2 (recall)
+  Turns                             5.7              4.0       -29%
+  Context (input)                 99.9k            67.5k       -32%
+  Cost                          $0.0298          $0.0249       -17%
+
+Session 3 (recall)
+  Turns                             3.3              2.0       -40%
+  Context (input)                 74.7k            41.6k       -44%
+  Cost                          $0.0249          $0.0194       -22%
+══════════════════════════════════════════════════════════════════
+```
+
+`icm bench-agent --sessions 10 --model haiku`
+
+### 知识留存
+
+智能体跨会话从密集技术文档中召回特定事实。第 1 次会话读取并记忆；第 2 次及之后的会话**不依赖**源文本回答 10 个事实性问题。
+
+```
+ICM Recall Benchmark (10 questions, model: haiku, 5 runs averaged)
+══════════════════════════════════════════════════════════════════════
+                                               No ICM     With ICM
+──────────────────────────────────────────────────────────────────────
+Average score                                      5%          68%
+Questions passed                                 0/10         5/10
+══════════════════════════════════════════════════════════════════════
+```
+
+`icm bench-recall --model haiku`
+
+### 本地 LLM（ollama）
+
+使用本地模型进行相同测试——纯上下文注入，无需工具调用。
+
+```
+Model               Params   No ICM   With ICM     Delta
+─────────────────────────────────────────────────────────
+qwen2.5:14b           14B       4%       97%       +93%
+mistral:7b             7B       4%       93%       +89%
+llama3.1:8b            8B       4%       93%       +89%
+qwen2.5:7b             7B       4%       90%       +86%
+phi4:14b              14B       6%       79%       +73%
+llama3.2:3b            3B       0%       76%       +76%
+gemma2:9b              9B       4%       76%       +72%
+qwen2.5:3b             3B       2%       58%       +56%
+─────────────────────────────────────────────────────────
+```
+
+`scripts/bench-ollama.sh qwen2.5:14b`
+
+### 测试协议
+
+所有基准测试均使用**真实 API 调用**——无模拟，无模拟响应，无缓存答案。
+
+- **智能体基准**：在临时目录中创建真实 Rust 项目。使用 `claude -p --output-format json` 运行 N 个会话。不使用 ICM：空 MCP 配置。使用 ICM：真实 MCP 服务器 + 自动提取 + 上下文注入。
+- **知识留存**：使用虚构技术文档（"Meridian Protocol"）。通过关键词匹配预期事实对答案评分。每次调用超时 120 秒。
+- **隔离**：每次运行使用独立的临时目录和全新的 SQLite 数据库。无会话持久化。
+
+## 文档
+
+| 文档 | 描述 |
+|----------|-------------|
+| [技术架构](docs/architecture.md) | Crate 结构、搜索流水线、衰减模型、sqlite-vec 集成、测试 |
+| [用户指南](docs/guide.md) | 安装、主题组织、整合、提取、故障排除 |
+| [产品概述](docs/product.md) | 使用场景、基准测试、与其他方案的对比 |
+
+## 许可证
+
+[Source-Available](LICENSE) — 个人及 20 人以下团队免费使用。20 人以上的组织需要企业许可证。联系方式：license@rtk.ai


### PR DESCRIPTION
## Summary
- Add language selector to main README.md
- Add 12 translated READMEs: FR, ES, DE, IT, PT, NL, PL, RU, JA, ZH, AR, KO
- Languages match mavoix.app supported languages

## Files
- `README.md` — added language selector bar at top
- `README_{fr,es,de,it,pt,nl,pl,ru,ja,zh,ar,ko}.md` — full translations

## Test plan
- [ ] Verify language selector links work on GitHub
- [ ] Spot-check translations for accuracy