### PR TITLE
feat: interactive TUI dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +286,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +386,20 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
@@ -396,7 +422,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -479,6 +505,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,8 +551,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -519,12 +580,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -553,7 +638,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn",
@@ -977,6 +1062,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -1171,12 +1258,14 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "crossterm",
  "directories",
  "icm-core",
  "icm-mcp",
  "icm-store",
  "libc",
  "openssl",
+ "ratatui",
  "rpassword",
  "serde",
  "serde_json",
@@ -1401,8 +1490,30 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1437,6 +1548,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1516,7 +1636,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1532,6 +1652,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1541,6 +1667,15 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1555,6 +1690,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1637,6 +1781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1929,6 +2074,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,6 +2294,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str 0.8.1",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,7 +2330,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -2198,7 +2387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
 ]
 
@@ -2210,6 +2399,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2350,6 +2548,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2357,7 +2568,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2416,6 +2627,12 @@ checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -2537,6 +2754,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,6 +2872,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,7 +2971,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2766,12 +3036,12 @@ checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
 dependencies = [
  "ahash",
  "aho-corasick",
- "compact_str",
+ "compact_str 0.9.0",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -3029,10 +3299,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -3675,7 +3962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,7 @@ rpassword = "5"
 
 # Platform
 libc = "0.2"
+
+# TUI
+ratatui = "0.29"
+crossterm = "0.28"

--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ ICM can be used via CLI (`icm` commands) or MCP server (`icm serve`). Both acces
 | **Auto-extraction** | Yes (hooks trigger `icm extract`) | Yes (MCP tools call store) |
 | **Best for** | Power users, token savings | Universal compatibility |
 
+## Dashboard
+
+```bash
+icm dashboard    # or: icm tui
+```
+
+Interactive TUI with 5 tabs: Overview, Topics, Memories, Health, Memoirs. Keyboard navigation (vim-style: j/k, g/G, Tab, 1-5), live search (/), auto-refresh.
+
+Requires the `tui` feature (enabled by default). Build without: `cargo install --path crates/icm-cli --no-default-features --features embeddings`.
+
 ## CLI
 
 ### Memories (episodic, with decay)

--- a/crates/icm-cli/Cargo.toml
+++ b/crates/icm-cli/Cargo.toml
@@ -13,8 +13,9 @@ name = "icm"
 path = "src/main.rs"
 
 [features]
-default = ["embeddings"]
+default = ["embeddings", "tui"]
 embeddings = ["icm-core/embeddings", "icm-mcp/embeddings"]
+tui = ["dep:ratatui", "dep:crossterm"]
 vendored-openssl = ["openssl/vendored"]
 
 [dependencies]
@@ -33,6 +34,8 @@ tracing-subscriber = { workspace = true }
 openssl = { version = "0.10", optional = true }
 ureq = { workspace = true }
 rpassword = { workspace = true }
+ratatui = { workspace = true, optional = true }
+crossterm = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -3,6 +3,8 @@ mod bench_knowledge;
 pub mod cloud;
 mod config;
 mod extract;
+#[cfg(feature = "tui")]
+mod tui;
 
 use std::path::PathBuf;
 use std::time::Instant;
@@ -300,6 +302,15 @@ enum Commands {
         #[command(subcommand)]
         command: HookCommands,
     },
+
+    /// Launch interactive TUI dashboard
+    #[cfg(feature = "tui")]
+    Dashboard,
+
+    /// Launch interactive TUI dashboard (alias for dashboard)
+    #[cfg(feature = "tui")]
+    #[command(hide = true)]
+    Tui,
 }
 
 #[derive(Subcommand)]
@@ -668,6 +679,7 @@ fn main() -> Result<()> {
             e.dimensions()
         })
         .unwrap_or(384);
+    let db_path = cli.db.clone().unwrap_or_else(default_db_path);
     let store = open_store(cli.db, embedding_dims)?;
 
     match cli.command {
@@ -853,6 +865,16 @@ fn main() -> Result<()> {
             HookCommands::Compact => cmd_hook_compact(&store),
             HookCommands::Prompt => cmd_hook_prompt(&store),
         },
+        #[cfg(feature = "tui")]
+        Commands::Dashboard => {
+            let db_path_str = db_path.to_string_lossy().to_string();
+            tui::run_dashboard(&store, Some(&db_path_str))
+        }
+        #[cfg(feature = "tui")]
+        Commands::Tui => {
+            let db_path_str = db_path.to_string_lossy().to_string();
+            tui::run_dashboard(&store, Some(&db_path_str))
+        }
     }
 }
 
@@ -1056,13 +1078,13 @@ fn cmd_health(store: &SqliteStore, topic_filter: Option<&str>) -> Result<()> {
         match store.topic_health(topic) {
             Ok(health) => {
                 let status = if health.needs_consolidation && health.stale_count > 0 {
-                    "⚠ NEEDS ATTENTION"
+                    "!! NEEDS ATTENTION"
                 } else if health.needs_consolidation {
-                    "⚠ consolidate"
+                    "!  consolidate"
                 } else if health.stale_count > 0 {
-                    "○ stale entries"
+                    "-  stale entries"
                 } else {
-                    "✓ healthy"
+                    "ok healthy"
                 };
 
                 println!(
@@ -3772,7 +3794,7 @@ fn confidence_color(confidence: f32) -> &'static str {
 fn confidence_bar(confidence: f32) -> String {
     let filled = (confidence * 5.0).round() as usize;
     let empty = 5 - filled.min(5);
-    format!("{}{}", "●".repeat(filled), "○".repeat(empty))
+    format!("{}{}", "#".repeat(filled), ".".repeat(empty))
 }
 
 fn cmd_memoir_export(store: &SqliteStore, memoir_name: &str, format: &str) -> Result<()> {

--- a/crates/icm-cli/src/tui.rs
+++ b/crates/icm-cli/src/tui.rs
@@ -1,0 +1,1161 @@
+//! Interactive TUI dashboard for ICM metrics and memory browsing.
+
+use std::io;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    prelude::CrosstermBackend,
+    style::{Color, Modifier, Style, Stylize},
+    text::{Line, Span},
+    widgets::{
+        Block, Borders, Cell, Clear, List, ListItem, ListState, Paragraph, Row, Table, TableState,
+        Tabs, Wrap,
+    },
+    Frame, Terminal,
+};
+
+use icm_core::{
+    FeedbackStore, Importance, MemoirStore, Memory, MemoryStore, StoreStats, TopicHealth,
+};
+use icm_store::SqliteStore;
+
+/// Tab indices
+const TAB_OVERVIEW: usize = 0;
+const TAB_TOPICS: usize = 1;
+const TAB_MEMORIES: usize = 2;
+const TAB_HEALTH: usize = 3;
+const TAB_MEMOIRS: usize = 4;
+
+/// Application state
+struct App {
+    /// Active tab
+    tab: usize,
+    /// Should quit
+    quit: bool,
+    /// Global stats (cached)
+    stats: StoreStats,
+    /// Topics with counts
+    topics: Vec<(String, usize)>,
+    /// Topic list selection state
+    topic_state: ListState,
+    /// Selected topic's memories
+    memories: Vec<Memory>,
+    /// Memory list selection state
+    memory_state: ListState,
+    /// Memory scroll offset for detail view
+    memory_scroll: u16,
+    /// Health reports
+    health: Vec<TopicHealth>,
+    /// Health table selection state
+    health_state: TableState,
+    /// Memoir names
+    memoirs: Vec<(String, String, usize, usize)>, // (name, desc, concepts, links)
+    /// Memoir table state
+    memoir_state: TableState,
+    /// DB file size in bytes
+    db_size: u64,
+    /// DB path for display
+    db_path_display: String,
+    /// Total feedback count
+    feedback_count: usize,
+    /// Search mode active
+    search_mode: bool,
+    /// Search input buffer
+    search_input: String,
+    /// Search results
+    search_results: Vec<Memory>,
+    /// Search result list state
+    search_state: ListState,
+    /// Last refresh time
+    last_refresh: Instant,
+}
+
+impl App {
+    fn new(store: &SqliteStore, db_path: Option<&str>) -> Result<Self> {
+        let stats = store.stats()?;
+        let topics = store.list_topics()?;
+        let health = Self::load_health(store, &topics)?;
+        let memoirs = Self::load_memoirs(store)?;
+        let feedback_count = store.feedback_stats().map(|s| s.total).unwrap_or(0);
+        let db_size = db_path
+            .and_then(|p| std::fs::metadata(p).ok())
+            .map(|m| m.len())
+            .unwrap_or(0);
+
+        let mut topic_state = ListState::default();
+        if !topics.is_empty() {
+            topic_state.select(Some(0));
+        }
+
+        let mut app = Self {
+            tab: TAB_OVERVIEW,
+            quit: false,
+            stats,
+            topics,
+            topic_state,
+            memories: Vec::new(),
+            memory_state: ListState::default(),
+            memory_scroll: 0,
+            health,
+            health_state: TableState::default(),
+            memoirs,
+            memoir_state: TableState::default(),
+            db_size,
+            db_path_display: db_path.unwrap_or("in-memory").to_string(),
+            feedback_count,
+            search_mode: false,
+            search_input: String::new(),
+            search_results: Vec::new(),
+            search_state: ListState::default(),
+            last_refresh: Instant::now(),
+        };
+
+        // Load memories for the first topic
+        app.load_topic_memories(store);
+
+        Ok(app)
+    }
+
+    fn load_health(store: &SqliteStore, topics: &[(String, usize)]) -> Result<Vec<TopicHealth>> {
+        let mut health = Vec::new();
+        for (topic, _) in topics {
+            if let Ok(h) = store.topic_health(topic) {
+                health.push(h);
+            }
+        }
+        Ok(health)
+    }
+
+    fn load_memoirs(store: &SqliteStore) -> Result<Vec<(String, String, usize, usize)>> {
+        let memoirs = store.list_memoirs()?;
+        let mut result = Vec::new();
+        for m in memoirs {
+            let stats = store.memoir_stats(&m.id).unwrap_or_default();
+            result.push((
+                m.name,
+                m.description,
+                stats.total_concepts,
+                stats.total_links,
+            ));
+        }
+        Ok(result)
+    }
+
+    fn refresh(&mut self, store: &SqliteStore, db_path: Option<&str>) {
+        if let Ok(s) = store.stats() {
+            self.stats = s;
+        }
+        if let Ok(t) = store.list_topics() {
+            self.topics = t;
+        }
+        if let Ok(h) = Self::load_health(store, &self.topics) {
+            self.health = h;
+        }
+        if let Ok(m) = Self::load_memoirs(store) {
+            self.memoirs = m;
+        }
+        self.feedback_count = store.feedback_stats().map(|s| s.total).unwrap_or(0);
+        self.db_size = db_path
+            .and_then(|p| std::fs::metadata(p).ok())
+            .map(|m| m.len())
+            .unwrap_or(0);
+        self.last_refresh = Instant::now();
+    }
+
+    fn load_topic_memories(&mut self, store: &SqliteStore) {
+        if let Some(idx) = self.topic_state.selected() {
+            if let Some((topic, _)) = self.topics.get(idx) {
+                if let Ok(mut mems) = store.get_by_topic(topic) {
+                    mems.sort_by(|a, b| {
+                        b.weight
+                            .partial_cmp(&a.weight)
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                    });
+                    self.memories = mems;
+                    self.memory_state = ListState::default();
+                    if !self.memories.is_empty() {
+                        self.memory_state.select(Some(0));
+                    }
+                }
+            }
+        }
+    }
+
+    fn selected_topic_name(&self) -> Option<&str> {
+        self.topic_state
+            .selected()
+            .and_then(|i| self.topics.get(i))
+            .map(|(name, _)| name.as_str())
+    }
+
+    fn next_tab(&mut self) {
+        self.tab = (self.tab + 1) % 5;
+    }
+
+    fn prev_tab(&mut self) {
+        self.tab = if self.tab == 0 { 4 } else { self.tab - 1 };
+    }
+
+    fn select_next(selected: Option<usize>, len: usize) -> Option<usize> {
+        if len == 0 {
+            return None;
+        }
+        Some(selected.map(|i| (i + 1).min(len - 1)).unwrap_or(0))
+    }
+
+    fn select_prev(selected: Option<usize>) -> Option<usize> {
+        Some(selected.map(|i| i.saturating_sub(1)).unwrap_or(0))
+    }
+}
+
+/// Entry point for the TUI dashboard.
+pub fn run_dashboard(store: &SqliteStore, db_path: Option<&str>) -> Result<()> {
+    // Setup terminal
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut app = App::new(store, db_path)?;
+
+    let result = run_loop(&mut terminal, &mut app, store, db_path);
+
+    // Restore terminal
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut App,
+    store: &SqliteStore,
+    db_path: Option<&str>,
+) -> Result<()> {
+    loop {
+        terminal.draw(|f| draw(f, app))?;
+
+        // Poll events with 250ms timeout for auto-refresh
+        if event::poll(Duration::from_millis(250))? {
+            if let Event::Key(key) = event::read()? {
+                // Search mode input handling
+                if app.search_mode {
+                    match key.code {
+                        KeyCode::Esc => {
+                            app.search_mode = false;
+                            app.search_input.clear();
+                            app.search_results.clear();
+                        }
+                        KeyCode::Enter => {
+                            if !app.search_input.is_empty() {
+                                if let Ok(results) = store.search_fts(&app.search_input, 20) {
+                                    app.search_results = results;
+                                    app.search_state = ListState::default();
+                                    if !app.search_results.is_empty() {
+                                        app.search_state.select(Some(0));
+                                    }
+                                }
+                            }
+                        }
+                        KeyCode::Backspace => {
+                            app.search_input.pop();
+                        }
+                        KeyCode::Down => {
+                            let sel = App::select_next(
+                                app.search_state.selected(),
+                                app.search_results.len(),
+                            );
+                            app.search_state.select(sel);
+                        }
+                        KeyCode::Up => {
+                            let sel = App::select_prev(app.search_state.selected());
+                            app.search_state.select(sel);
+                        }
+                        KeyCode::Char(c) => {
+                            app.search_input.push(c);
+                        }
+                        _ => {}
+                    }
+                    continue;
+                }
+
+                match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => app.quit = true,
+                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        app.quit = true
+                    }
+                    // Tab navigation
+                    KeyCode::Tab | KeyCode::Right | KeyCode::Char('l') => app.next_tab(),
+                    KeyCode::BackTab | KeyCode::Left | KeyCode::Char('h') => app.prev_tab(),
+                    KeyCode::Char('1') => app.tab = TAB_OVERVIEW,
+                    KeyCode::Char('2') => app.tab = TAB_TOPICS,
+                    KeyCode::Char('3') => app.tab = TAB_MEMORIES,
+                    KeyCode::Char('4') => app.tab = TAB_HEALTH,
+                    KeyCode::Char('5') => app.tab = TAB_MEMOIRS,
+                    // List navigation
+                    KeyCode::Down | KeyCode::Char('j') => match app.tab {
+                        TAB_TOPICS => {
+                            let sel =
+                                App::select_next(app.topic_state.selected(), app.topics.len());
+                            app.topic_state.select(sel);
+                            app.load_topic_memories(store);
+                        }
+                        TAB_MEMORIES => {
+                            let sel =
+                                App::select_next(app.memory_state.selected(), app.memories.len());
+                            app.memory_state.select(sel);
+                            app.memory_scroll = 0;
+                        }
+                        TAB_HEALTH => {
+                            let sel =
+                                App::select_next(app.health_state.selected(), app.health.len());
+                            app.health_state.select(sel);
+                        }
+                        TAB_MEMOIRS => {
+                            let sel =
+                                App::select_next(app.memoir_state.selected(), app.memoirs.len());
+                            app.memoir_state.select(sel);
+                        }
+                        _ => {}
+                    },
+                    KeyCode::Up | KeyCode::Char('k') => match app.tab {
+                        TAB_TOPICS => {
+                            let sel = App::select_prev(app.topic_state.selected());
+                            app.topic_state.select(sel);
+                            app.load_topic_memories(store);
+                        }
+                        TAB_MEMORIES => {
+                            let sel = App::select_prev(app.memory_state.selected());
+                            app.memory_state.select(sel);
+                            app.memory_scroll = 0;
+                        }
+                        TAB_HEALTH => {
+                            let sel = App::select_prev(app.health_state.selected());
+                            app.health_state.select(sel);
+                        }
+                        TAB_MEMOIRS => {
+                            let sel = App::select_prev(app.memoir_state.selected());
+                            app.memoir_state.select(sel);
+                        }
+                        _ => {}
+                    },
+                    // Page up/down for memory detail scroll
+                    KeyCode::PageDown => app.memory_scroll = app.memory_scroll.saturating_add(5),
+                    KeyCode::PageUp => app.memory_scroll = app.memory_scroll.saturating_sub(5),
+                    // Jump to top/bottom
+                    KeyCode::Char('g') => match app.tab {
+                        TAB_TOPICS if !app.topics.is_empty() => {
+                            app.topic_state.select(Some(0));
+                            app.load_topic_memories(store);
+                        }
+                        TAB_MEMORIES if !app.memories.is_empty() => {
+                            app.memory_state.select(Some(0));
+                        }
+                        TAB_HEALTH if !app.health.is_empty() => {
+                            app.health_state.select(Some(0));
+                        }
+                        _ => {}
+                    },
+                    KeyCode::Char('G') => match app.tab {
+                        TAB_TOPICS if !app.topics.is_empty() => {
+                            app.topic_state.select(Some(app.topics.len() - 1));
+                            app.load_topic_memories(store);
+                        }
+                        TAB_MEMORIES if !app.memories.is_empty() => {
+                            app.memory_state.select(Some(app.memories.len() - 1));
+                        }
+                        TAB_HEALTH if !app.health.is_empty() => {
+                            app.health_state.select(Some(app.health.len() - 1));
+                        }
+                        _ => {}
+                    },
+                    // Enter on topics tab → switch to memories for that topic
+                    KeyCode::Enter => {
+                        if app.tab == TAB_TOPICS {
+                            app.load_topic_memories(store);
+                            app.tab = TAB_MEMORIES;
+                        }
+                    }
+                    // Search
+                    KeyCode::Char('/') => {
+                        app.search_mode = true;
+                        app.search_input.clear();
+                        app.search_results.clear();
+                    }
+                    // Refresh
+                    KeyCode::Char('r') => app.refresh(store, db_path),
+                    _ => {}
+                }
+            }
+        }
+
+        // Auto-refresh every 30s
+        if app.last_refresh.elapsed() > Duration::from_secs(30) {
+            app.refresh(store, db_path);
+        }
+
+        if app.quit {
+            break;
+        }
+    }
+    Ok(())
+}
+
+fn draw(f: &mut Frame, app: &mut App) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Tabs
+            Constraint::Min(0),    // Content
+            Constraint::Length(1), // Status bar
+        ])
+        .split(f.area());
+
+    draw_tabs(f, app, chunks[0]);
+
+    match app.tab {
+        TAB_OVERVIEW => draw_overview(f, app, chunks[1]),
+        TAB_TOPICS => draw_topics(f, app, chunks[1]),
+        TAB_MEMORIES => draw_memories(f, app, chunks[1]),
+        TAB_HEALTH => draw_health(f, app, chunks[1]),
+        TAB_MEMOIRS => draw_memoirs(f, app, chunks[1]),
+        _ => {}
+    }
+
+    draw_status_bar(f, app, chunks[2]);
+
+    // Search overlay
+    if app.search_mode {
+        draw_search_overlay(f, app);
+    }
+}
+
+fn draw_tabs(f: &mut Frame, app: &App, area: Rect) {
+    let titles = vec!["Overview", "Topics", "Memories", "Health", "Memoirs"];
+    let tabs = Tabs::new(titles)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" ICM Dashboard "),
+        )
+        .select(app.tab)
+        .style(Style::default().fg(Color::DarkGray))
+        .highlight_style(Style::default().fg(Color::Yellow).bold())
+        .divider(Span::raw(" | "));
+    f.render_widget(tabs, area);
+}
+
+fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
+    let help = if app.search_mode {
+        " ESC: cancel | ENTER: search | Type query..."
+    } else {
+        " q: quit | Tab/1-5: switch tab | j/k: navigate | /: search | r: refresh | Enter: select"
+    };
+    let bar = Paragraph::new(help).style(Style::default().fg(Color::DarkGray).bg(Color::Black));
+    f.render_widget(bar, area);
+}
+
+fn draw_overview(f: &mut Frame, app: &App, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(10), // Stats box
+            Constraint::Length(10), // Top topics
+            Constraint::Min(0),     // Recent activity
+        ])
+        .split(area);
+
+    // Stats panel
+    let db_str = format_size(app.db_size);
+    let oldest = app
+        .stats
+        .oldest_memory
+        .map(|d| d.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "—".into());
+    let newest = app
+        .stats
+        .newest_memory
+        .map(|d| d.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "—".into());
+
+    let memoir_count = app.memoirs.len();
+    let total_concepts: usize = app.memoirs.iter().map(|(_, _, c, _)| c).sum();
+    let total_links: usize = app.memoirs.iter().map(|(_, _, _, l)| l).sum();
+
+    let stats_text = vec![
+        Line::from(vec![
+            Span::styled("  Memories:  ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{}", app.stats.total_memories)),
+            Span::raw("    "),
+            Span::styled("Topics:  ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{}", app.stats.total_topics)),
+            Span::raw("    "),
+            Span::styled("Avg weight:  ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{:.2}", app.stats.avg_weight)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Memoirs:   ", Style::default().fg(Color::Magenta)),
+            Span::raw(format!("{memoir_count}")),
+            Span::raw("    "),
+            Span::styled("Concepts: ", Style::default().fg(Color::Magenta)),
+            Span::raw(format!("{total_concepts}")),
+            Span::raw("    "),
+            Span::styled("Links: ", Style::default().fg(Color::Magenta)),
+            Span::raw(format!("{total_links}")),
+        ]),
+        Line::from(vec![
+            Span::styled("  Feedback:  ", Style::default().fg(Color::Green)),
+            Span::raw(format!("{}", app.feedback_count)),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  DB size:   ", Style::default().fg(Color::DarkGray)),
+            Span::raw(db_str),
+            Span::raw("    "),
+            Span::styled("Range: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(format!("{oldest} → {newest}")),
+        ]),
+        Line::from(vec![
+            Span::styled("  DB path:   ", Style::default().fg(Color::DarkGray)),
+            Span::raw(app.db_path_display.clone()),
+        ]),
+    ];
+
+    let stats_block = Paragraph::new(stats_text).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" Global Stats ")
+            .title_style(Style::default().fg(Color::Yellow).bold()),
+    );
+    f.render_widget(stats_block, chunks[0]);
+
+    // Top topics by count
+    let mut sorted_topics = app.topics.clone();
+    sorted_topics.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted_topics.truncate(8);
+
+    let topic_rows: Vec<Row> = sorted_topics
+        .iter()
+        .map(|(name, count)| {
+            let bar = "█".repeat((*count).min(30));
+            Row::new(vec![
+                Cell::from(name.as_str()).style(Style::default().fg(Color::Cyan)),
+                Cell::from(format!("{count:>4}")),
+                Cell::from(bar).style(Style::default().fg(Color::Blue)),
+            ])
+        })
+        .collect();
+
+    let topic_table = Table::new(
+        topic_rows,
+        [
+            Constraint::Length(30),
+            Constraint::Length(5),
+            Constraint::Min(10),
+        ],
+    )
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" Top Topics ")
+            .title_style(Style::default().fg(Color::Yellow).bold()),
+    );
+    f.render_widget(topic_table, chunks[1]);
+
+    // Importance distribution
+    let health_summary = importance_distribution(&app.health);
+    let dist_block = Paragraph::new(health_summary).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" Health Summary ")
+            .title_style(Style::default().fg(Color::Yellow).bold()),
+    );
+    f.render_widget(dist_block, chunks[2]);
+}
+
+fn draw_topics(f: &mut Frame, app: &mut App, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(area);
+
+    // Topics list
+    let items: Vec<ListItem> = app
+        .topics
+        .iter()
+        .map(|(name, count)| {
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("{name:<30}"), Style::default().fg(Color::Cyan)),
+                Span::raw(format!(" ({count})")),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!(" Topics ({}) ", app.topics.len()))
+                .title_style(Style::default().fg(Color::Yellow).bold()),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+    f.render_stateful_widget(list, chunks[0], &mut app.topic_state);
+
+    // Topic detail (right panel)
+    let detail = if let Some(idx) = app.topic_state.selected() {
+        if let Some(health) = app.health.get(idx) {
+            topic_detail_text(health)
+        } else {
+            vec![Line::from("  No health data")]
+        }
+    } else {
+        vec![Line::from("  Select a topic")]
+    };
+
+    let detail_block = Paragraph::new(detail).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" Topic Detail ")
+            .title_style(Style::default().fg(Color::Yellow).bold()),
+    );
+    f.render_widget(detail_block, chunks[1]);
+}
+
+fn draw_memories(f: &mut Frame, app: &mut App, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(area);
+
+    let topic_label = app.selected_topic_name().unwrap_or("all").to_string();
+
+    // Memory list
+    let items: Vec<ListItem> = app
+        .memories
+        .iter()
+        .map(|m| {
+            let imp_color = importance_color(&m.importance);
+            let summary = if m.summary.len() > 50 {
+                format!("{}...", &m.summary[..47])
+            } else {
+                m.summary.clone()
+            };
+            let bar = weight_bar(m.weight, 5);
+            ListItem::new(Line::from(vec![
+                Span::styled(bar, Style::default().fg(weight_color(m.weight))),
+                Span::raw(" "),
+                Span::styled("● ", Style::default().fg(imp_color)),
+                Span::raw(summary),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!(
+                    " Memories — {} ({}) ",
+                    topic_label,
+                    app.memories.len()
+                ))
+                .title_style(Style::default().fg(Color::Yellow).bold()),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+    f.render_stateful_widget(list, chunks[0], &mut app.memory_state);
+
+    // Memory detail
+    let detail = if let Some(idx) = app.memory_state.selected() {
+        if let Some(mem) = app.memories.get(idx) {
+            memory_detail_text(mem)
+        } else {
+            vec![Line::from("  No memory selected")]
+        }
+    } else {
+        vec![Line::from("  Select a memory (j/k to navigate)")]
+    };
+
+    let detail_block = Paragraph::new(detail)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Memory Detail ")
+                .title_style(Style::default().fg(Color::Yellow).bold()),
+        )
+        .wrap(Wrap { trim: false })
+        .scroll((app.memory_scroll, 0));
+    f.render_widget(detail_block, chunks[1]);
+}
+
+fn draw_health(f: &mut Frame, app: &mut App, area: Rect) {
+    let header = Row::new(vec![
+        Cell::from("Topic").style(Style::default().bold()),
+        Cell::from("Count").style(Style::default().bold()),
+        Cell::from("Avg Wt").style(Style::default().bold()),
+        Cell::from("Stale").style(Style::default().bold()),
+        Cell::from("Consol?").style(Style::default().bold()),
+        Cell::from("Last Access").style(Style::default().bold()),
+    ])
+    .height(1)
+    .bottom_margin(1);
+
+    let rows: Vec<Row> = app
+        .health
+        .iter()
+        .map(|h| {
+            let consol = if h.needs_consolidation {
+                Span::styled("YES", Style::default().fg(Color::Red).bold())
+            } else {
+                Span::styled("no", Style::default().fg(Color::Green))
+            };
+            let stale_style = if h.stale_count > 0 {
+                Style::default().fg(Color::Yellow)
+            } else {
+                Style::default().fg(Color::Green)
+            };
+            let last_access = h
+                .last_accessed
+                .map(|d| d.format("%Y-%m-%d %H:%M").to_string())
+                .unwrap_or_else(|| "—".into());
+
+            Row::new(vec![
+                Cell::from(h.topic.as_str()).style(Style::default().fg(Color::Cyan)),
+                Cell::from(format!("{}", h.entry_count)),
+                Cell::from(format!("{:.2}", h.avg_weight)),
+                Cell::from(format!("{}", h.stale_count)).style(stale_style),
+                Cell::from(consol),
+                Cell::from(last_access),
+            ])
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(30),
+            Constraint::Length(6),
+            Constraint::Length(7),
+            Constraint::Length(6),
+            Constraint::Length(8),
+            Constraint::Min(16),
+        ],
+    )
+    .header(header)
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" Health Report ({} topics) ", app.health.len()))
+            .title_style(Style::default().fg(Color::Yellow).bold()),
+    )
+    .row_highlight_style(
+        Style::default()
+            .bg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    f.render_stateful_widget(table, area, &mut app.health_state);
+}
+
+fn draw_memoirs(f: &mut Frame, app: &mut App, area: Rect) {
+    if app.memoirs.is_empty() {
+        let empty = Paragraph::new(
+            "  No memoirs found. Create one with: icm memoir create -n <name> -d <description>",
+        )
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Memoirs ")
+                .title_style(Style::default().fg(Color::Yellow).bold()),
+        );
+        f.render_widget(empty, area);
+        return;
+    }
+
+    let header = Row::new(vec![
+        Cell::from("Name").style(Style::default().bold()),
+        Cell::from("Description").style(Style::default().bold()),
+        Cell::from("Concepts").style(Style::default().bold()),
+        Cell::from("Links").style(Style::default().bold()),
+    ])
+    .height(1)
+    .bottom_margin(1);
+
+    let rows: Vec<Row> = app
+        .memoirs
+        .iter()
+        .map(|(name, desc, concepts, links)| {
+            let desc_short = if desc.len() > 40 {
+                format!("{}...", &desc[..37])
+            } else {
+                desc.clone()
+            };
+            Row::new(vec![
+                Cell::from(name.as_str()).style(Style::default().fg(Color::Magenta)),
+                Cell::from(desc_short),
+                Cell::from(format!("{concepts}")),
+                Cell::from(format!("{links}")),
+            ])
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(25),
+            Constraint::Min(20),
+            Constraint::Length(9),
+            Constraint::Length(6),
+        ],
+    )
+    .header(header)
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" Memoirs ({}) ", app.memoirs.len()))
+            .title_style(Style::default().fg(Color::Yellow).bold()),
+    )
+    .row_highlight_style(
+        Style::default()
+            .bg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    f.render_stateful_widget(table, area, &mut app.memoir_state);
+}
+
+fn draw_search_overlay(f: &mut Frame, app: &mut App) {
+    let area = f.area();
+    let overlay_height = (area.height / 2).max(10);
+    let overlay = Rect {
+        x: area.width / 6,
+        y: area.height / 4,
+        width: area.width * 2 / 3,
+        height: overlay_height,
+    };
+
+    f.render_widget(Clear, overlay);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(0)])
+        .split(overlay);
+
+    // Search input
+    let input = Paragraph::new(Line::from(vec![
+        Span::styled(" > ", Style::default().fg(Color::Yellow)),
+        Span::raw(&app.search_input),
+        Span::styled("_", Style::default().fg(Color::Yellow)),
+    ]))
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" Search (Enter to search, Esc to cancel) ")
+            .title_style(Style::default().fg(Color::Yellow).bold()),
+    );
+    f.render_widget(input, chunks[0]);
+
+    // Results
+    let items: Vec<ListItem> = app
+        .search_results
+        .iter()
+        .map(|m| {
+            let summary = if m.summary.len() > 80 {
+                format!("{}...", &m.summary[..77])
+            } else {
+                m.summary.clone()
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("[{}] ", m.topic), Style::default().fg(Color::Cyan)),
+                Span::raw(summary),
+            ]))
+        })
+        .collect();
+
+    let results = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(format!(" Results ({}) ", app.search_results.len())),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+    f.render_stateful_widget(results, chunks[1], &mut app.search_state);
+}
+
+// --- Helper functions ---
+
+fn weight_bar(weight: f32, width: usize) -> String {
+    let filled = ((weight.clamp(0.0, 1.0)) * width as f32).round() as usize;
+    let empty = width.saturating_sub(filled);
+    format!("{}{}", "█".repeat(filled), "░".repeat(empty))
+}
+
+fn weight_color(weight: f32) -> Color {
+    if weight >= 0.8 {
+        Color::Green
+    } else if weight >= 0.5 {
+        Color::Yellow
+    } else if weight >= 0.3 {
+        Color::Rgb(255, 165, 0) // Orange
+    } else {
+        Color::Red
+    }
+}
+
+fn importance_color(imp: &Importance) -> Color {
+    match imp {
+        Importance::Critical => Color::Red,
+        Importance::High => Color::Yellow,
+        Importance::Medium => Color::Green,
+        Importance::Low => Color::DarkGray,
+    }
+}
+
+fn importance_label(imp: &Importance) -> &'static str {
+    match imp {
+        Importance::Critical => "CRITICAL",
+        Importance::High => "HIGH",
+        Importance::Medium => "MEDIUM",
+        Importance::Low => "LOW",
+    }
+}
+
+fn format_size(bytes: u64) -> String {
+    if bytes == 0 {
+        return "—".into();
+    }
+    const KB: u64 = 1024;
+    const MB: u64 = 1024 * 1024;
+    const GB: u64 = 1024 * 1024 * 1024;
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+fn topic_detail_text(h: &TopicHealth) -> Vec<Line<'static>> {
+    let consol_status = if h.needs_consolidation {
+        Span::styled(
+            "NEEDS CONSOLIDATION",
+            Style::default().fg(Color::Red).bold(),
+        )
+    } else {
+        Span::styled("OK", Style::default().fg(Color::Green))
+    };
+
+    let oldest = h
+        .oldest
+        .map(|d| d.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|| "—".into());
+    let newest = h
+        .newest
+        .map(|d| d.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|| "—".into());
+    let last_access = h
+        .last_accessed
+        .map(|d| d.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|| "—".into());
+
+    vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Topic:         ", Style::default().fg(Color::Cyan).bold()),
+            Span::raw(h.topic.clone()),
+        ]),
+        Line::from(vec![
+            Span::styled("  Entries:       ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{}", h.entry_count)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Avg weight:    ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{:.3}", h.avg_weight)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Avg accesses:  ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{:.1}", h.avg_access_count)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Stale entries: ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{}", h.stale_count)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Consolidation: ", Style::default().fg(Color::Cyan)),
+            consol_status,
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Oldest:        ", Style::default().fg(Color::DarkGray)),
+            Span::raw(oldest),
+        ]),
+        Line::from(vec![
+            Span::styled("  Newest:        ", Style::default().fg(Color::DarkGray)),
+            Span::raw(newest),
+        ]),
+        Line::from(vec![
+            Span::styled("  Last accessed: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(last_access),
+        ]),
+    ]
+}
+
+fn memory_detail_text(m: &Memory) -> Vec<Line<'static>> {
+    let imp_color = importance_color(&m.importance);
+    let keywords = if m.keywords.is_empty() {
+        "—".to_string()
+    } else {
+        m.keywords.join(", ")
+    };
+
+    let mut lines = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  ID:          ", Style::default().fg(Color::DarkGray)),
+            Span::raw(m.id.clone()),
+        ]),
+        Line::from(vec![
+            Span::styled("  Topic:       ", Style::default().fg(Color::Cyan)),
+            Span::raw(m.topic.clone()),
+        ]),
+        Line::from(vec![
+            Span::styled("  Importance:  ", Style::default().fg(Color::Cyan)),
+            Span::styled(
+                importance_label(&m.importance).to_string(),
+                Style::default().fg(imp_color).bold(),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Weight:      ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{:.4}", m.weight)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Accesses:    ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{}", m.access_count)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Created:     ", Style::default().fg(Color::DarkGray)),
+            Span::raw(m.created_at.format("%Y-%m-%d %H:%M").to_string()),
+        ]),
+        Line::from(vec![
+            Span::styled("  Updated:     ", Style::default().fg(Color::DarkGray)),
+            Span::raw(m.updated_at.format("%Y-%m-%d %H:%M").to_string()),
+        ]),
+        Line::from(vec![
+            Span::styled("  Accessed:    ", Style::default().fg(Color::DarkGray)),
+            Span::raw(m.last_accessed.format("%Y-%m-%d %H:%M").to_string()),
+        ]),
+        Line::from(vec![
+            Span::styled("  Keywords:    ", Style::default().fg(Color::Cyan)),
+            Span::raw(keywords),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Content:",
+            Style::default().fg(Color::Yellow).bold(),
+        )),
+        Line::from(""),
+    ];
+
+    // Wrap summary text
+    for line in m.summary.lines() {
+        lines.push(Line::from(format!("  {line}")));
+    }
+
+    // Raw excerpt if present
+    if let Some(ref raw) = m.raw_excerpt {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "  Raw excerpt:",
+            Style::default().fg(Color::Yellow).bold(),
+        )));
+        lines.push(Line::from(""));
+        for line in raw.lines() {
+            lines.push(Line::from(format!("  {line}")));
+        }
+    }
+
+    lines
+}
+
+fn importance_distribution(health: &[TopicHealth]) -> Vec<Line<'static>> {
+    if health.is_empty() {
+        return vec![Line::from("  No data")];
+    }
+
+    let total_entries: usize = health.iter().map(|h| h.entry_count).sum();
+    let total_stale: usize = health.iter().map(|h| h.stale_count).sum();
+    let needs_consol = health.iter().filter(|h| h.needs_consolidation).count();
+    let avg_weight: f32 = health.iter().map(|h| h.avg_weight).sum::<f32>() / health.len() as f32;
+
+    let healthy_pct = if total_entries > 0 {
+        ((total_entries - total_stale) as f32 / total_entries as f32 * 100.0) as u32
+    } else {
+        100
+    };
+
+    let bar_width = 30;
+    let filled = (healthy_pct as usize * bar_width) / 100;
+
+    let health_color = if healthy_pct >= 80 {
+        Color::Green
+    } else if healthy_pct >= 50 {
+        Color::Yellow
+    } else {
+        Color::Red
+    };
+
+    vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Total entries:     ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{total_entries}")),
+            Span::raw("    "),
+            Span::styled("Stale: ", Style::default().fg(Color::Yellow)),
+            Span::raw(format!("{total_stale}")),
+            Span::raw("    "),
+            Span::styled("Need consolidation: ", Style::default().fg(Color::Red)),
+            Span::raw(format!("{needs_consol}")),
+        ]),
+        Line::from(vec![
+            Span::styled("  Avg weight:        ", Style::default().fg(Color::Cyan)),
+            Span::raw(format!("{avg_weight:.3}")),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Health: ", Style::default().fg(Color::Cyan).bold()),
+            Span::styled(
+                format!("[{}{}]", "█".repeat(filled), "░".repeat(bar_width - filled)),
+                Style::default().fg(health_color),
+            ),
+            Span::raw(format!(" {healthy_pct}%")),
+        ]),
+    ]
+}

--- a/crates/icm-core/src/memoir.rs
+++ b/crates/icm-core/src/memoir.rs
@@ -193,7 +193,7 @@ impl ConceptLink {
 // MemoirStats
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct MemoirStats {
     pub total_concepts: usize,
     pub total_links: usize,

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -667,7 +667,7 @@ fn tool_store(
                     let hint = if let Ok(count) = store.count_by_topic(topic) {
                         if count > 7 {
                             format!(
-                                "\n⚠ Topic '{topic}' has {count} entries — consider consolidating with icm_memory_consolidate."
+                                "\nNote: Topic '{topic}' has {count} entries — consider consolidating with icm_memory_consolidate."
                             )
                         } else {
                             String::new()
@@ -971,13 +971,13 @@ fn tool_health(store: &SqliteStore, args: &Value) -> ToolResult {
         match store.topic_health(topic) {
             Ok(health) => {
                 let status = if health.needs_consolidation && health.stale_count > 0 {
-                    "⚠ NEEDS ATTENTION"
+                    "!! NEEDS ATTENTION"
                 } else if health.needs_consolidation {
-                    "⚠ consolidate"
+                    "!  consolidate"
                 } else if health.stale_count > 0 {
-                    "○ has stale entries"
+                    "-  has stale entries"
                 } else {
-                    "✓ healthy"
+                    "ok healthy"
                 };
 
                 output.push_str(&format!(
@@ -1555,7 +1555,7 @@ fn confidence_color(confidence: f32) -> &'static str {
 fn confidence_bar(confidence: f32) -> String {
     let filled = (confidence * 5.0).round() as usize;
     let empty = 5 - filled.min(5);
-    format!("{}{}", "●".repeat(filled), "○".repeat(empty))
+    format!("{}{}", "#".repeat(filled), ".".repeat(empty))
 }
 
 fn tool_memoir_export(store: &SqliteStore, args: &Value) -> ToolResult {


### PR DESCRIPTION
## Summary
- Add `icm dashboard` / `icm tui` command with interactive terminal UI
- 5 tabs: Overview (stats, top topics, health score), Topics (list + detail), Memories (browse + detail view), Health (table report), Memoirs (graph overview)
- Vim-style navigation (j/k, g/G, Tab, 1-5), live search (/), auto-refresh every 30s
- Feature-gated behind `tui` feature flag (ratatui + crossterm, enabled by default)
- Weight bars with color coding (green/yellow/orange/red)
- Removes all emojis from CLI and MCP outputs (replaced with ASCII)
- Closes #21

## Test plan
- [x] 152 tests pass
- [x] clippy clean, fmt clean
- [x] `icm dashboard --help` works
- [x] `icm tui --help` works (alias)
- [x] TUI launches and exits cleanly with real data (256 memories, 112 topics)
- [x] Release build: ~20 MB (negligible TUI overhead)