### PR TITLE
fix: release-please workspace config

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,9 +23,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
-        with:
-          release-type: rust
-          package-name: icm
 
   build-release:
     name: Build and upload release assets

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "crates/icm-cli": "0.4.0"
+  "crates/icm-cli": "0.10.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,10 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [
-        "../../CHANGELOG.md"
+        "../../CHANGELOG.md",
+        "../icm-core/Cargo.toml",
+        "../icm-store/Cargo.toml",
+        "../icm-mcp/Cargo.toml"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Remove `release-type` and `package-name` from workflow top-level (was conflicting with workspace `Cargo.toml` — caused `is not a package manifest` error)
- Update manifest from v0.4.0 to v0.10.0 (current version)
- Add extra-files for all crate `Cargo.toml` so versions are bumped together

Fixes all 5 consecutive release-please failures.