### PR TITLE
fix: strip icm-v prefix from Homebrew formula version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,9 @@ jobs:
           if [ -z "$TAG" ]; then
             TAG="${{ github.event.release.tag_name }}"
           fi
-          VERSION="${TAG#v}"
+          # Strip tag prefixes: "icm-v0.10.1" → "0.10.1", "v0.10.1" → "0.10.1"
+          VERSION="${TAG#icm-v}"
+          VERSION="${VERSION#v}"
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary
- The release-please tag format is `icm-v0.10.1` (monorepo component prefix)
- The old code only stripped `v` prefix: `${TAG#v}` → `icm-0.10.1`
- Homebrew couldn't compare `icm-0.10.1` with `0.5.0`, so `brew upgrade` was broken
- Fix: strip both prefixes: `${TAG#icm-v}` then `${TAG#v}` → `0.10.1`

## Test plan
- [x] Manually fixed the current formula in homebrew-tap (already deployed, `brew upgrade icm` works)
- [ ] Next release-please merge will generate the correct version in the formula