### PR TITLE
feat: mandatory ICM store triggers for all AI tools

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1659,29 +1659,35 @@ fn cmd_init(mode: InitMode) -> Result<()> {
 
         let icm_block = "\
 <!-- icm:start -->\n\
-## Persistent memory (ICM)\n\
+## Persistent memory (ICM) — MANDATORY\n\
 \n\
 This project uses [ICM](https://github.com/rtk-ai/icm) for persistent memory across sessions.\n\
+You MUST use it actively. Not optional.\n\
 \n\
 ### Recall (before starting work)\n\
 ```bash\n\
-icm recall \"topic keywords\"              # search memories\n\
-icm recall-context \"query\" --limit 5     # formatted for prompt injection\n\
+icm recall \"query\"                        # search memories\n\
+icm recall \"query\" -t \"topic-name\"        # filter by topic\n\
+icm recall-context \"query\" --limit 5      # formatted for prompt injection\n\
 ```\n\
 \n\
-### Store (after completing significant work)\n\
-```bash\n\
-icm store -t \"topic\" -c \"summary\" -i medium   # importance: critical|high|medium|low\n\
-icm store -t \"decisions\" -c \"chose X over Y because...\" -i high\n\
-icm store -t \"errors-resolved\" -c \"fix: ...\" -k \"error,fix\"\n\
-```\n\
+### Store — MANDATORY triggers\n\
+You MUST call `icm store` when ANY of the following happens:\n\
+1. **Error resolved** → `icm store -t errors-resolved -c \"description\" -i high -k \"keyword1,keyword2\"`\n\
+2. **Architecture/design decision** → `icm store -t decisions-{project} -c \"description\" -i high`\n\
+3. **User preference discovered** → `icm store -t preferences -c \"description\" -i critical`\n\
+4. **Significant task completed** → `icm store -t context-{project} -c \"summary of work done\" -i high`\n\
+5. **Conversation exceeds ~20 tool calls without a store** → store a progress summary\n\
+\n\
+Do this BEFORE responding to the user. Not after. Not later. Immediately.\n\
+\n\
+Do NOT store: trivial details, info already in CLAUDE.md, ephemeral state (build logs, git status).\n\
 \n\
 ### Other commands\n\
 ```bash\n\
 icm update <id> -c \"updated content\"     # edit memory in-place\n\
 icm health                                # topic hygiene audit\n\
 icm topics                                # list all topics\n\
-icm feedback record -t \"topic\" -c \"context\" -p \"predicted\" --corrected \"actual\"\n\
 ```\n\
 <!-- icm:end -->";
 
@@ -1741,17 +1747,21 @@ globs:
 alwaysApply: true
 ---
 
-This project uses ICM (Infinite Context Memory) for persistent memory.
+This project uses ICM (Infinite Context Memory) for persistent memory. Usage is MANDATORY.
 
-At the start of each task, recall relevant context:
+**Recall** — at the start of each task, search for relevant past context:
 ```bash
-icm recall \"topic keywords\"
+icm recall \"query\"
 ```
 
-After completing significant work, store a summary:
-```bash
-icm store -t \"topic\" -c \"summary\"
-```
+**Store** — you MUST store when any of these happens:
+1. Error resolved → `icm store -t errors-resolved -c \"description\" -i high`
+2. Architecture decision → `icm store -t decisions-{project} -c \"description\" -i high`
+3. User preference discovered → `icm store -t preferences -c \"description\" -i critical`
+4. Significant task completed → `icm store -t context-{project} -c \"summary\" -i high`
+5. Conversation exceeds ~20 tool calls without a store → store progress summary
+
+Do this BEFORE responding to the user. Not optional.
 ";
         install_skill(&cursor_rules_dir, "icm.mdc", cursor_icm_rule, "Cursor rule")?;
 

--- a/crates/icm-mcp/src/server.rs
+++ b/crates/icm-mcp/src/server.rs
@@ -111,11 +111,14 @@ Use ICM (Infinite Context Memory) proactively to maintain long-term memory acros
 RECALL (icm_memory_recall): At the start of a task, search for relevant past context — decisions, \
 resolved errors, user preferences. Search only what is relevant, do not dump everything.\n\
 \n\
-STORE (icm_memory_store): Automatically store important information:\n\
-- Architecture decisions → topic: \"decisions-{project}\"\n\
-- Resolved errors with solutions → topic: \"errors-resolved\"\n\
-- User preferences discovered in session → topic: \"preferences\"\n\
-- Project context after significant work → topic: \"context-{project}\"\n\
+STORE (icm_memory_store): You MUST store when ANY of these triggers occur:\n\
+1. Error resolved → topic: \"errors-resolved\", importance: high\n\
+2. Architecture/design decision made → topic: \"decisions-{project}\", importance: high\n\
+3. User preference discovered (correction, feedback) → topic: \"preferences\", importance: critical\n\
+4. Significant task completed (feature, fix, config, review) → topic: \"context-{project}\", importance: high\n\
+5. Conversation exceeds ~20 tool calls without a store → store a progress summary\n\
+\n\
+Do this BEFORE responding to the user. Not after. Not later. Immediately.\n\
 \n\
 Do NOT store: trivial details, information already in CLAUDE.md, ephemeral state.\n\
 \n\


### PR DESCRIPTION
## Summary
- Replace passive "after completing significant work" with 5 explicit MUST triggers
- Applies to: CLI mode (CLAUDE.md, AGENTS.md, GEMINI.md), MCP server instructions, Cursor/Roo rules
- All say "BEFORE responding to the user. Not optional."

## Why
LLMs were ignoring soft "store proactively" instructions — memory was barely saved during sessions. Explicit numbered triggers with MANDATORY/MUST wording improves compliance.

## Triggers
1. Error resolved → `errors-resolved`
2. Architecture decision → `decisions-{project}`  
3. User preference → `preferences`
4. Significant task completed → `context-{project}`
5. >20 tool calls without store → progress summary