### PR TITLE
feat: add .deb/.rpm packages, drop Windows ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,6 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             archive: zip
-          - target: aarch64-pc-windows-msvc
-            os: windows-latest
-            archive: zip
 
     steps:
       - name: Checkout
@@ -92,9 +89,73 @@ jobs:
           name: icm-${{ matrix.target }}
           path: icm-${{ matrix.target }}.${{ matrix.archive }}
 
+  build-deb:
+    name: Build .deb
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-deb
+        run: cargo install cargo-deb
+
+      - name: Build .deb
+        run: cargo deb -p icm-cli
+
+      - name: Prepare artifacts
+        run: |
+          mkdir -p deb-out
+          cp target/debian/*.deb deb-out/
+          # Create version-agnostic name
+          cp target/debian/*.deb deb-out/icm_amd64.deb
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: icm-deb
+          path: deb-out/*.deb
+
+  build-rpm:
+    name: Build .rpm
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    steps:
+      - name: Install dependencies
+        run: dnf install -y git rust cargo rpm-build
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install cargo-generate-rpm
+        run: cargo install cargo-generate-rpm
+
+      - name: Build release
+        run: cargo build --release -p icm-cli
+
+      - name: Generate .rpm
+        run: cargo generate-rpm -p crates/icm-cli
+
+      - name: Prepare artifacts
+        run: |
+          mkdir -p rpm-out
+          cp target/generate-rpm/*.rpm rpm-out/
+          # Create version-agnostic name
+          VERSION=$(grep '^version' crates/icm-cli/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          cp target/generate-rpm/*.rpm "rpm-out/icm-${VERSION}-1.x86_64.rpm"
+          cp target/generate-rpm/*.rpm rpm-out/icm.x86_64.rpm
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: icm-rpm
+          path: rpm-out/*.rpm
+
   release:
     name: Create Release
-    needs: [build]
+    needs: [build, build-deb, build-rpm]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -119,7 +180,7 @@ jobs:
       - name: Flatten artifacts
         run: |
           mkdir -p release
-          find artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" \) -exec cp {} release/ \;
+          find artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.deb" -o -name "*.rpm" \) -exec cp {} release/ \;
 
       - name: Create checksums
         run: |

--- a/crates/icm-cli/Cargo.toml
+++ b/crates/icm-cli/Cargo.toml
@@ -39,3 +39,14 @@ crossterm = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
+
+[package.metadata.deb]
+maintainer = "Patrick Szymkowiak"
+copyright = "2024-2026 Patrick Szymkowiak"
+extended-description = "Permanent memory for AI agents — MCP server with hybrid search, temporal decay, and multilingual embeddings."
+section = "utility"
+priority = "optional"
+assets = [["target/release/icm", "usr/bin/", "755"]]
+
+[package.metadata.generate-rpm]
+assets = [{ source = "target/release/icm", dest = "/usr/bin/icm", mode = "755" }]

--- a/install.ps1
+++ b/install.ps1
@@ -10,8 +10,7 @@ function Get-Arch {
     $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
     switch ($arch) {
         "X64"   { return "x86_64" }
-        "Arm64" { return "aarch64" }
-        default { throw "Unsupported architecture: $arch" }
+        default { throw "Unsupported architecture: $arch. Only x86_64 is supported on Windows." }
     }
 }
 


### PR DESCRIPTION
## Summary

Aligne la release ICM sur RTK : ajout des paquets `.deb` et `.rpm`, suppression de Windows ARM64 (inutile).

**Release assets après merge :**
| Platform | Format |
|----------|--------|
| macOS Intel | `.tar.gz` |
| macOS ARM | `.tar.gz` |
| Linux x64 | `.tar.gz` + `.deb` + `.rpm` |
| Linux ARM64 | `.tar.gz` |
| Windows x64 | `.zip` |

**Nouveaux jobs CI :**
- `build-deb` — `cargo-deb` sur Ubuntu
- `build-rpm` — `cargo-generate-rpm` dans un container Fedora

## Test plan

- [ ] Vérifier que le workflow release produit les 7+ artifacts attendus (prochaine release)
- [x] Metadata deb/rpm ajoutée à `crates/icm-cli/Cargo.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)