### PR TITLE
fix: add openssl-devel to RPM build container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
     container: fedora:latest
     steps:
       - name: Install dependencies
-        run: dnf install -y git rust cargo rpm-build
+        run: dnf install -y git rust cargo rpm-build openssl-devel pkg-config perl-FindBin perl-File-Compare
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fix RPM build failure — Fedora container was missing `openssl-devel` and `pkg-config` needed by `openssl-sys` crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)