### PR TITLE
fix: add gcc-c++ to RPM build container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
     container: fedora:latest
     steps:
       - name: Install dependencies
-        run: dnf install -y git rust cargo rpm-build openssl-devel pkg-config perl-FindBin perl-File-Compare
+        run: dnf install -y git rust cargo rpm-build openssl-devel pkg-config perl-FindBin perl-File-Compare gcc-c++
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
RPM build fails linking: `cannot find -lstdc++`. Adding `gcc-c++` to Fedora deps.