### PR TITLE
fix: JSONC parsing in init + OpenCode plugin extraction (#57, #58)

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1904,10 +1904,7 @@ fn inject_claude_hook(
     detect_patterns: &[&str],
 ) -> Result<String> {
     let mut config: Value = if settings_path.exists() {
-        let content = std::fs::read_to_string(settings_path)
-            .with_context(|| format!("cannot read {}", settings_path.display()))?;
-        serde_json::from_str(&content)
-            .with_context(|| format!("cannot parse {}", settings_path.display()))?
+        parse_json_config(settings_path)?
     } else {
         serde_json::json!({})
     };
@@ -1983,6 +1980,82 @@ fn install_skill(dir: &PathBuf, filename: &str, content: &str, label: &str) -> R
     Ok(())
 }
 
+/// Strip JSONC comments (// and /* */) and handle empty/whitespace-only content.
+/// Returns valid JSON or an empty object.
+fn strip_jsonc_comments(content: &str) -> String {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return "{}".to_string();
+    }
+    let mut result = String::with_capacity(content.len());
+    let mut chars = content.chars().peekable();
+    let mut in_string = false;
+    let mut escape_next = false;
+
+    while let Some(c) = chars.next() {
+        if escape_next {
+            result.push(c);
+            escape_next = false;
+            continue;
+        }
+        if in_string {
+            if c == '\\' {
+                escape_next = true;
+            } else if c == '"' {
+                in_string = false;
+            }
+            result.push(c);
+            continue;
+        }
+        match c {
+            '"' => {
+                in_string = true;
+                result.push(c);
+            }
+            '/' => match chars.peek() {
+                Some('/') => {
+                    chars.next();
+                    // Skip until end of line
+                    for ch in chars.by_ref() {
+                        if ch == '\n' {
+                            result.push('\n');
+                            break;
+                        }
+                    }
+                }
+                Some('*') => {
+                    chars.next();
+                    // Skip until */
+                    let mut prev = ' ';
+                    for ch in chars.by_ref() {
+                        if prev == '*' && ch == '/' {
+                            break;
+                        }
+                        prev = ch;
+                    }
+                }
+                _ => result.push(c),
+            },
+            _ => result.push(c),
+        }
+    }
+    let r = result.trim();
+    if r.is_empty() {
+        "{}".to_string()
+    } else {
+        result
+    }
+}
+
+/// Parse a JSON/JSONC config file, handling comments and empty files gracefully.
+fn parse_json_config(config_path: &std::path::Path) -> Result<Value> {
+    let content = std::fs::read_to_string(config_path)
+        .with_context(|| format!("cannot read {}", config_path.display()))?;
+    let clean = strip_jsonc_comments(&content);
+    serde_json::from_str(&clean)
+        .with_context(|| format!("invalid JSON in {}", config_path.display()))
+}
+
 /// Inject ICM MCP server into a JSON config file. Returns a status string.
 /// `servers_key` is the JSON key for the servers object (e.g. "mcpServers", "servers", "context_servers").
 fn inject_mcp_server(
@@ -1993,12 +2066,8 @@ fn inject_mcp_server(
 ) -> Result<String> {
     // Read existing config or create empty object
     let mut config: Value = if config_path.exists() {
-        let content = std::fs::read_to_string(config_path)
-            .with_context(|| format!("cannot read {}", config_path.display()))?;
-        serde_json::from_str(&content)
-            .with_context(|| format!("invalid JSON in {}", config_path.display()))?
+        parse_json_config(config_path)?
     } else {
-        // Create parent dirs if needed
         if let Some(parent) = config_path.parent() {
             std::fs::create_dir_all(parent).ok();
         }
@@ -2049,10 +2118,7 @@ fn inject_mcp_server(
 /// Inject ICM MCP server into Zed settings.json (uses `context_servers` with nested `command` object).
 fn inject_zed_mcp_server(config_path: &PathBuf, name: &str, bin_path: &str) -> Result<String> {
     let mut config: Value = if config_path.exists() {
-        let content = std::fs::read_to_string(config_path)
-            .with_context(|| format!("cannot read {}", config_path.display()))?;
-        serde_json::from_str(&content)
-            .with_context(|| format!("invalid JSON in {}", config_path.display()))?
+        parse_json_config(config_path)?
     } else {
         if let Some(parent) = config_path.parent() {
             std::fs::create_dir_all(parent).ok();
@@ -2143,10 +2209,7 @@ fn inject_codex_mcp_server(config_path: &PathBuf, name: &str, icm_bin: &str) -> 
 /// Inject ICM MCP server into OpenCode config (uses "mcp" key, command is array).
 fn inject_opencode_mcp_server(config_path: &PathBuf, name: &str, icm_bin: &str) -> Result<String> {
     let mut config: Value = if config_path.exists() {
-        let content = std::fs::read_to_string(config_path)
-            .with_context(|| format!("cannot read {}", config_path.display()))?;
-        serde_json::from_str(&content)
-            .with_context(|| format!("invalid JSON in {}", config_path.display()))?
+        parse_json_config(config_path)?
     } else {
         if let Some(parent) = config_path.parent() {
             std::fs::create_dir_all(parent).ok();

--- a/plugins/opencode-icm.js
+++ b/plugins/opencode-icm.js
@@ -5,7 +5,7 @@
 // Layer 1: experimental.session.compacting → extract from conversation before compaction
 // Layer 2: session.created → inject recalled context
 
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 
 const ICM_BIN = process.env.ICM_BIN || "icm";
 let toolCallCount = 0;
@@ -13,9 +13,23 @@ const EXTRACT_EVERY = 15;
 
 function icm(...args) {
   try {
-    return execSync(`${ICM_BIN} --no-embeddings ${args.join(" ")}`, {
+    return execFileSync(ICM_BIN, args, {
       encoding: "utf-8",
-      timeout: 5000,
+      timeout: 10000,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+// Pass text via stdin to avoid shell escaping issues
+function icmWithStdin(args, input) {
+  try {
+    return execFileSync(ICM_BIN, args, {
+      encoding: "utf-8",
+      timeout: 10000,
+      input: input,
       stdio: ["pipe", "pipe", "pipe"],
     }).trim();
   } catch {
@@ -31,11 +45,19 @@ function getProject(directory) {
 export const IcmPlugin = async ({ directory }) => {
   const project = getProject(directory);
 
+  // Verify icm binary is available
+  const version = icm("--version");
+  if (!version) {
+    console.error("[icm] icm binary not found in PATH — plugin disabled");
+    return {};
+  }
+  console.error(`[icm] plugin loaded (${version})`);
+
   return {
     // Layer 0: extract facts from tool output every N calls
     "tool.execute.after": async ({ tool, output }) => {
       // Skip ICM's own tools
-      if (tool?.startsWith("icm") || tool?.startsWith("mcp__icm__")) return;
+      if (!tool || tool.startsWith("icm") || tool.startsWith("mcp__icm__")) return;
 
       toolCallCount++;
       if (toolCallCount < EXTRACT_EVERY) return;
@@ -44,8 +66,8 @@ export const IcmPlugin = async ({ directory }) => {
       if (!output || typeof output !== "string" || output.length < 20) return;
 
       try {
-        const escaped = output.slice(0, 4000).replace(/'/g, "'\\''");
-        icm("extract", "-p", project, "-t", `'${escaped}'`);
+        // Use stdin instead of -t flag to avoid shell escaping issues
+        icmWithStdin(["extract", "-p", project], output.slice(0, 4000));
       } catch {
         // silent
       }
@@ -74,8 +96,8 @@ export const IcmPlugin = async ({ directory }) => {
       if (text.length < 50) return;
 
       try {
-        const escaped = text.replace(/'/g, "'\\''");
-        icm("extract", "--store-raw", "-p", project, "-t", `'${escaped}'`);
+        // Use stdin instead of -t flag to avoid shell escaping issues
+        icmWithStdin(["extract", "--store-raw", "-p", project], text);
       } catch {
         // silent
       }
@@ -84,7 +106,7 @@ export const IcmPlugin = async ({ directory }) => {
     // Layer 2: recall context at session start
     "session.created": async () => {
       try {
-        const ctx = icm("recall-context", `"${project}"`, "--limit", "5");
+        const ctx = icm("recall-context", project, "--limit", "5");
         if (ctx) {
           console.error(`[icm] recalled ${ctx.split("\n").length} lines of context`);
         }


### PR DESCRIPTION
## Summary

Fixes #57 and #58.

**#57 — JSON parsing bug on `icm init`:**
- Added `strip_jsonc_comments()` to handle `//` and `/* */` comments in config files (VS Code, Cursor, Zed all use JSONC)
- Added `parse_json_config()` helper that handles empty files and whitespace-only content
- Applied to all 4 JSON injection functions

**#58 — OpenCode auto-extraction not working:**
- Root cause: `execSync` with shell quoting broke on text content containing quotes/special chars
- Fix: switched to `execFileSync` (no shell) + pass text via `stdin` instead of `-t` flag
- Added binary availability check at plugin load with version logging
- Increased timeout 5s → 10s
- Removed unnecessary `--no-embeddings` flag

## Test plan
- [x] 185 tests pass
- [x] Tested JSONC parsing with comments, empty files, comments-only files
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)