### PR TITLE
fix: OpenCode plugin — correct hook signature + output path

### DIFF
--- a/plugins/opencode-icm.ts
+++ b/plugins/opencode-icm.ts
@@ -6,9 +6,23 @@
 // Layer 2: session.created → inject recalled context
 
 import type { Plugin } from "@opencode-ai/plugin"
+import { execFileSync } from "child_process"
 
 const EXTRACT_EVERY = 3
 let toolCallCount = 0
+
+function icmExtract(args: string[], input: string): void {
+  try {
+    execFileSync("icm", args, {
+      encoding: "utf-8",
+      timeout: 10000,
+      input,
+      stdio: ["pipe", "pipe", "pipe"],
+    })
+  } catch {
+    // silent — extraction is best-effort
+  }
+}
 
 export const IcmPlugin: Plugin = async ({ $, directory }) => {
   const project = directory?.split("/").pop() || "project"
@@ -26,25 +40,28 @@ export const IcmPlugin: Plugin = async ({ $, directory }) => {
 
   return {
     // Layer 0: extract facts from tool output every N calls
-    "tool.execute.after": async ({ tool, output }) => {
+    "tool.execute.after": async (input: any, result: any) => {
+      const tool = String(input?.tool ?? "")
       if (!tool || tool.startsWith("icm") || tool.startsWith("mcp__icm__")) return
 
       toolCallCount++
       if (toolCallCount < EXTRACT_EVERY) return
       toolCallCount = 0
 
+      // OpenCode puts tool output in result.metadata.output
+      const output =
+        result?.metadata?.output ?? result?.output ?? (typeof result === "string" ? result : "")
       if (!output || typeof output !== "string" || output.length < 20) return
 
       try {
-        const text = output.slice(0, 4000)
-        await $`echo ${text} | icm extract --store-raw -p ${project}`.quiet().nothrow()
+        icmExtract(["extract", "--store-raw", "-p", project], output.slice(0, 4000))
       } catch {
         // silent
       }
     },
 
     // Layer 1: extract from conversation before compaction
-    "experimental.session.compacting": async ({ messages }) => {
+    "experimental.session.compacting": async ({ messages }: any) => {
       if (!messages || !Array.isArray(messages)) return
 
       const text = messages
@@ -65,7 +82,7 @@ export const IcmPlugin: Plugin = async ({ $, directory }) => {
       if (text.length < 50) return
 
       try {
-        await $`echo ${text} | icm extract --store-raw -p ${project}`.quiet().nothrow()
+        icmExtract(["extract", "--store-raw", "-p", project], text)
       } catch {
         // silent
       }


### PR DESCRIPTION
## Summary

The OpenCode plugin wasn't extracting anything because:

1. **Wrong hook signature**: used `({ tool, output })` but OpenCode passes `(input, result)` 
2. **Wrong output path**: output is in `result.metadata.output`, not `result.output`

**Verified working** on OpenCode 1.3.17 — extraction fires and stores memories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)