### PR TITLE
feat: add MCP icm_learn tool + forget --topic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.8"
+version = "0.10.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1269,6 +1269,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
+ "tempfile",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -1285,6 +1286,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "toml",
  "ulid",
 ]
 
@@ -1298,6 +1300,7 @@ dependencies = [
  "icm-store",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
 ]
 

--- a/crates/icm-cli/src/learn_tests.rs
+++ b/crates/icm-cli/src/learn_tests.rs
@@ -1,0 +1,192 @@
+#[cfg(test)]
+mod tests {
+    use icm_core::learn::learn_project;
+    use icm_core::MemoirStore;
+    use icm_store::SqliteStore;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn test_store() -> (TempDir, SqliteStore) {
+        let tmp = TempDir::new().expect("failed to create temp dir");
+        let db_path = tmp.path().join("test.db");
+        let store = SqliteStore::with_dims(&db_path, 384).expect("failed to create store");
+        (tmp, store)
+    }
+
+    #[test]
+    fn test_learn_rust_project() {
+        let (tmp, store) = test_store();
+
+        // Create a fake Rust workspace project
+        let project_dir = tmp.path().join("my-project");
+        fs::create_dir_all(project_dir.join("crates/core/src")).unwrap();
+        fs::create_dir_all(project_dir.join("crates/cli/src")).unwrap();
+        fs::create_dir_all(project_dir.join(".github/workflows")).unwrap();
+        fs::create_dir_all(project_dir.join("scripts")).unwrap();
+
+        // Root Cargo.toml (workspace)
+        fs::write(
+            project_dir.join("Cargo.toml"),
+            r#"
+[workspace]
+resolver = "2"
+members = ["crates/*"]
+
+[workspace.dependencies]
+serde = "1.0"
+tokio = { version = "1", features = ["full"] }
+anyhow = "1"
+"#,
+        )
+        .unwrap();
+
+        // Core crate
+        fs::write(
+            project_dir.join("crates/core/Cargo.toml"),
+            r#"
+[package]
+name = "my-core"
+version = "0.1.0"
+edition = "2021"
+description = "Core library"
+"#,
+        )
+        .unwrap();
+        fs::write(
+            project_dir.join("crates/core/src/lib.rs"),
+            "pub fn hello() {}",
+        )
+        .unwrap();
+
+        // CLI crate
+        fs::write(
+            project_dir.join("crates/cli/Cargo.toml"),
+            r#"
+[package]
+name = "my-cli"
+version = "0.1.0"
+edition = "2021"
+description = "CLI tool"
+"#,
+        )
+        .unwrap();
+        fs::write(project_dir.join("crates/cli/src/main.rs"), "fn main() {}").unwrap();
+
+        // GitHub workflow
+        fs::write(
+            project_dir.join(".github/workflows/ci.yml"),
+            "name: CI\non: push\n",
+        )
+        .unwrap();
+
+        // Script
+        fs::write(
+            project_dir.join("scripts/build.sh"),
+            "#!/bin/bash\ncargo build",
+        )
+        .unwrap();
+
+        // Makefile
+        fs::write(project_dir.join("Makefile"), "build:\n\tcargo build").unwrap();
+
+        // Run learn
+        let result = learn_project(&store, &project_dir, None).expect("learn_project failed");
+
+        // Verify memoir was created
+        let memoir = store.get_memoir(&result.memoir_id).unwrap().unwrap();
+        assert_eq!(memoir.name, "my-project");
+
+        // Verify concepts
+        let concepts = store.list_concepts(&result.memoir_id).unwrap();
+        let kinds: Vec<String> = concepts
+            .iter()
+            .flat_map(|c| {
+                c.labels
+                    .iter()
+                    .map(|l| format!("{}:{}", l.namespace, l.value))
+            })
+            .collect();
+
+        assert!(kinds.contains(&"kind:project".to_string()));
+        assert!(kinds.contains(&"kind:dependency".to_string()));
+        assert!(kinds.contains(&"kind:module".to_string()));
+        assert!(kinds.contains(&"kind:entrypoint".to_string()));
+        assert!(kinds.contains(&"kind:config".to_string()));
+        assert!(kinds.contains(&"kind:script".to_string()));
+
+        // Verify links exist
+        let links = store.get_links_for_memoir(&result.memoir_id).unwrap();
+        assert!(!links.is_empty(), "should have created links");
+
+        // Verify we have at least: 1 project + 3 deps + 2 modules + entrypoints + configs + scripts
+        assert!(
+            concepts.len() >= 7,
+            "expected at least 7 concepts, got {}",
+            concepts.len()
+        );
+    }
+
+    #[test]
+    fn test_learn_node_project() {
+        let (tmp, store) = test_store();
+
+        let project_dir = tmp.path().join("my-node-app");
+        fs::create_dir_all(project_dir.join("src")).unwrap();
+
+        fs::write(
+            project_dir.join("package.json"),
+            r#"{
+  "name": "my-node-app",
+  "version": "1.0.0",
+  "description": "A Node.js app",
+  "dependencies": {
+    "express": "^4.18.0",
+    "lodash": "^4.17.0"
+  }
+}"#,
+        )
+        .unwrap();
+
+        fs::write(project_dir.join("index.ts"), "console.log('hello')").unwrap();
+        fs::write(project_dir.join("tsconfig.json"), "{}").unwrap();
+
+        let result = learn_project(&store, &project_dir, Some("node-test")).expect("learn failed");
+
+        let memoir = store.get_memoir(&result.memoir_id).unwrap().unwrap();
+        assert_eq!(memoir.name, "node-test");
+
+        let concepts = store.list_concepts(&result.memoir_id).unwrap();
+        assert!(
+            concepts.len() >= 4,
+            "expected at least 4 concepts (project + 2 deps + entrypoint), got {}",
+            concepts.len()
+        );
+    }
+
+    #[test]
+    fn test_learn_replaces_existing_memoir() {
+        let (tmp, store) = test_store();
+
+        let project_dir = tmp.path().join("replace-test");
+        fs::create_dir_all(&project_dir).unwrap();
+        fs::write(
+            project_dir.join("Cargo.toml"),
+            r#"
+[package]
+name = "replace-test"
+version = "0.1.0"
+edition = "2021"
+"#,
+        )
+        .unwrap();
+
+        // First learn
+        let r1 = learn_project(&store, &project_dir, Some("replace-test")).unwrap();
+        // Second learn should replace
+        let r2 = learn_project(&store, &project_dir, Some("replace-test")).unwrap();
+
+        assert_ne!(r1.memoir_id, r2.memoir_id, "should create a new memoir");
+        // Old memoir should be gone
+        assert!(store.get_memoir(&r1.memoir_id).unwrap().is_none());
+    }
+}

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -3,7 +3,8 @@ mod bench_knowledge;
 pub mod cloud;
 mod config;
 mod extract;
-mod learn;
+#[cfg(test)]
+mod learn_tests;
 #[cfg(feature = "tui")]
 mod tui;
 
@@ -97,10 +98,14 @@ enum Commands {
         sort: SortField,
     },
 
-    /// Delete a memory by ID
+    /// Forget (delete) a memory by ID, or all memories in a topic
     Forget {
-        /// Memory ID
-        id: String,
+        /// Memory ID to forget
+        id: Option<String>,
+
+        /// Delete all memories in this topic
+        #[arg(short, long)]
+        topic: Option<String>,
     },
 
     /// Update an existing memory in-place
@@ -757,7 +762,7 @@ fn main() -> Result<()> {
             )
         }
         Commands::List { topic, all, sort } => cmd_list(&store, topic.as_deref(), all, sort),
-        Commands::Forget { id } => cmd_forget(&store, &id),
+        Commands::Forget { id, topic } => cmd_forget(&store, id.as_deref(), topic.as_deref()),
         Commands::Update {
             id,
             content,
@@ -885,7 +890,8 @@ fn main() -> Result<()> {
             let dir = dir
                 .map(PathBuf::from)
                 .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
-            learn::learn_project(&store, &dir, name.as_deref())?;
+            let result = icm_core::learn_project(&store, &dir, name.as_deref())?;
+            println!("{result}");
             Ok(())
         }
         Commands::Config => cmd_config(),
@@ -1066,9 +1072,24 @@ fn cmd_list(store: &SqliteStore, topic: Option<&str>, all: bool, sort: SortField
     Ok(())
 }
 
-fn cmd_forget(store: &SqliteStore, id: &str) -> Result<()> {
-    store.delete(id)?;
-    println!("Deleted: {id}");
+fn cmd_forget(store: &SqliteStore, id: Option<&str>, topic: Option<&str>) -> Result<()> {
+    match (id, topic) {
+        (_, Some(topic)) => {
+            let memories = store.get_by_topic(topic)?;
+            let count = memories.len();
+            for m in &memories {
+                store.delete(&m.id)?;
+            }
+            println!("Deleted {count} memories from topic: {topic}");
+        }
+        (Some(id), None) => {
+            store.delete(id)?;
+            println!("Deleted: {id}");
+        }
+        (None, None) => {
+            anyhow::bail!("either --topic or a memory ID is required");
+        }
+    }
     Ok(())
 }
 

--- a/crates/icm-core/Cargo.toml
+++ b/crates/icm-core/Cargo.toml
@@ -13,5 +13,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 ulid = { workspace = true }
+toml = { workspace = true }
 fastembed = { workspace = true, optional = true }
 directories = { workspace = true, optional = true }

--- a/crates/icm-core/src/learn.rs
+++ b/crates/icm-core/src/learn.rs
@@ -1,19 +1,40 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
-use icm_core::{Concept, ConceptLink, Label, Memoir, MemoirStore, Relation};
-use icm_store::SqliteStore;
-use tracing::info;
+use crate::error::IcmResult;
+use crate::memoir::{Concept, ConceptLink, Label, Memoir, Relation};
+use crate::memoir_store::MemoirStore;
+
+/// Result of learning a project.
+#[derive(Debug, Clone)]
+pub struct LearnResult {
+    pub memoir_id: String,
+    pub project_name: String,
+    pub total_concepts: usize,
+    pub link_count: usize,
+}
+
+impl std::fmt::Display for LearnResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Learned {}: {} concepts, {} links (memoir: {})",
+            self.project_name, self.total_concepts, self.link_count, self.memoir_id
+        )
+    }
+}
 
 /// Learn a project by scanning its directory and creating a Memoir knowledge graph.
-pub fn learn_project(store: &SqliteStore, dir: &Path, name: Option<&str>) -> Result<String> {
+pub fn learn_project(
+    store: &dyn MemoirStore,
+    dir: &Path,
+    name: Option<&str>,
+) -> IcmResult<LearnResult> {
     let project_name = name
         .or_else(|| dir.file_name().and_then(|f| f.to_str()))
         .unwrap_or("project");
 
     // Check if memoir already exists — delete and recreate
     if let Ok(Some(existing)) = store.get_memoir_by_name(project_name) {
-        info!("Memoir '{}' already exists — replacing", project_name);
         store.delete_memoir(&existing.id)?;
     }
 
@@ -96,11 +117,12 @@ pub fn learn_project(store: &SqliteStore, dir: &Path, name: Option<&str>) -> Res
         + config_ids.len()
         + script_ids.len();
 
-    println!(
-        "Learned {project_name}: {total_concepts} concepts, {link_count} links (memoir: {memoir_id})"
-    );
-
-    Ok(memoir_id)
+    Ok(LearnResult {
+        memoir_id,
+        project_name: project_name.to_string(),
+        total_concepts,
+        link_count,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -108,12 +130,12 @@ pub fn learn_project(store: &SqliteStore, dir: &Path, name: Option<&str>) -> Res
 // ---------------------------------------------------------------------------
 
 fn add_concept(
-    store: &SqliteStore,
+    store: &dyn MemoirStore,
     memoir_id: &str,
     name: &str,
     definition: &str,
     kind: &str,
-) -> Result<String> {
+) -> IcmResult<String> {
     let mut concept = Concept::new(
         memoir_id.to_string(),
         name.to_string(),
@@ -131,11 +153,11 @@ fn add_concept(
 
 /// Read project identity from Cargo.toml / package.json / pyproject.toml / go.mod.
 fn scan_project_identity(
-    store: &SqliteStore,
+    store: &dyn MemoirStore,
     memoir_id: &str,
     dir: &Path,
     project_name: &str,
-) -> Result<String> {
+) -> IcmResult<String> {
     let mut description = format!("Project: {project_name}");
 
     if let Some(info) = read_cargo_toml(dir) {
@@ -148,12 +170,15 @@ fn scan_project_identity(
         description = info;
     }
 
-    info!("Project identity: {}", project_name);
     add_concept(store, memoir_id, project_name, &description, "project")
 }
 
 /// Extract top dependencies from config files.
-fn scan_dependencies(store: &SqliteStore, memoir_id: &str, dir: &Path) -> Result<Vec<String>> {
+fn scan_dependencies(
+    store: &dyn MemoirStore,
+    memoir_id: &str,
+    dir: &Path,
+) -> IcmResult<Vec<String>> {
     let mut dep_ids = Vec::new();
     let deps = collect_dependencies(dir);
 
@@ -163,7 +188,6 @@ fn scan_dependencies(store: &SqliteStore, memoir_id: &str, dir: &Path) -> Result
         } else {
             format!("Dependency: {name} ({version})")
         };
-        info!("Dependency: {}", name);
         let id = add_concept(store, memoir_id, &name, &def, "dependency")?;
         dep_ids.push(id);
     }
@@ -173,12 +197,15 @@ fn scan_dependencies(store: &SqliteStore, memoir_id: &str, dir: &Path) -> Result
 
 /// Scan workspace members / top-level modules.
 /// Returns (concept_id, module_name) pairs.
-fn scan_modules(store: &SqliteStore, memoir_id: &str, dir: &Path) -> Result<Vec<(String, String)>> {
+fn scan_modules(
+    store: &dyn MemoirStore,
+    memoir_id: &str,
+    dir: &Path,
+) -> IcmResult<Vec<(String, String)>> {
     let mut module_ids = Vec::new();
     let modules = collect_modules(dir);
 
     for (name, def) in &modules {
-        info!("Module: {}", name);
         let id = add_concept(store, memoir_id, name, def, "module")?;
         module_ids.push((id, name.clone()));
     }
@@ -189,22 +216,17 @@ fn scan_modules(store: &SqliteStore, memoir_id: &str, dir: &Path) -> Result<Vec<
 /// Find entry point files (main.rs, lib.rs, index.ts, etc.).
 /// Returns (concept_id, Option<parent_module_name>).
 fn scan_entrypoints(
-    store: &SqliteStore,
+    store: &dyn MemoirStore,
     memoir_id: &str,
     dir: &Path,
     modules: &[(String, String)],
-) -> Result<Vec<(String, Option<String>)>> {
+) -> IcmResult<Vec<(String, Option<String>)>> {
     let mut result = Vec::new();
     let entrypoints = collect_entrypoints(dir);
 
     for (rel_path, parent) in &entrypoints {
-        let name = rel_path
-            .file_name()
-            .and_then(|f| f.to_str())
-            .unwrap_or("unknown");
         let path_str = rel_path.display().to_string();
         let def = format!("Entry point: {path_str}");
-        info!("Entrypoint: {}", path_str);
 
         // Resolve parent module
         let parent_module = parent
@@ -213,7 +235,6 @@ fn scan_entrypoints(
 
         let concept_name = path_str;
         let id = add_concept(store, memoir_id, &concept_name, &def, "entrypoint")?;
-        let _ = name; // used for logging context only
         result.push((id, parent_module));
     }
 
@@ -221,13 +242,12 @@ fn scan_entrypoints(
 }
 
 /// Find config/CI files.
-fn scan_configs(store: &SqliteStore, memoir_id: &str, dir: &Path) -> Result<Vec<String>> {
+fn scan_configs(store: &dyn MemoirStore, memoir_id: &str, dir: &Path) -> IcmResult<Vec<String>> {
     let mut ids = Vec::new();
     let configs = collect_configs(dir);
 
     for (rel_path, def) in &configs {
         let path_str = rel_path.display().to_string();
-        info!("Config: {}", path_str);
         let id = add_concept(store, memoir_id, &path_str, def, "config")?;
         ids.push(id);
     }
@@ -236,13 +256,12 @@ fn scan_configs(store: &SqliteStore, memoir_id: &str, dir: &Path) -> Result<Vec<
 }
 
 /// Find scripts (Makefile, justfile, etc.).
-fn scan_scripts(store: &SqliteStore, memoir_id: &str, dir: &Path) -> Result<Vec<String>> {
+fn scan_scripts(store: &dyn MemoirStore, memoir_id: &str, dir: &Path) -> IcmResult<Vec<String>> {
     let mut ids = Vec::new();
     let scripts = collect_scripts(dir);
 
     for (rel_path, def) in &scripts {
         let path_str = rel_path.display().to_string();
-        info!("Script: {}", path_str);
         let id = add_concept(store, memoir_id, &path_str, def, "script")?;
         ids.push(id);
     }
@@ -825,200 +844,4 @@ fn collect_scripts(dir: &Path) -> Vec<(PathBuf, String)> {
     }
 
     result
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-    use tempfile::TempDir;
-
-    fn test_store() -> (TempDir, SqliteStore) {
-        let tmp = TempDir::new().expect("failed to create temp dir");
-        let db_path = tmp.path().join("test.db");
-        let store = SqliteStore::with_dims(&db_path, 384).expect("failed to create store");
-        (tmp, store)
-    }
-
-    #[test]
-    fn test_learn_rust_project() {
-        let (tmp, store) = test_store();
-
-        // Create a fake Rust workspace project
-        let project_dir = tmp.path().join("my-project");
-        fs::create_dir_all(project_dir.join("crates/core/src")).unwrap();
-        fs::create_dir_all(project_dir.join("crates/cli/src")).unwrap();
-        fs::create_dir_all(project_dir.join(".github/workflows")).unwrap();
-        fs::create_dir_all(project_dir.join("scripts")).unwrap();
-
-        // Root Cargo.toml (workspace)
-        fs::write(
-            project_dir.join("Cargo.toml"),
-            r#"
-[workspace]
-resolver = "2"
-members = ["crates/*"]
-
-[workspace.dependencies]
-serde = "1.0"
-tokio = { version = "1", features = ["full"] }
-anyhow = "1"
-"#,
-        )
-        .unwrap();
-
-        // Core crate
-        fs::write(
-            project_dir.join("crates/core/Cargo.toml"),
-            r#"
-[package]
-name = "my-core"
-version = "0.1.0"
-edition = "2021"
-description = "Core library"
-"#,
-        )
-        .unwrap();
-        fs::write(
-            project_dir.join("crates/core/src/lib.rs"),
-            "pub fn hello() {}",
-        )
-        .unwrap();
-
-        // CLI crate
-        fs::write(
-            project_dir.join("crates/cli/Cargo.toml"),
-            r#"
-[package]
-name = "my-cli"
-version = "0.1.0"
-edition = "2021"
-description = "CLI tool"
-"#,
-        )
-        .unwrap();
-        fs::write(project_dir.join("crates/cli/src/main.rs"), "fn main() {}").unwrap();
-
-        // GitHub workflow
-        fs::write(
-            project_dir.join(".github/workflows/ci.yml"),
-            "name: CI\non: push\n",
-        )
-        .unwrap();
-
-        // Script
-        fs::write(
-            project_dir.join("scripts/build.sh"),
-            "#!/bin/bash\ncargo build",
-        )
-        .unwrap();
-
-        // Makefile
-        fs::write(project_dir.join("Makefile"), "build:\n\tcargo build").unwrap();
-
-        // Run learn
-        let memoir_id = learn_project(&store, &project_dir, None).expect("learn_project failed");
-
-        // Verify memoir was created
-        let memoir = store.get_memoir(&memoir_id).unwrap().unwrap();
-        assert_eq!(memoir.name, "my-project");
-
-        // Verify concepts
-        let concepts = store.list_concepts(&memoir_id).unwrap();
-        let kinds: Vec<String> = concepts
-            .iter()
-            .flat_map(|c| {
-                c.labels
-                    .iter()
-                    .map(|l| format!("{}:{}", l.namespace, l.value))
-            })
-            .collect();
-
-        assert!(kinds.contains(&"kind:project".to_string()));
-        assert!(kinds.contains(&"kind:dependency".to_string()));
-        assert!(kinds.contains(&"kind:module".to_string()));
-        assert!(kinds.contains(&"kind:entrypoint".to_string()));
-        assert!(kinds.contains(&"kind:config".to_string()));
-        assert!(kinds.contains(&"kind:script".to_string()));
-
-        // Verify links exist
-        let links = store.get_links_for_memoir(&memoir_id).unwrap();
-        assert!(!links.is_empty(), "should have created links");
-
-        // Verify we have at least: 1 project + 3 deps + 2 modules + entrypoints + configs + scripts
-        assert!(
-            concepts.len() >= 7,
-            "expected at least 7 concepts, got {}",
-            concepts.len()
-        );
-    }
-
-    #[test]
-    fn test_learn_node_project() {
-        let (tmp, store) = test_store();
-
-        let project_dir = tmp.path().join("my-node-app");
-        fs::create_dir_all(project_dir.join("src")).unwrap();
-
-        fs::write(
-            project_dir.join("package.json"),
-            r#"{
-  "name": "my-node-app",
-  "version": "1.0.0",
-  "description": "A Node.js app",
-  "dependencies": {
-    "express": "^4.18.0",
-    "lodash": "^4.17.0"
-  }
-}"#,
-        )
-        .unwrap();
-
-        fs::write(project_dir.join("index.ts"), "console.log('hello')").unwrap();
-        fs::write(project_dir.join("tsconfig.json"), "{}").unwrap();
-
-        let memoir_id =
-            learn_project(&store, &project_dir, Some("node-test")).expect("learn failed");
-
-        let memoir = store.get_memoir(&memoir_id).unwrap().unwrap();
-        assert_eq!(memoir.name, "node-test");
-
-        let concepts = store.list_concepts(&memoir_id).unwrap();
-        assert!(
-            concepts.len() >= 4,
-            "expected at least 4 concepts (project + 2 deps + entrypoint), got {}",
-            concepts.len()
-        );
-    }
-
-    #[test]
-    fn test_learn_replaces_existing_memoir() {
-        let (tmp, store) = test_store();
-
-        let project_dir = tmp.path().join("replace-test");
-        fs::create_dir_all(&project_dir).unwrap();
-        fs::write(
-            project_dir.join("Cargo.toml"),
-            r#"
-[package]
-name = "replace-test"
-version = "0.1.0"
-edition = "2021"
-"#,
-        )
-        .unwrap();
-
-        // First learn
-        let id1 = learn_project(&store, &project_dir, Some("replace-test")).unwrap();
-        // Second learn should replace
-        let id2 = learn_project(&store, &project_dir, Some("replace-test")).unwrap();
-
-        assert_ne!(id1, id2, "should create a new memoir");
-        // Old memoir should be gone
-        assert!(store.get_memoir(&id1).unwrap().is_none());
-    }
 }

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod fastembed_embedder;
 pub mod feedback;
 pub mod feedback_store;
+pub mod learn;
 pub mod memoir;
 pub mod memoir_store;
 pub mod memory;
@@ -24,6 +25,8 @@ pub use memory::{
     Importance, Memory, MemorySource, PatternCluster, Scope, StoreStats, TopicHealth,
 };
 pub use store::MemoryStore;
+
+pub use learn::{learn_project, LearnResult};
 
 /// Common message for empty search results.
 pub const MSG_NO_MEMORIES: &str = "No memories found.";

--- a/crates/icm-mcp/Cargo.toml
+++ b/crates/icm-mcp/Cargo.toml
@@ -15,3 +15,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -130,6 +130,37 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
             }
         }),
         json!({
+            "name": "icm_memory_forget_topic",
+            "description": "Delete ALL memories in a topic. Use to clear an entire topic at once.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "topic": {
+                        "type": "string",
+                        "description": "Topic whose memories should all be deleted"
+                    }
+                },
+                "required": ["topic"]
+            }
+        }),
+        json!({
+            "name": "icm_learn",
+            "description": "Scan a project directory and create a Memoir knowledge graph with its structure, dependencies, modules, and config files.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "directory": {
+                        "type": "string",
+                        "description": "Project directory to scan (default: current working directory)"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Memoir name (default: directory name)"
+                    }
+                }
+            }
+        }),
+        json!({
             "name": "icm_memory_consolidate",
             "description": "Consolidate all memories of a topic into a single summary. Useful when a topic accumulates too many entries.",
             "inputSchema": {
@@ -538,6 +569,7 @@ pub fn call_tool(
         "icm_memory_store" => tool_store(store, embedder, args, compact),
         "icm_memory_recall" => tool_recall(store, embedder, args, compact),
         "icm_memory_forget" => tool_forget(store, args),
+        "icm_memory_forget_topic" => tool_forget_topic(store, args),
         "icm_memory_update" => tool_update(store, embedder, args),
         "icm_memory_consolidate" => tool_consolidate(store, args),
         "icm_memory_list_topics" => tool_list_topics(store),
@@ -556,6 +588,8 @@ pub fn call_tool(
         "icm_memoir_link" => tool_memoir_link(store, args),
         "icm_memoir_inspect" => tool_memoir_inspect(store, args),
         "icm_memoir_export" => tool_memoir_export(store, args),
+        // Learn tool
+        "icm_learn" => tool_learn(store, args),
         // Feedback tools
         "icm_feedback_record" => tool_feedback_record(store, args, compact),
         "icm_feedback_search" => tool_feedback_search(store, args),
@@ -853,6 +887,43 @@ fn tool_forget(store: &SqliteStore, args: &Value) -> ToolResult {
     match store.delete(id) {
         Ok(()) => ToolResult::text(format!("Deleted memory: {id}")),
         Err(e) => ToolResult::error(format!("failed to delete: {e}")),
+    }
+}
+
+fn tool_forget_topic(store: &SqliteStore, args: &Value) -> ToolResult {
+    let topic = match get_str(args, "topic") {
+        Some(t) => t,
+        None => return ToolResult::error("missing required field: topic".into()),
+    };
+
+    let memories = match store.get_by_topic(topic) {
+        Ok(m) => m,
+        Err(e) => return ToolResult::error(format!("failed to get memories: {e}")),
+    };
+
+    let count = memories.len();
+    for m in &memories {
+        if let Err(e) = store.delete(&m.id) {
+            return ToolResult::error(format!("failed to delete memory {}: {e}", m.id));
+        }
+    }
+
+    ToolResult::text(format!("Deleted {count} memories from topic: {topic}"))
+}
+
+fn tool_learn(store: &SqliteStore, args: &Value) -> ToolResult {
+    let dir_str = get_str(args, "directory").unwrap_or(".");
+    let dir = std::path::PathBuf::from(dir_str);
+
+    if !dir.exists() || !dir.is_dir() {
+        return ToolResult::error(format!("directory not found: {}", dir.display()));
+    }
+
+    let name = get_str(args, "name");
+
+    match icm_core::learn_project(store, &dir, name) {
+        Ok(result) => ToolResult::text(result.to_string()),
+        Err(e) => ToolResult::error(format!("learn failed: {e}")),
     }
 }
 
@@ -2629,5 +2700,109 @@ mod tests {
             false,
         );
         assert!(!result.is_error);
+    }
+
+    #[test]
+    fn test_forget_topic() {
+        let store = test_store();
+
+        // Store 3 memories in topic "doomed"
+        for i in 0..3 {
+            let r = call_tool(
+                &store,
+                None,
+                "icm_memory_store",
+                &json!({"topic": "doomed", "content": format!("memory {i}")}),
+                false,
+            );
+            assert!(!r.is_error);
+        }
+
+        // Verify they exist
+        let topics = call_tool(&store, None, "icm_memory_list_topics", &json!({}), false);
+        assert!(topics.content[0].text.contains("doomed"));
+
+        // Forget the topic
+        let result = call_tool(
+            &store,
+            None,
+            "icm_memory_forget_topic",
+            &json!({"topic": "doomed"}),
+            false,
+        );
+        assert!(!result.is_error);
+        assert!(result.content[0].text.contains("Deleted 3 memories"));
+
+        // Verify topic is gone
+        let memories = store.get_by_topic("doomed").unwrap();
+        assert!(memories.is_empty());
+    }
+
+    #[test]
+    fn test_forget_topic_missing_field() {
+        let store = test_store();
+        let result = call_tool(&store, None, "icm_memory_forget_topic", &json!({}), false);
+        assert!(result.is_error);
+        assert!(result.content[0].text.contains("topic"));
+    }
+
+    #[test]
+    fn test_forget_topic_empty() {
+        let store = test_store();
+        let result = call_tool(
+            &store,
+            None,
+            "icm_memory_forget_topic",
+            &json!({"topic": "nonexistent"}),
+            false,
+        );
+        assert!(!result.is_error);
+        assert!(result.content[0].text.contains("Deleted 0 memories"));
+    }
+
+    #[test]
+    fn test_mcp_learn() {
+        let store = test_store();
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project_dir = tmp.path().join("test-proj");
+        std::fs::create_dir_all(project_dir.join("src")).unwrap();
+        std::fs::write(
+            project_dir.join("Cargo.toml"),
+            r#"
+[package]
+name = "test-proj"
+version = "0.1.0"
+edition = "2021"
+description = "A test project"
+"#,
+        )
+        .unwrap();
+        std::fs::write(project_dir.join("src/main.rs"), "fn main() {}").unwrap();
+
+        let result = call_tool(
+            &store,
+            None,
+            "icm_learn",
+            &json!({"directory": project_dir.to_str().unwrap()}),
+            false,
+        );
+        assert!(!result.is_error, "learn failed: {}", result.content[0].text);
+        assert!(result.content[0].text.contains("Learned test-proj"));
+        assert!(result.content[0].text.contains("concepts"));
+    }
+
+    #[test]
+    fn test_mcp_learn_invalid_dir() {
+        let store = test_store();
+        let result = call_tool(
+            &store,
+            None,
+            "icm_learn",
+            &json!({"directory": "/nonexistent/path/xyz"}),
+            false,
+        );
+        assert!(result.is_error);
+        assert!(result.content[0].text.contains("directory not found"));
     }
 }

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -3845,4 +3845,28 @@ mod tests {
         // (9998 + 4 = 10002 > 10000, so the emoji at 9998 is excluded; end = 9998)
         // Result should just be the 'a' tokens
     }
+
+    #[test]
+    fn test_forget_topic() {
+        let store = test_store();
+
+        // Create 3 memories in topic "ephemeral"
+        for i in 0..3 {
+            let m = make_memory("ephemeral", &format!("item {i}"));
+            store.store(m).unwrap();
+        }
+
+        // Verify they exist
+        let before = store.get_by_topic("ephemeral").unwrap();
+        assert_eq!(before.len(), 3);
+
+        // Delete all memories in the topic
+        for m in &before {
+            store.delete(&m.id).unwrap();
+        }
+
+        // Verify 0 remain
+        let after = store.get_by_topic("ephemeral").unwrap();
+        assert!(after.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

Two new features:

### 1. `icm forget --topic <name>` (CLI + MCP)
Delete all memories in a topic at once:
```bash
icm forget --topic "errors-resolved"  # deletes all entries
```
Also available as MCP tool `icm_memory_forget_topic`.

### 2. `icm_learn` MCP tool
Exposes `icm learn` as an MCP tool — the AI agent can scan a project and create a knowledge graph:
```json
{"name": "icm_learn", "arguments": {"directory": "/path/to/repo"}}
```

Learn logic moved from icm-cli to icm-core (shared between CLI and MCP).

## Test plan
- [x] 194 tests pass (+6 new)
- [x] `forget --topic` tested: 2 memories deleted, other topics untouched
- [x] MCP `icm_learn` tested: 33 concepts, 32 links on ICM project

🤖 Generated with [Claude Code](https://claude.com/claude-code)