### PR TITLE
fix: preserve key order in config files during icm init (#80)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.11"
+version = "0.10.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2702,6 +2702,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ fastembed = "4"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 toml = "0.8"
 
 # Error handling


### PR DESCRIPTION
## Summary

Closes #80. `icm init` was reordering JSON keys alphabetically when writing config files. This confused users who thought their settings were overwritten.

**Fix:** Enable `serde_json` `preserve_order` feature — keys now stay in their original order.

**Verified:**
- Key order preserved ✅
- Existing MCP servers preserved ✅  
- Custom settings preserved ✅
- Second init says "already configured" ✅
- 213 tests pass ✅

Note: JSONC comments (`//`, `/* */`) are still stripped (serde_json limitation). Data is always preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)