### PR TITLE
feat: add `icm wake-up` command + `icm_wake_up` MCP tool

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -17,8 +17,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 use serde_json::Value;
 
 use icm_core::{
-    keyword_matches, topic_matches, Concept, ConceptLink, Feedback, FeedbackStore, Importance,
-    Label, Memoir, MemoirStore, Memory, MemoryStore, Relation, MSG_NO_MEMORIES,
+    build_wake_up, keyword_matches, topic_matches, Concept, ConceptLink, Feedback, FeedbackStore,
+    Importance, Label, Memoir, MemoirStore, Memory, MemoryStore, Relation, WakeUpFormat,
+    WakeUpOptions, MSG_NO_MEMORIES,
 };
 use icm_store::SqliteStore;
 
@@ -277,6 +278,29 @@ enum Commands {
         /// Maximum memories to include
         #[arg(short, long, default_value = "10")]
         limit: usize,
+    },
+
+    /// Print a compact critical-facts pack for LLM system-prompt injection
+    ///
+    /// Selects critical/high memories (and preferences) optionally scoped by
+    /// project, ranks them by importance × recency × weight, then truncates
+    /// to fit the token budget. Inspired by MemPalace's `wake-up` command.
+    WakeUp {
+        /// Project filter (default: auto-detect from PWD/git remote; use "-" to disable)
+        #[arg(short, long)]
+        project: Option<String>,
+
+        /// Approximate token budget (1 token ≈ 4 characters)
+        #[arg(short = 't', long, default_value = "200")]
+        max_tokens: usize,
+
+        /// Output format
+        #[arg(short, long, default_value = "markdown")]
+        format: CliWakeUpFormat,
+
+        /// Exclude global preferences/identity memories
+        #[arg(long)]
+        no_preferences: bool,
     },
 
     /// Auto-save context for the current project (detects from PWD / git remote)
@@ -633,6 +657,21 @@ impl From<CliImportance> for Importance {
     }
 }
 
+#[derive(Clone, Copy, ValueEnum)]
+enum CliWakeUpFormat {
+    Markdown,
+    Plain,
+}
+
+impl From<CliWakeUpFormat> for WakeUpFormat {
+    fn from(val: CliWakeUpFormat) -> Self {
+        match val {
+            CliWakeUpFormat::Markdown => WakeUpFormat::Markdown,
+            CliWakeUpFormat::Plain => WakeUpFormat::Plain,
+        }
+    }
+}
+
 #[derive(Clone, ValueEnum)]
 enum CliImportFormat {
     Auto,
@@ -923,6 +962,12 @@ fn main() -> Result<()> {
         }
         Commands::RecallContext { query, limit } => cmd_recall_context(&store, &query, limit),
         Commands::RecallProject { limit } => cmd_recall_project(&store, limit),
+        Commands::WakeUp {
+            project,
+            max_tokens,
+            format,
+            no_preferences,
+        } => cmd_wake_up(&store, project, max_tokens, format, no_preferences),
         Commands::SaveProject {
             content,
             importance,
@@ -2575,6 +2620,45 @@ fn cmd_recall_project(store: &SqliteStore, limit: usize) -> Result<()> {
     } else {
         print!("{ctx}");
     }
+    Ok(())
+}
+
+/// Build and print a wake-up pack for LLM system-prompt injection.
+///
+/// Selects critical/high memories (plus preferences) optionally scoped to a
+/// project, ranks by importance × recency × weight, and truncates to fit the
+/// token budget.
+fn cmd_wake_up(
+    store: &SqliteStore,
+    project: Option<String>,
+    max_tokens: usize,
+    format: CliWakeUpFormat,
+    no_preferences: bool,
+) -> Result<()> {
+    // Resolve project: explicit "-" disables, None auto-detects, Some(name) uses it.
+    let detected;
+    let project_ref: Option<&str> = match project.as_deref() {
+        Some("-") => None,
+        Some(p) => Some(p),
+        None => {
+            detected = detect_project();
+            if detected.is_empty() || detected == "unknown" {
+                None
+            } else {
+                Some(detected.as_str())
+            }
+        }
+    };
+
+    let opts = WakeUpOptions {
+        project: project_ref,
+        max_tokens,
+        format: format.into(),
+        include_preferences: !no_preferences,
+    };
+
+    let pack = build_wake_up(store, &opts)?;
+    print!("{pack}");
     Ok(())
 }
 

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2645,6 +2645,9 @@ fn cmd_wake_up(
             if detected.is_empty() || detected == "unknown" {
                 None
             } else {
+                // Make auto-detection visible so users understand why
+                // specific topics show (or don't).
+                eprintln!("Project: {detected} (auto-detected; use --project - to disable)");
                 Some(detected.as_str())
             }
         }

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod memoir;
 pub mod memoir_store;
 pub mod memory;
 pub mod store;
+pub mod wake_up;
 
 /// Default embedding vector dimensions (used when no embedder is configured).
 pub const DEFAULT_EMBEDDING_DIMS: usize = 384;
@@ -25,6 +26,7 @@ pub use memory::{
     Importance, Memory, MemorySource, PatternCluster, Scope, StoreStats, TopicHealth,
 };
 pub use store::MemoryStore;
+pub use wake_up::{build_wake_up, build_wake_up_from_memories, WakeUpFormat, WakeUpOptions};
 
 pub use learn::{learn_project, LearnResult};
 

--- a/crates/icm-core/src/wake_up.rs
+++ b/crates/icm-core/src/wake_up.rs
@@ -100,6 +100,7 @@ pub fn build_wake_up<S: MemoryStore + ?Sized>(
 }
 
 /// Build a wake-up pack from an in-memory list (pure, testable).
+#[must_use]
 pub fn build_wake_up_from_memories(memories: Vec<Memory>, opts: &WakeUpOptions<'_>) -> String {
     let now = Utc::now();
 
@@ -148,8 +149,13 @@ fn is_preference_topic(topic: &str) -> bool {
         || lower.starts_with("user.")
 }
 
-/// Return true if a topic matches the project filter (substring match),
-/// or if the filter is absent.
+/// Return true if a topic matches the project filter, or if the filter is
+/// absent. Matching is **segment-aware**: both the topic and the project
+/// filter are split on `-`, `.`, `_`, `/`, `:` and every project segment must
+/// appear as a complete topic segment (case-insensitive). This avoids false
+/// positives like `"icm"` matching `"icmp-notes"` while still allowing
+/// `"icm"` to match `"decisions-icm-core"` (via the `"icm"` segment) and
+/// `"icm-core"` to match `"decisions-icm-core"` (via both segments).
 fn project_matches(topic: &str, project: Option<&str>) -> bool {
     let Some(proj) = project else {
         return true;
@@ -161,9 +167,24 @@ fn project_matches(topic: &str, project: Option<&str>) -> bool {
     if is_preference_topic(topic) {
         return true;
     }
-    let lower_topic = topic.to_lowercase();
-    let lower_proj = proj.to_lowercase();
-    lower_topic.contains(&lower_proj)
+
+    let is_delim = |c: char| matches!(c, '-' | '.' | '_' | '/' | ':');
+    let topic_segs: Vec<String> = topic
+        .split(is_delim)
+        .map(str::to_lowercase)
+        .filter(|s| !s.is_empty())
+        .collect();
+    let proj_segs: Vec<String> = proj
+        .split(is_delim)
+        .map(str::to_lowercase)
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if proj_segs.is_empty() {
+        return true;
+    }
+
+    proj_segs.iter().all(|ps| topic_segs.contains(ps))
 }
 
 fn compute_score(m: &Memory, now: DateTime<Utc>) -> f32 {
@@ -173,7 +194,10 @@ fn compute_score(m: &Memory, now: DateTime<Utc>) -> f32 {
         Importance::Medium => 2.0,
         Importance::Low => 0.5,
     };
-    let days = (now - m.created_at).num_days().max(0) as f32;
+    // Recency is access-aware: use the more recent of created_at and
+    // last_accessed, so memories that are frequently recalled stay fresh.
+    let reference = m.created_at.max(m.last_accessed);
+    let days = (now - reference).num_days().max(0) as f32;
     // Recency factor: 1.0 at day 0, ~0.5 at day 30, ~0.25 at day 90.
     let recency = 1.0 / (1.0 + days / 30.0);
     let stored_weight = m.weight.max(0.01);
@@ -210,12 +234,14 @@ fn categorize(m: &Memory) -> Category {
 
 /// Greedy selection that stops once the accumulated character budget is exceeded.
 /// Always includes at least one memory if any candidate exists.
+/// Counts user-visible characters (not bytes) so multibyte summaries aren't
+/// over-penalized.
 fn truncate_by_budget(candidates: Vec<ScoredMemory>, max_chars: usize) -> Vec<ScoredMemory> {
     let mut total = 0usize;
     let mut out = Vec::new();
     for c in candidates {
         // Account for bullet prefix + newline.
-        let line_len = c.memory.summary.len().saturating_add(4);
+        let line_len = c.memory.summary.chars().count().saturating_add(4);
         if !out.is_empty() && total.saturating_add(line_len) > max_chars {
             break;
         }
@@ -225,8 +251,33 @@ fn truncate_by_budget(candidates: Vec<ScoredMemory>, max_chars: usize) -> Vec<Sc
     out
 }
 
+/// Approximate token count for a rendered body: `chars / 4`, rounded up.
+/// Uses characters (not bytes) so the displayed count is honest for non-ASCII.
 fn approx_tokens(s: &str) -> usize {
-    s.len().div_ceil(4)
+    s.chars().count().div_ceil(4)
+}
+
+/// Flatten a summary into a single-line safe string: trim surrounding space,
+/// replace newlines with spaces so an embedded heading can't break section
+/// structure in the rendered Markdown.
+fn sanitize_summary(summary: &str) -> String {
+    let flattened: String = summary
+        .trim()
+        .chars()
+        .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
+        .collect();
+    // Collapse runs of spaces that result from the flattening.
+    let mut out = String::with_capacity(flattened.len());
+    let mut prev_space = false;
+    for c in flattened.chars() {
+        let is_space = c == ' ';
+        if is_space && prev_space {
+            continue;
+        }
+        out.push(c);
+        prev_space = is_space;
+    }
+    out
 }
 
 fn render(selected: &[ScoredMemory], opts: &WakeUpOptions<'_>) -> String {
@@ -282,22 +333,21 @@ fn render_body(selected: &[ScoredMemory], format: WakeUpFormat) -> String {
             WakeUpFormat::Markdown => {
                 out.push_str(&format!("## {}\n", cat.label()));
                 for s in &group {
-                    out.push_str(&format!("- {}\n", s.memory.summary.trim()));
+                    out.push_str(&format!("- {}\n", sanitize_summary(&s.memory.summary)));
                 }
                 out.push('\n');
             }
             WakeUpFormat::Plain => {
                 out.push_str(&format!("[{}]\n", cat.label()));
                 for s in &group {
-                    out.push_str(&format!("- {}\n", s.memory.summary.trim()));
+                    out.push_str(&format!("- {}\n", sanitize_summary(&s.memory.summary)));
                 }
                 out.push('\n');
             }
         }
     }
-    // Sort the categories output (we iterate in `all_ordered` already).
-    // Ensure we don't end with multiple blank lines.
-    while out.ends_with("\n\n\n") {
+    // Collapse trailing blank lines to a single newline.
+    while out.ends_with("\n\n") {
         out.pop();
     }
     out
@@ -489,10 +539,147 @@ mod tests {
     }
 
     #[test]
-    fn project_matches_substring() {
+    fn project_matches_segment_aware() {
+        // Positive: exact segment across various separators
         assert!(project_matches("decisions-icm", Some("icm")));
         assert!(project_matches("context-icm-core", Some("icm")));
+        assert!(project_matches("icm.decisions", Some("icm")));
+        assert!(project_matches("project:icm/notes", Some("icm")));
+        assert!(project_matches("icm_errors", Some("icm")));
+
+        // Positive: multi-segment project filter where all segments appear
+        assert!(project_matches("decisions-icm-core", Some("icm-core")));
+        assert!(project_matches("context.icm.core", Some("icm.core")));
+
+        // Negative: unrelated
         assert!(!project_matches("decisions-ramiga", Some("icm")));
+
+        // Negative: substring that would have matched under a naive
+        // contains() impl but is not a real segment.
+        assert!(
+            !project_matches("icmp-notes", Some("icm")),
+            "icmp should not match icm"
+        );
+        assert!(
+            !project_matches("picm-rules", Some("icm")),
+            "picm should not match icm"
+        );
+
+        // Negative: multi-segment project with one missing segment
+        assert!(
+            !project_matches("decisions-icm", Some("icm-core")),
+            "icm-core should not match plain decisions-icm"
+        );
+
+        // None filter → pass all
         assert!(project_matches("anything", None));
+        // Empty filter → pass all
+        assert!(project_matches("anything", Some("")));
+    }
+
+    #[test]
+    fn include_preferences_false_drops_preference_memories() {
+        let memories = vec![
+            mem("decisions-icm", "Critical decision", Importance::Critical),
+            mem("preferences", "User prefers French", Importance::Medium),
+        ];
+        let opts = WakeUpOptions {
+            include_preferences: false,
+            ..Default::default()
+        };
+        let pack = build_wake_up_from_memories(memories, &opts);
+        assert!(pack.contains("Critical decision"));
+        assert!(!pack.contains("French"), "preferences should be excluded");
+        assert!(!pack.contains("## Identity"));
+    }
+
+    #[test]
+    fn sanitize_summary_flattens_newlines_and_collapses_spaces() {
+        let input = "  line one\nline two\r\n## injected header  ";
+        let out = sanitize_summary(input);
+        assert_eq!(out, "line one line two ## injected header");
+    }
+
+    #[test]
+    fn renders_without_breaking_on_multiline_summary() {
+        let memories = vec![mem(
+            "decisions-icm",
+            "First line\n## Fake section header\nSecond line",
+            Importance::Critical,
+        )];
+        let pack = build_wake_up_from_memories(memories, &WakeUpOptions::default());
+        // There should be exactly ONE `## ` section header (Critical decisions),
+        // never two from the injected fake header.
+        let header_count = pack.matches("\n## ").count();
+        assert_eq!(
+            header_count, 1,
+            "injected markdown header leaked into render: {pack}"
+        );
+    }
+
+    #[test]
+    fn respects_token_budget_with_multibyte_chars() {
+        // 20 long French summaries with accents (multibyte).
+        let memories: Vec<Memory> = (0..20)
+            .map(|i| {
+                mem(
+                    "decisions-icm",
+                    &format!("Décision numéro {i} très très importante ").repeat(10),
+                    Importance::Critical,
+                )
+            })
+            .collect();
+        let opts = WakeUpOptions {
+            project: Some("icm"),
+            max_tokens: 40,
+            ..Default::default()
+        };
+        let pack = build_wake_up_from_memories(memories, &opts);
+        // Budget is 40 tok ≈ 160 chars; with the header and section label
+        // we expect the body to be bounded under 600 chars.
+        assert!(
+            pack.chars().count() < 600,
+            "char count {} should be bounded",
+            pack.chars().count()
+        );
+    }
+
+    #[test]
+    fn compute_score_uses_last_accessed_when_more_recent() {
+        // Create memory "long ago" then update last_accessed to now.
+        let mut m = mem("decisions-icm", "Old decision", Importance::Critical);
+        let long_ago = Utc::now() - chrono::Duration::days(180);
+        m.created_at = long_ago;
+        m.last_accessed = Utc::now();
+
+        let fresh_score = compute_score(&m, Utc::now());
+
+        // Same memory, never re-accessed.
+        let mut stale = mem("decisions-icm", "Old decision", Importance::Critical);
+        stale.created_at = long_ago;
+        stale.last_accessed = long_ago;
+        let stale_score = compute_score(&stale, Utc::now());
+
+        assert!(
+            fresh_score > stale_score,
+            "recently-accessed memory should outscore stale peer ({fresh_score} vs {stale_score})"
+        );
+    }
+
+    #[test]
+    fn plain_format_omits_header_and_token_count() {
+        let memories = vec![mem("decisions-icm", "Use SQLite", Importance::Critical)];
+        let opts = WakeUpOptions {
+            format: WakeUpFormat::Plain,
+            project: Some("icm"),
+            ..Default::default()
+        };
+        let pack = build_wake_up_from_memories(memories, &opts);
+        assert!(!pack.starts_with("# ICM Wake-up"));
+        assert!(
+            !pack.contains("~"),
+            "plain format should not have token count"
+        );
+        assert!(pack.contains("[Critical decisions]"));
     }
 }

--- a/crates/icm-core/src/wake_up.rs
+++ b/crates/icm-core/src/wake_up.rs
@@ -1,0 +1,498 @@
+//! Wake-up pack: build a compact, token-budgeted snapshot of critical memories
+//! suitable for injection into an LLM system prompt at session start.
+//!
+//! Inspired by MemPalace's 4-layer memory stack and `wake-up` command, adapted
+//! to ICM's importance/decay model.
+
+use chrono::{DateTime, Utc};
+
+use crate::error::IcmResult;
+use crate::memory::{Importance, Memory};
+use crate::store::MemoryStore;
+
+/// Output format for the wake-up pack.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum WakeUpFormat {
+    /// Plain text bullet list, no headers.
+    Plain,
+    /// Markdown with section headers (default).
+    #[default]
+    Markdown,
+}
+
+/// Options for building a wake-up pack.
+#[derive(Debug, Clone)]
+pub struct WakeUpOptions<'a> {
+    /// Optional project filter (matched as substring against topic).
+    pub project: Option<&'a str>,
+    /// Approximate token budget (1 token ≈ 4 chars).
+    pub max_tokens: usize,
+    /// Output format.
+    pub format: WakeUpFormat,
+    /// Include preference/identity memories regardless of project filter.
+    pub include_preferences: bool,
+}
+
+impl Default for WakeUpOptions<'_> {
+    fn default() -> Self {
+        Self {
+            project: None,
+            max_tokens: 200,
+            format: WakeUpFormat::Markdown,
+            include_preferences: true,
+        }
+    }
+}
+
+/// Category a memory lands in for the wake-up rendering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Category {
+    Identity,
+    Decision,
+    Constraint,
+    Error,
+    Milestone,
+    Context,
+}
+
+impl Category {
+    /// Section header label.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Identity => "Identity & preferences",
+            Self::Decision => "Critical decisions",
+            Self::Constraint => "Active constraints",
+            Self::Error => "Recent errors resolved",
+            Self::Milestone => "Milestones",
+            Self::Context => "Project context",
+        }
+    }
+
+    fn all_ordered() -> [Category; 6] {
+        [
+            Self::Identity,
+            Self::Decision,
+            Self::Constraint,
+            Self::Error,
+            Self::Milestone,
+            Self::Context,
+        ]
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ScoredMemory {
+    memory: Memory,
+    score: f32,
+    category: Category,
+}
+
+/// Build a wake-up pack by querying the store directly.
+///
+/// Selects critical/high memories optionally scoped by project, ranks them by
+/// `importance * recency * weight`, then truncates to fit `max_tokens`.
+pub fn build_wake_up<S: MemoryStore + ?Sized>(
+    store: &S,
+    opts: &WakeUpOptions<'_>,
+) -> IcmResult<String> {
+    let all = store.list_all()?;
+    Ok(build_wake_up_from_memories(all, opts))
+}
+
+/// Build a wake-up pack from an in-memory list (pure, testable).
+pub fn build_wake_up_from_memories(memories: Vec<Memory>, opts: &WakeUpOptions<'_>) -> String {
+    let now = Utc::now();
+
+    let mut candidates: Vec<ScoredMemory> = memories
+        .into_iter()
+        .filter(|m| {
+            let is_pref = opts.include_preferences && is_preference_topic(&m.topic);
+            // Critical/high are always eligible; preferences always eligible
+            // when the option is set (they may be medium-importance).
+            matches!(m.importance, Importance::Critical | Importance::High) || is_pref
+        })
+        .filter(|m| project_matches(&m.topic, opts.project))
+        .map(|m| {
+            let score = compute_score(&m, now);
+            let category = categorize(&m);
+            ScoredMemory {
+                memory: m,
+                score,
+                category,
+            }
+        })
+        .collect();
+
+    candidates.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    // Token budget: 1 token ≈ 4 characters (rough approximation).
+    let max_chars = opts.max_tokens.saturating_mul(4);
+    let selected = truncate_by_budget(candidates, max_chars);
+
+    render(&selected, opts)
+}
+
+/// Return true when a topic looks like it holds identity/preference data.
+fn is_preference_topic(topic: &str) -> bool {
+    let lower = topic.to_lowercase();
+    lower == "preferences"
+        || lower == "identity"
+        || lower.starts_with("preferences-")
+        || lower.starts_with("preferences.")
+        || lower.contains("preference")
+        || lower.starts_with("user-")
+        || lower.starts_with("user.")
+}
+
+/// Return true if a topic matches the project filter (substring match),
+/// or if the filter is absent.
+fn project_matches(topic: &str, project: Option<&str>) -> bool {
+    let Some(proj) = project else {
+        return true;
+    };
+    if proj.is_empty() {
+        return true;
+    }
+    // Preferences/identity are global and always included when filtering.
+    if is_preference_topic(topic) {
+        return true;
+    }
+    let lower_topic = topic.to_lowercase();
+    let lower_proj = proj.to_lowercase();
+    lower_topic.contains(&lower_proj)
+}
+
+fn compute_score(m: &Memory, now: DateTime<Utc>) -> f32 {
+    let importance_weight = match m.importance {
+        Importance::Critical => 10.0,
+        Importance::High => 5.0,
+        Importance::Medium => 2.0,
+        Importance::Low => 0.5,
+    };
+    let days = (now - m.created_at).num_days().max(0) as f32;
+    // Recency factor: 1.0 at day 0, ~0.5 at day 30, ~0.25 at day 90.
+    let recency = 1.0 / (1.0 + days / 30.0);
+    let stored_weight = m.weight.max(0.01);
+    importance_weight * recency * stored_weight
+}
+
+fn categorize(m: &Memory) -> Category {
+    let t = m.topic.to_lowercase();
+    let s = m.summary.to_lowercase();
+
+    if is_preference_topic(&m.topic) {
+        return Category::Identity;
+    }
+    if t.contains("decision") || s.contains("decided ") || s.contains("chose ") {
+        return Category::Decision;
+    }
+    if t.contains("constraint")
+        || t.contains("rule")
+        || t.contains("convention")
+        || s.starts_with("always ")
+        || s.starts_with("never ")
+        || s.starts_with("must ")
+    {
+        return Category::Constraint;
+    }
+    if t.contains("error") || t.contains("bug") || s.starts_with("fixed ") {
+        return Category::Error;
+    }
+    if t.contains("milestone") || t.contains("release") || s.contains("shipped") {
+        return Category::Milestone;
+    }
+    Category::Context
+}
+
+/// Greedy selection that stops once the accumulated character budget is exceeded.
+/// Always includes at least one memory if any candidate exists.
+fn truncate_by_budget(candidates: Vec<ScoredMemory>, max_chars: usize) -> Vec<ScoredMemory> {
+    let mut total = 0usize;
+    let mut out = Vec::new();
+    for c in candidates {
+        // Account for bullet prefix + newline.
+        let line_len = c.memory.summary.len().saturating_add(4);
+        if !out.is_empty() && total.saturating_add(line_len) > max_chars {
+            break;
+        }
+        total = total.saturating_add(line_len);
+        out.push(c);
+    }
+    out
+}
+
+fn approx_tokens(s: &str) -> usize {
+    s.len().div_ceil(4)
+}
+
+fn render(selected: &[ScoredMemory], opts: &WakeUpOptions<'_>) -> String {
+    if selected.is_empty() {
+        return String::from(
+            "# ICM Wake-up\n\n(no critical memories yet — use `icm store` to seed)\n",
+        );
+    }
+
+    // Group by category, preserving per-group score ordering.
+    let mut out = String::new();
+    let header = match opts.project {
+        Some(p) if !p.is_empty() => format!("# ICM Wake-up (project: {p})"),
+        _ => String::from("# ICM Wake-up"),
+    };
+
+    // Pre-compute body to get token count, then prepend header with count.
+    let body = render_body(selected, opts.format);
+    let tok = approx_tokens(&body);
+
+    match opts.format {
+        WakeUpFormat::Markdown => {
+            out.push_str(&format!("{header} · ~{tok} tok\n\n"));
+            out.push_str(&body);
+        }
+        WakeUpFormat::Plain => {
+            out.push_str(&body);
+        }
+    }
+
+    out
+}
+
+fn render_body(selected: &[ScoredMemory], format: WakeUpFormat) -> String {
+    let mut out = String::new();
+    for cat in Category::all_ordered() {
+        let group: Vec<&ScoredMemory> = selected
+            .iter()
+            .filter(|s| s.category == cat)
+            .collect::<Vec<_>>();
+        if group.is_empty() {
+            continue;
+        }
+        // Sort group by original score (already in selected order, re-sort for safety).
+        let mut group = group;
+        group.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        match format {
+            WakeUpFormat::Markdown => {
+                out.push_str(&format!("## {}\n", cat.label()));
+                for s in &group {
+                    out.push_str(&format!("- {}\n", s.memory.summary.trim()));
+                }
+                out.push('\n');
+            }
+            WakeUpFormat::Plain => {
+                out.push_str(&format!("[{}]\n", cat.label()));
+                for s in &group {
+                    out.push_str(&format!("- {}\n", s.memory.summary.trim()));
+                }
+                out.push('\n');
+            }
+        }
+    }
+    // Sort the categories output (we iterate in `all_ordered` already).
+    // Ensure we don't end with multiple blank lines.
+    while out.ends_with("\n\n\n") {
+        out.pop();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mem(topic: &str, summary: &str, imp: Importance) -> Memory {
+        Memory::new(topic.to_string(), summary.to_string(), imp)
+    }
+
+    #[test]
+    fn filters_out_low_and_medium_non_preferences() {
+        let memories = vec![
+            mem(
+                "decisions-icm",
+                "Use SQLite with FTS5",
+                Importance::Critical,
+            ),
+            mem("other", "random medium fact", Importance::Medium),
+            mem("other", "random low fact", Importance::Low),
+        ];
+        let pack = build_wake_up_from_memories(memories, &WakeUpOptions::default());
+        assert!(pack.contains("SQLite"));
+        assert!(!pack.contains("random medium"));
+        assert!(!pack.contains("random low"));
+    }
+
+    #[test]
+    fn includes_preferences_even_at_medium_importance() {
+        let memories = vec![mem(
+            "preferences",
+            "User prefers French",
+            Importance::Medium,
+        )];
+        let pack = build_wake_up_from_memories(memories, &WakeUpOptions::default());
+        assert!(pack.contains("French"));
+        assert!(pack.contains("Identity"));
+    }
+
+    #[test]
+    fn respects_project_filter() {
+        let memories = vec![
+            mem("decisions-icm", "ICM: SQLite backend", Importance::Critical),
+            mem(
+                "decisions-other",
+                "OTHER: Postgres backend",
+                Importance::Critical,
+            ),
+        ];
+        let opts = WakeUpOptions {
+            project: Some("icm"),
+            ..Default::default()
+        };
+        let pack = build_wake_up_from_memories(memories, &opts);
+        assert!(pack.contains("ICM: SQLite"));
+        assert!(!pack.contains("OTHER: Postgres"));
+    }
+
+    #[test]
+    fn preferences_are_global_under_project_filter() {
+        let memories = vec![
+            mem(
+                "decisions-other",
+                "OTHER: Postgres backend",
+                Importance::Critical,
+            ),
+            mem("preferences", "User prefers French", Importance::Medium),
+        ];
+        let opts = WakeUpOptions {
+            project: Some("icm"),
+            ..Default::default()
+        };
+        let pack = build_wake_up_from_memories(memories, &opts);
+        assert!(
+            pack.contains("French"),
+            "preferences should bypass project filter"
+        );
+        assert!(!pack.contains("Postgres"));
+    }
+
+    #[test]
+    fn respects_token_budget_approximately() {
+        // 20 critical memories with long summaries.
+        let memories: Vec<Memory> = (0..20)
+            .map(|i| {
+                mem(
+                    "decisions-icm",
+                    &format!("Long decision number {i} ").repeat(20),
+                    Importance::Critical,
+                )
+            })
+            .collect();
+        let opts = WakeUpOptions {
+            project: Some("icm"),
+            max_tokens: 50, // ~200 chars
+            ..Default::default()
+        };
+        let pack = build_wake_up_from_memories(memories, &opts);
+        // Should drop most entries — total body well under 1000 chars.
+        assert!(
+            pack.len() < 1500,
+            "pack length {} should be bounded",
+            pack.len()
+        );
+    }
+
+    #[test]
+    fn always_includes_at_least_one_entry_if_possible() {
+        // One massive entry far exceeding the budget.
+        let memories = vec![mem(
+            "decisions-icm",
+            &"x".repeat(5000),
+            Importance::Critical,
+        )];
+        let opts = WakeUpOptions {
+            max_tokens: 10,
+            ..Default::default()
+        };
+        let pack = build_wake_up_from_memories(memories, &opts);
+        assert!(pack.contains("xxxx"), "at least one entry must survive");
+    }
+
+    #[test]
+    fn empty_store_returns_placeholder() {
+        let pack = build_wake_up_from_memories(vec![], &WakeUpOptions::default());
+        assert!(pack.contains("no critical memories"));
+    }
+
+    #[test]
+    fn markdown_format_uses_section_headers() {
+        let memories = vec![
+            mem("decisions-icm", "Use SQLite", Importance::Critical),
+            mem("preferences", "User prefers French", Importance::High),
+        ];
+        let pack = build_wake_up_from_memories(memories, &WakeUpOptions::default());
+        assert!(pack.contains("## Identity"));
+        assert!(pack.contains("## Critical decisions"));
+        assert!(pack.starts_with("# ICM Wake-up"));
+    }
+
+    #[test]
+    fn plain_format_uses_bracket_headers() {
+        let memories = vec![mem("decisions-icm", "Use SQLite", Importance::Critical)];
+        let opts = WakeUpOptions {
+            format: WakeUpFormat::Plain,
+            ..Default::default()
+        };
+        let pack = build_wake_up_from_memories(memories, &opts);
+        assert!(pack.contains("[Critical decisions]"));
+        assert!(!pack.contains("## Critical"));
+    }
+
+    #[test]
+    fn critical_outranks_high_when_same_age() {
+        let memories = vec![
+            mem("decisions-a", "ALPHA high fact", Importance::High),
+            mem("decisions-b", "BETA critical fact", Importance::Critical),
+        ];
+        let pack = build_wake_up_from_memories(memories, &WakeUpOptions::default());
+        let alpha_pos = pack.find("ALPHA").unwrap();
+        let beta_pos = pack.find("BETA").unwrap();
+        assert!(
+            beta_pos < alpha_pos,
+            "critical should be rendered before high"
+        );
+    }
+
+    #[test]
+    fn categorize_detects_errors() {
+        let m = mem("errors-resolved", "Fixed cache init", Importance::High);
+        assert_eq!(categorize(&m), Category::Error);
+    }
+
+    #[test]
+    fn categorize_detects_decisions_from_topic() {
+        let m = mem("decisions-icm", "Use FTS5", Importance::Critical);
+        assert_eq!(categorize(&m), Category::Decision);
+    }
+
+    #[test]
+    fn is_preference_topic_matches_variants() {
+        assert!(is_preference_topic("preferences"));
+        assert!(is_preference_topic("preferences-icm"));
+        assert!(is_preference_topic("user-profile"));
+        assert!(!is_preference_topic("decisions-icm"));
+    }
+
+    #[test]
+    fn project_matches_substring() {
+        assert!(project_matches("decisions-icm", Some("icm")));
+        assert!(project_matches("context-icm-core", Some("icm")));
+        assert!(!project_matches("decisions-ramiga", Some("icm")));
+        assert!(project_matches("anything", None));
+    }
+}

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -637,7 +637,12 @@ pub fn call_tool(
 // ---------------------------------------------------------------------------
 
 fn tool_wake_up(store: &SqliteStore, args: &Value) -> ToolResult {
-    let project = get_str(args, "project");
+    // Normalize the project filter: empty string or "-" both mean "disabled",
+    // mirroring the CLI convention.
+    let project = match get_str(args, "project") {
+        Some("") | Some("-") => None,
+        other => other,
+    };
     // Clamp token budget to [20, 4000] to guard against accidental blowups.
     let max_tokens = get_i64(args, "max_tokens", 200).clamp(20, 4000) as usize;
     let format = match get_str(args, "format").unwrap_or("markdown") {

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -2,8 +2,9 @@ use chrono::Utc;
 use serde_json::{json, Value};
 
 use icm_core::{
-    keyword_matches, topic_matches, Concept, ConceptLink, Embedder, Feedback, FeedbackStore, Label,
-    Memoir, MemoirStore, Memory, MemoryStore, Relation, MSG_NO_MEMORIES,
+    build_wake_up, keyword_matches, topic_matches, Concept, ConceptLink, Embedder, Feedback,
+    FeedbackStore, Label, Memoir, MemoirStore, Memory, MemoryStore, Relation, WakeUpFormat,
+    WakeUpOptions, MSG_NO_MEMORIES,
 };
 use icm_store::SqliteStore;
 
@@ -532,6 +533,37 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "properties": {}
             }
         }),
+        json!({
+            "name": "icm_wake_up",
+            "description": "Build a compact critical-facts pack for LLM system-prompt injection. Selects critical/high memories (and preferences) optionally scoped by project, ranks by importance × recency × weight, and truncates to a token budget. Use at session start to hydrate an agent with the most load-bearing context.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project": {
+                        "type": "string",
+                        "description": "Project name filter (substring match against topic). Preferences/identity memories are always included."
+                    },
+                    "max_tokens": {
+                        "type": "integer",
+                        "default": 200,
+                        "minimum": 20,
+                        "maximum": 4000,
+                        "description": "Approximate token budget (1 token ≈ 4 characters)"
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["markdown", "plain"],
+                        "default": "markdown",
+                        "description": "Output format"
+                    },
+                    "include_preferences": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Include global preferences/identity memories regardless of the project filter"
+                    }
+                }
+            }
+        }),
     ];
 
     if has_embedder {
@@ -594,7 +626,39 @@ pub fn call_tool(
         "icm_feedback_record" => tool_feedback_record(store, args, compact),
         "icm_feedback_search" => tool_feedback_search(store, args),
         "icm_feedback_stats" => tool_feedback_stats(store),
+        // Wake-up tool
+        "icm_wake_up" => tool_wake_up(store, args),
         _ => ToolResult::error(format!("unknown tool: {name}")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wake-up tool handler
+// ---------------------------------------------------------------------------
+
+fn tool_wake_up(store: &SqliteStore, args: &Value) -> ToolResult {
+    let project = get_str(args, "project");
+    // Clamp token budget to [20, 4000] to guard against accidental blowups.
+    let max_tokens = get_i64(args, "max_tokens", 200).clamp(20, 4000) as usize;
+    let format = match get_str(args, "format").unwrap_or("markdown") {
+        "plain" => WakeUpFormat::Plain,
+        _ => WakeUpFormat::Markdown,
+    };
+    let include_preferences = args
+        .get("include_preferences")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+
+    let opts = WakeUpOptions {
+        project,
+        max_tokens,
+        format,
+        include_preferences,
+    };
+
+    match build_wake_up(store, &opts) {
+        Ok(pack) => ToolResult::text(pack),
+        Err(e) => ToolResult::error(format!("wake_up failed: {e}")),
     }
 }
 
@@ -2804,5 +2868,184 @@ description = "A test project"
         );
         assert!(result.is_error);
         assert!(result.content[0].text.contains("directory not found"));
+    }
+
+    // ── icm_wake_up ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_mcp_wake_up_empty_store() {
+        let store = test_store();
+        let result = call_tool(&store, None, "icm_wake_up", &json!({}), false);
+        assert!(!result.is_error);
+        assert!(result.content[0].text.contains("no critical memories"));
+    }
+
+    #[test]
+    fn test_mcp_wake_up_filters_and_renders() {
+        let store = test_store();
+        // Seed: 1 critical decision, 1 low-importance (should be filtered), 1 preference
+        call_tool(
+            &store,
+            None,
+            "icm_memory_store",
+            &json!({
+                "topic": "decisions-icm",
+                "content": "Use SQLite with FTS5 for hybrid search",
+                "importance": "critical"
+            }),
+            false,
+        );
+        call_tool(
+            &store,
+            None,
+            "icm_memory_store",
+            &json!({
+                "topic": "noise",
+                "content": "This is low-importance noise",
+                "importance": "low"
+            }),
+            false,
+        );
+        call_tool(
+            &store,
+            None,
+            "icm_memory_store",
+            &json!({
+                "topic": "preferences",
+                "content": "User prefers French responses",
+                "importance": "medium"
+            }),
+            false,
+        );
+
+        let result = call_tool(&store, None, "icm_wake_up", &json!({}), false);
+        assert!(!result.is_error);
+        let text = &result.content[0].text;
+        assert!(text.contains("SQLite"), "decision missing: {text}");
+        assert!(text.contains("French"), "preference missing: {text}");
+        assert!(
+            !text.contains("noise"),
+            "low-imp should be filtered: {text}"
+        );
+        assert!(text.contains("## Identity"));
+        assert!(text.contains("## Critical decisions"));
+    }
+
+    #[test]
+    fn test_mcp_wake_up_project_filter() {
+        let store = test_store();
+        call_tool(
+            &store,
+            None,
+            "icm_memory_store",
+            &json!({
+                "topic": "decisions-icm",
+                "content": "ICM uses multilingual embeddings",
+                "importance": "critical"
+            }),
+            false,
+        );
+        call_tool(
+            &store,
+            None,
+            "icm_memory_store",
+            &json!({
+                "topic": "decisions-grit",
+                "content": "GRIT uses AST-level locks",
+                "importance": "critical"
+            }),
+            false,
+        );
+
+        let result = call_tool(
+            &store,
+            None,
+            "icm_wake_up",
+            &json!({"project": "icm"}),
+            false,
+        );
+        assert!(!result.is_error);
+        let text = &result.content[0].text;
+        assert!(text.contains("ICM uses"));
+        assert!(!text.contains("GRIT uses"), "project filter leaked: {text}");
+        assert!(text.contains("project: icm"));
+    }
+
+    #[test]
+    fn test_mcp_wake_up_plain_format() {
+        let store = test_store();
+        call_tool(
+            &store,
+            None,
+            "icm_memory_store",
+            &json!({
+                "topic": "decisions-icm",
+                "content": "Use SQLite",
+                "importance": "critical"
+            }),
+            false,
+        );
+        let result = call_tool(
+            &store,
+            None,
+            "icm_wake_up",
+            &json!({"format": "plain"}),
+            false,
+        );
+        assert!(!result.is_error);
+        let text = &result.content[0].text;
+        assert!(text.contains("[Critical decisions]"));
+        assert!(!text.contains("## Critical"));
+    }
+
+    #[test]
+    fn test_mcp_wake_up_clamps_max_tokens() {
+        let store = test_store();
+        // Budget out of range: should clamp to [20, 4000]
+        let result = call_tool(
+            &store,
+            None,
+            "icm_wake_up",
+            &json!({"max_tokens": 999999}),
+            false,
+        );
+        assert!(!result.is_error, "should not error on huge budget");
+    }
+
+    #[test]
+    fn test_mcp_wake_up_exclude_preferences() {
+        let store = test_store();
+        call_tool(
+            &store,
+            None,
+            "icm_memory_store",
+            &json!({
+                "topic": "preferences",
+                "content": "User prefers French",
+                "importance": "medium"
+            }),
+            false,
+        );
+        let result = call_tool(
+            &store,
+            None,
+            "icm_wake_up",
+            &json!({"include_preferences": false}),
+            false,
+        );
+        assert!(!result.is_error);
+        // With preferences excluded and nothing else critical, pack should say no memories
+        assert!(result.content[0].text.contains("no critical memories"));
+    }
+
+    #[test]
+    fn test_mcp_wake_up_appears_in_tools_list() {
+        let defs = tool_definitions(false);
+        let tools = defs.get("tools").and_then(|v| v.as_array()).unwrap();
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|t| t.get("name").and_then(|v| v.as_str()))
+            .collect();
+        assert!(names.contains(&"icm_wake_up"), "tool not listed: {names:?}");
     }
 }


### PR DESCRIPTION
## Summary

Adds a compact **critical-facts pack** generator for LLM system-prompt injection, inspired by MemPalace's `wake-up` command but grounded in ICM's importance/decay model. Complements `icm_memory_recall` (pull by query) with a static, token-budgeted snapshot suitable for session-start hydration.

## Why

MemPalace's wake-up (~170 tok in system prompt) solved a real gap for local models and agents that can't call MCP mid-session. ICM already has `RecallContext` (query-driven) and `RecallProject` (topic-driven), but nothing that produces a **predictable, category-grouped pack** optimized for direct paste into the system prompt.

## What it does

- Filters memories to Critical/High importance (+ preferences regardless of importance)
- Optionally scopes by **project** using segment-aware matching (splits topic and filter on `-./_:/`, requires every project segment to appear as a complete topic segment — rejects `"icm"` matching `"icmp-notes"`)
- Ranks by `importance × recency × stored_weight`, where recency uses `max(created_at, last_accessed)` so frequently recalled memories stay fresh
- Categorizes into Identity / Decisions / Constraints / Errors / Milestones / Context
- Truncates to fit a token budget (chars-based, not bytes — honest for multibyte summaries)
- Flattens newlines in summaries to prevent stored content from breaking the rendered Markdown structure
- Renders as Markdown (default, with `# ICM Wake-up · ~N tok` header) or Plain text

## Surface

### CLI

```
icm wake-up [--project <name|->] [--max-tokens 200] [--format markdown|plain] [--no-preferences]
```

- `--project` auto-detects from git remote / PWD if omitted, and prints the detected value to stderr. Pass `-` to disable.
- Token budget default 200; rough 1 tok ≈ 4 chars.

### MCP tool

```json
{
  "name": "icm_wake_up",
  "inputSchema": {
    "project": "string (optional; empty or '-' to disable)",
    "max_tokens": "integer [20, 4000], default 200",
    "format": "enum markdown|plain, default markdown",
    "include_preferences": "boolean, default true"
  }
}
```

## Example output

```
# ICM Wake-up (project: icm) · ~21 tok

## Identity & preferences
- French préféré

## Critical decisions
- Use SQLite with FTS5 and sqlite-vec

## Recent errors resolved
- Fixed fastembed cache init by using Mutex + double-check
```

## Implementation

- New module `crates/icm-core/src/wake_up.rs` (~540 lines with 20 unit tests)
  - `build_wake_up<S: MemoryStore + ?Sized>` (impure, store I/O)
  - `build_wake_up_from_memories(Vec<Memory>, &WakeUpOptions) -> String` (pure, testable, `#[must_use]`)
  - `WakeUpOptions { project, max_tokens, format, include_preferences }` + `WakeUpFormat::{Plain,Markdown}`
- New CLI subcommand in `crates/icm-cli/src/main.rs` + `CliWakeUpFormat` + `cmd_wake_up` handler
- New MCP tool `icm_wake_up` in `crates/icm-mcp/src/tools.rs` with schema, dispatch, handler, 7 integration tests

## Test plan

- [x] `cargo test --workspace` — 240 tests passing (20 new core + 7 new MCP)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] E2E smoke test with real binary: store 4 memories (one multiline with injected `## header`), verify:
  - Auto-detected project prints to stderr
  - `--project icm` does NOT include `decisions-icmp` (segment match working)
  - `--project -` shows everything including global errors
  - Multiline summary flattened to one line, no markdown injection
  - Multibyte French characters ("préféré") render correctly

## Out of scope (deferred)

- French keywords in `categorize` (currently English-only for Decision/Error/Milestone detection — falls back to Context category)
- Replacing `list_all()` + in-memory filter with a `list_by_importance()` query (perf only matters at >10k memories)
- Feeding `wake-up` output through a `SessionStart` Claude Code hook (will come in a follow-up PR along with `Stop` + `PreCompact` hooks)

## Inspired by

[milla-jovovich/mempalace](https://github.com/milla-jovovich/mempalace) — the wake-up idea, adapted to ICM's Rust / importance-weighted / multilingual architecture.