### PR TITLE
chore(init): switch to serde_json_lenient to accept trailing commas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.19"
+version = "0.10.20"
 dependencies = [
  "anyhow",
  "axum",
@@ -1332,6 +1332,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
+ "serde_json_lenient",
  "tempfile",
  "tokio",
  "toml",
@@ -2832,6 +2833,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_json_lenient"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e033097bf0d2b59a62b42c18ebbb797503839b26afdda2c4e1415cb6c813540"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ fastembed = "4"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+serde_json_lenient = { version = "0.2", features = ["preserve_order"] }
 toml = "0.8"
 
 # Error handling

--- a/crates/icm-cli/Cargo.toml
+++ b/crates/icm-cli/Cargo.toml
@@ -43,6 +43,7 @@ tower-http = { workspace = true, optional = true }
 rust-embed = { workspace = true, optional = true }
 mime_guess = { workspace = true, optional = true }
 getrandom = { workspace = true, optional = true }
+serde_json_lenient = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2604,12 +2604,20 @@ fn strip_jsonc_comments(content: &str) -> String {
 }
 
 /// Parse a JSON/JSONC config file, handling comments and empty files gracefully.
+/// Parse a JSON config file with lenient parsing: accepts trailing commas
+/// and JSONC comments (// and /* */). This is the only place we use lenient
+/// parsing — all other JSON handling uses strict serde_json.
 fn parse_json_config(config_path: &std::path::Path) -> Result<Value> {
     let content = std::fs::read_to_string(config_path)
         .with_context(|| format!("cannot read {}", config_path.display()))?;
     let clean = strip_jsonc_comments(&content);
-    serde_json::from_str(&clean)
-        .with_context(|| format!("invalid JSON in {}", config_path.display()))
+    // Use serde_json_lenient to accept trailing commas in user-edited configs,
+    // then round-trip to serde_json::Value for compatibility with the rest of the codebase.
+    let lenient: serde_json_lenient::Value = serde_json_lenient::from_str(&clean)
+        .with_context(|| format!("invalid JSON in {}", config_path.display()))?;
+    let strict: Value = serde_json::from_str(&lenient.to_string())
+        .with_context(|| format!("JSON conversion error in {}", config_path.display()))?;
+    Ok(strict)
 }
 
 /// Inject ICM MCP server into a JSON config file. Returns a status string.


### PR DESCRIPTION
I wasn't able to init my zed settings due to the fact that default zed formatter (prettier) adds trailing commas everywhere:
```sh
❯ icm init --mode mcp
[mcp] Claude Code      already configured
[mcp] Claude Desktop   already configured
[mcp] Cursor           already configured
[mcp] Windsurf         already configured
[mcp] VS Code          already configured
[mcp] Gemini           already configured
[mcp] Amp              already configured
[mcp] Amazon Q         already configured
[mcp] Cline            already configured
[mcp] Roo Code         already configured
[mcp] Kilo Code        already configured
Error: invalid JSON in ~/.config/zed/settings.json
```

This also allows to get rid of custom comments cleaning