### PR TITLE
fix: persist hook counter in SQLite instead of /tmp file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.15"
+version = "0.10.16"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1440,24 +1440,16 @@ fn cmd_hook_post(store: &SqliteStore, extract_every: usize, store_raw: bool) -> 
         return Ok(());
     }
 
-    // Counter file for tracking tool calls between invocations
-    let counter_file =
-        std::env::var("ICM_HOOK_COUNTER").unwrap_or_else(|_| "/tmp/icm-hook-counter".to_string());
-
-    let count: usize = std::fs::read_to_string(&counter_file)
-        .ok()
-        .and_then(|s| s.trim().parse().ok())
-        .unwrap_or(0)
-        + 1;
-    let _ = std::fs::write(&counter_file, count.to_string());
+    // Track tool calls in SQLite (atomic, persists across reboots)
+    let count = store.increment_hook_counter().unwrap_or(1);
 
     // Not time to extract yet
     if count < extract_every {
         return Ok(());
     }
 
-    // Reset counter
-    let _ = std::fs::write(&counter_file, "0");
+    // Reset counter after triggering extraction
+    let _ = store.reset_hook_counter();
 
     // Extract from tool output
     let tool_output = json
@@ -4699,5 +4691,66 @@ mod hook_start_tests {
         // call does not panic and returns a valid, non-empty pack.
         assert!(!pack.is_empty());
         assert!(pack.starts_with("# ICM Wake-up"));
+    }
+}
+
+#[cfg(test)]
+mod hook_post_tests {
+    use icm_store::SqliteStore;
+
+    /// Simulates the hook post counter logic: increment, check threshold, reset.
+    /// Returns true if extraction should trigger (count >= extract_every).
+    fn should_extract(store: &SqliteStore, extract_every: usize) -> bool {
+        let count = store.increment_hook_counter().unwrap_or(1);
+        if count >= extract_every {
+            let _ = store.reset_hook_counter();
+            true
+        } else {
+            false
+        }
+    }
+
+    #[test]
+    fn counter_increments_across_calls() {
+        let store = SqliteStore::in_memory().unwrap();
+        // extract_every = 100 so extraction never triggers
+        for i in 1..=10 {
+            let count = store.increment_hook_counter().unwrap();
+            assert_eq!(count, i, "call {i} should return {i}");
+        }
+    }
+
+    #[test]
+    fn extraction_triggers_at_threshold() {
+        let store = SqliteStore::in_memory().unwrap();
+        let extract_every = 3;
+
+        assert!(!should_extract(&store, extract_every)); // call 1
+        assert!(!should_extract(&store, extract_every)); // call 2
+        assert!(should_extract(&store, extract_every)); // call 3 → triggers + resets
+    }
+
+    #[test]
+    fn counter_resets_after_extraction() {
+        let store = SqliteStore::in_memory().unwrap();
+        let extract_every = 3;
+
+        // First cycle: 1, 2, 3 → extract
+        assert!(!should_extract(&store, extract_every));
+        assert!(!should_extract(&store, extract_every));
+        assert!(should_extract(&store, extract_every));
+
+        // Second cycle: counter should start fresh at 1
+        assert!(!should_extract(&store, extract_every)); // 1
+        assert!(!should_extract(&store, extract_every)); // 2
+        assert!(should_extract(&store, extract_every)); // 3 → extract again
+    }
+
+    #[test]
+    fn extract_every_one_triggers_every_call() {
+        let store = SqliteStore::in_memory().unwrap();
+        for _ in 0..5 {
+            assert!(should_extract(&store, 1));
+        }
     }
 }

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -88,6 +88,34 @@ impl SqliteStore {
         Ok(())
     }
 
+    /// Atomically increment the hook call counter and return the new value.
+    /// Uses RETURNING for single-statement atomic increment-and-read.
+    pub fn increment_hook_counter(&self) -> IcmResult<usize> {
+        let count: usize = self
+            .conn
+            .query_row(
+                "INSERT INTO icm_metadata (key, value) VALUES ('hook_counter', '1')
+                 ON CONFLICT(key) DO UPDATE SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT)
+                 RETURNING CAST(value AS INTEGER)",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(db_err)?;
+        Ok(count)
+    }
+
+    /// Reset the hook call counter to 0.
+    pub fn reset_hook_counter(&self) -> IcmResult<()> {
+        self.conn
+            .execute(
+                "INSERT INTO icm_metadata (key, value) VALUES ('hook_counter', '0')
+                 ON CONFLICT(key) DO UPDATE SET value = '0'",
+                [],
+            )
+            .map_err(db_err)?;
+        Ok(())
+    }
+
     pub fn in_memory() -> IcmResult<Self> {
         ensure_sqlite_vec();
         let conn = Connection::open_in_memory()
@@ -3868,5 +3896,59 @@ mod tests {
         // Verify 0 remain
         let after = store.get_by_topic("ephemeral").unwrap();
         assert!(after.is_empty());
+    }
+
+    // === Hook counter tests ===
+
+    #[test]
+    fn test_hook_counter_starts_at_one() {
+        let store = test_store();
+        let count = store.increment_hook_counter().unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_hook_counter_increments() {
+        let store = test_store();
+        for expected in 1..=5 {
+            let count = store.increment_hook_counter().unwrap();
+            assert_eq!(count, expected);
+        }
+    }
+
+    #[test]
+    fn test_hook_counter_reset() {
+        let store = test_store();
+        // Increment a few times
+        store.increment_hook_counter().unwrap();
+        store.increment_hook_counter().unwrap();
+        store.increment_hook_counter().unwrap();
+
+        // Reset
+        store.reset_hook_counter().unwrap();
+
+        // Next increment should return 1 again
+        let count = store.increment_hook_counter().unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_hook_counter_reset_then_increment_cycle() {
+        let store = test_store();
+
+        // First cycle: increment to 3
+        for expected in 1..=3 {
+            let count = store.increment_hook_counter().unwrap();
+            assert_eq!(count, expected);
+        }
+
+        // Reset
+        store.reset_hook_counter().unwrap();
+
+        // Second cycle: increment to 3 again (mimics extract_every=3)
+        for expected in 1..=3 {
+            let count = store.increment_hook_counter().unwrap();
+            assert_eq!(count, expected);
+        }
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -232,7 +232,7 @@ SqliteStore::in_memory() -> IcmResult<Self>                     // for tests
 | `concepts` | regular | Knowledge graph nodes with UNIQUE(memoir_id, name) |
 | `concepts_fts` | FTS5 virtual | Full-text search on concept id, name, definition, labels |
 | `concept_links` | regular | Typed edges with CHECK(source_id != target_id) |
-| `icm_metadata` | regular | Key-value store (embedding_dims, last_decay_at) |
+| `icm_metadata` | regular | Key-value store (embedding_dims, last_decay_at, hook_counter) |
 
 FTS tables are synchronized via AFTER INSERT/UPDATE/DELETE triggers.
 

--- a/scripts/hooks/icm-post-tool.sh
+++ b/scripts/hooks/icm-post-tool.sh
@@ -6,6 +6,10 @@
 # Input (stdin): JSON with tool_name, tool_input, tool_output, etc.
 # Output: nothing (PostToolUse hooks are fire-and-forget)
 
+# NOTE: The Rust binary (icm hook post) now persists the hook counter in SQLite
+# (icm_metadata table) for reliable, atomic, reboot-safe counting.
+# This shell script retains the file-based /tmp counter for standalone/legacy usage.
+
 set -euo pipefail
 
 # Config


### PR DESCRIPTION
## Summary
Fixes #83

- **Replaced file-based counter** (`/tmp/icm-hook-counter`) with SQLite `icm_metadata` table — atomic `INSERT...ON CONFLICT...RETURNING` eliminates silent write failures in sandboxed environments
- **Added `increment_hook_counter()` + `reset_hook_counter()`** to `SqliteStore`, matching the existing `maybe_auto_decay()` pattern
- **8 new tests** covering sequential increments, reset cycles, threshold triggering, and `extract_every=1` edge case
- **Shell script** (`icm-post-tool.sh`) annotated with deprecation comment; file-based counter retained for standalone/legacy usage

## Why this matters
Claude Code hooks are stateless — each invocation spawns a fresh process. The `/tmp` file write silently failed (sandbox, permissions, `/tmp` cleanup), causing the counter to reset to 1 on every call. Auto-extraction never triggered.

## Known gap (pre-existing, not introduced here)
The shell script resets the counter on `icm_memory_store` tool calls (voluntary store). The Rust binary does not. This is a separate enhancement.

## Test plan
- [x] `cargo test -p icm-store -- hook_counter` (4 tests)
- [x] `cargo test -p icm-cli -- hook_post` (4 tests)
- [x] `cargo test -p icm-store -p icm-cli` (167 tests, full regression)
- [x] `cargo clippy -p icm-store -p icm-cli -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)