### PR TITLE
feat: graph-aware recall, auto-linking & multi-tool hooks (Gemini/Codex/Copilot)

### DIFF
--- a/.github/hooks/icm.json
+++ b/.github/hooks/icm.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "/Users/patrick/dev/rtk-ai/icm/target/release/icm hook start",
+        "timeoutSec": 10
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "/Users/patrick/dev/rtk-ai/icm/target/release/icm hook pre",
+        "timeoutSec": 5
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "bash": "/Users/patrick/dev/rtk-ai/icm/target/release/icm hook post",
+        "timeoutSec": 10
+      }
+    ],
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "/Users/patrick/dev/rtk-ai/icm/target/release/icm hook prompt",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+<!-- icm:start -->
+## Persistent memory (ICM) — MANDATORY
+
+This project uses [ICM](https://github.com/rtk-ai/icm) for persistent memory across sessions.
+You MUST use it actively. Not optional.
+
+### Recall (before starting work)
+```bash
+icm recall "query"                        # search memories
+icm recall "query" -t "topic-name"        # filter by topic
+icm recall-context "query" --limit 5      # formatted for prompt injection
+```
+
+### Store — MANDATORY triggers
+You MUST call `icm store` when ANY of the following happens:
+1. **Error resolved** → `icm store -t errors-resolved -c "description" -i high -k "keyword1,keyword2"`
+2. **Architecture/design decision** → `icm store -t decisions-{project} -c "description" -i high`
+3. **User preference discovered** → `icm store -t preferences -c "description" -i critical`
+4. **Significant task completed** → `icm store -t context-{project} -c "summary of work done" -i high`
+5. **Conversation exceeds ~20 tool calls without a store** → store a progress summary
+
+Do this BEFORE responding to the user. Not after. Not later. Immediately.
+
+Do NOT store: trivial details, info already in CLAUDE.md, ephemeral state (build logs, git status).
+
+### Other commands
+```bash
+icm update <id> -c "updated content"     # edit memory in-place
+icm health                                # topic hygiene audit
+icm topics                                # list all topics
+```
+<!-- icm:end -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.15"
+version = "0.10.16"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1067,8 +1067,36 @@ fn cmd_store(
         }
     }
 
+    // Auto-link: wire the new memory into the existing graph before
+    // persisting. No-op when embedding is unavailable.
+    let auto_link_opts = icm_core::AutoLinkOptions::default();
+    let linked_ids = if memory.embedding.is_some() {
+        icm_core::auto_link_memory(store, &mut memory, &auto_link_opts).unwrap_or_else(|e| {
+            eprintln!("warning: auto-link failed: {e}");
+            Vec::new()
+        })
+    } else {
+        Vec::new()
+    };
+
     let id = store.store(memory)?;
-    println!("Stored: {id}");
+
+    // Back-refs: update each linked memory so the edges are bidirectional.
+    if !linked_ids.is_empty() {
+        if let Err(e) = icm_core::add_backrefs(store, &id, &linked_ids) {
+            eprintln!("warning: auto-link back-refs failed: {e}");
+        }
+    }
+
+    if linked_ids.is_empty() {
+        println!("Stored: {id}");
+    } else {
+        println!(
+            "Stored: {id} (+{} link{})",
+            linked_ids.len(),
+            if linked_ids.len() == 1 { "" } else { "s" }
+        );
+    }
     Ok(())
 }
 
@@ -1097,14 +1125,21 @@ fn cmd_recall(
                     scored.retain(|(m, _)| keyword_matches(&m.keywords, kw));
                 }
 
-                if scored.is_empty() {
+                // Graph-aware expansion: follow related_ids one hop and
+                // fold neighbors into results (discounted 0.5× score).
+                let max_neighbors = (limit / 3).max(1);
+                let expanded = store
+                    .expand_with_neighbors(&scored, max_neighbors, 0.5, limit)
+                    .unwrap_or(scored);
+
+                if expanded.is_empty() {
                     println!("{MSG_NO_MEMORIES}");
                     return Ok(());
                 }
 
-                let ids: Vec<&str> = scored.iter().map(|(m, _)| m.id.as_str()).collect();
+                let ids: Vec<&str> = expanded.iter().map(|(m, _)| m.id.as_str()).collect();
                 let _ = store.batch_update_access(&ids);
-                for (mem, score) in &scored {
+                for (mem, score) in &expanded {
                     print_memory_detail(mem, Some(*score));
                 }
                 return Ok(());
@@ -1127,14 +1162,21 @@ fn cmd_recall(
         results.retain(|m| keyword_matches(&m.keywords, kw));
     }
 
-    if results.is_empty() {
+    // Graph-aware expansion also runs in the keyword-only fallback path.
+    let scored: Vec<(Memory, f32)> = results.into_iter().map(|m| (m, 1.0)).collect();
+    let max_neighbors = (limit / 3).max(1);
+    let expanded = store
+        .expand_with_neighbors(&scored, max_neighbors, 0.5, limit)
+        .unwrap_or(scored);
+
+    if expanded.is_empty() {
         println!("{MSG_NO_MEMORIES}");
         return Ok(());
     }
 
-    let ids: Vec<&str> = results.iter().map(|m| m.id.as_str()).collect();
+    let ids: Vec<&str> = expanded.iter().map(|(m, _)| m.id.as_str()).collect();
     let _ = store.batch_update_access(&ids);
-    for mem in &results {
+    for (mem, _) in &expanded {
         print_memory_detail(mem, None);
     }
 
@@ -1370,14 +1412,18 @@ fn cmd_hook_pre() -> Result<()> {
         Err(_) => return Ok(()), // Malformed input — pass through silently
     };
 
-    // Only handle Bash tool calls
+    // Only handle Bash/shell tool calls (name varies by tool:
+    //   Claude Code/Codex: "Bash", Gemini CLI: "run_shell_command")
     let tool_name = json.get("tool_name").and_then(|v| v.as_str()).unwrap_or("");
-    if tool_name != "Bash" {
+    if !matches!(tool_name, "Bash" | "run_shell_command") {
         return Ok(());
     }
 
+    // Command path varies: Claude/Codex use tool_input.command,
+    // Gemini uses tool_input.command or input.command
     let cmd = json
         .pointer("/tool_input/command")
+        .or_else(|| json.pointer("/input/command"))
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
@@ -1598,9 +1644,13 @@ fn cmd_hook_prompt(store: &SqliteStore) -> Result<()> {
         Err(_) => return Ok(()),
     };
 
-    // Extract query from user message
+    // Extract query from user message (field name varies by tool:
+    //   Claude Code: "user_message", Codex: "user_message",
+    //   Gemini BeforeAgent: "prompt" or "input", fallback: "message")
     let message = json
         .get("user_message")
+        .or_else(|| json.get("prompt"))
+        .or_else(|| json.get("input"))
         .or_else(|| json.get("message"))
         .and_then(|v| v.as_str())
         .unwrap_or("");
@@ -1945,6 +1995,12 @@ fn cmd_init(mode: InitMode) -> Result<()> {
         let opencode_path = PathBuf::from(&home).join(".config/opencode/opencode.json");
         let opencode_status = inject_opencode_mcp_server(&opencode_path, "icm", &icm_bin_str)?;
         println!("[mcp] {:<16} {opencode_status}", "OpenCode");
+
+        // Copilot CLI uses mcpServers key with explicit "type": "local"
+        let copilot_path = PathBuf::from(&home).join(".copilot/mcp-config.json");
+        let copilot_status =
+            inject_copilot_cli_mcp_server(&copilot_path, "icm", &icm_bin_str)?;
+        println!("[mcp] {:<16} {copilot_status}", "Copilot CLI");
     }
 
     // --- CLI mode: inject instructions into each tool's file ---
@@ -2087,7 +2143,7 @@ Do this BEFORE responding to the user. Not optional.
 
         // PreToolUse hook: `icm hook pre` (auto-allow icm commands)
         let pre_cmd = format!("{} hook pre", icm_bin_str);
-        let pre_status = inject_claude_hook(
+        let pre_status = inject_settings_hook(
             &claude_settings_path,
             "PreToolUse",
             &pre_cmd,
@@ -2098,7 +2154,7 @@ Do this BEFORE responding to the user. Not optional.
 
         // PostToolUse hook: `icm hook post` (auto-extract context)
         let post_cmd = format!("{} hook post", icm_bin_str);
-        let post_status = inject_claude_hook(
+        let post_status = inject_settings_hook(
             &claude_settings_path,
             "PostToolUse",
             &post_cmd,
@@ -2109,7 +2165,7 @@ Do this BEFORE responding to the user. Not optional.
 
         // PreCompact hook: `icm hook compact` (extract from transcript before compression)
         let compact_cmd = format!("{} hook compact", icm_bin_str);
-        let compact_status = inject_claude_hook(
+        let compact_status = inject_settings_hook(
             &claude_settings_path,
             "PreCompact",
             &compact_cmd,
@@ -2120,7 +2176,7 @@ Do this BEFORE responding to the user. Not optional.
 
         // UserPromptSubmit hook: `icm hook prompt` (recall context on each prompt)
         let prompt_cmd = format!("{} hook prompt", icm_bin_str);
-        let prompt_status = inject_claude_hook(
+        let prompt_status = inject_settings_hook(
             &claude_settings_path,
             "UserPromptSubmit",
             &prompt_cmd,
@@ -2131,7 +2187,7 @@ Do this BEFORE responding to the user. Not optional.
 
         // SessionStart hook: `icm hook start` (inject wake-up pack of critical facts)
         let start_cmd = format!("{} hook start", icm_bin_str);
-        let start_status = inject_claude_hook(
+        let start_status = inject_settings_hook(
             &claude_settings_path,
             "SessionStart",
             &start_cmd,
@@ -2157,6 +2213,105 @@ Do this BEFORE responding to the user. Not optional.
                 .with_context(|| format!("cannot write {}", opencode_plugin_path.display()))?;
             println!("[hook] OpenCode plugin: installed");
         }
+
+        // --- Gemini CLI hooks (same settings.json format as Claude Code, different event names) ---
+        let gemini_settings_path = PathBuf::from(&home).join(".gemini/settings.json");
+        let detect = &["icm hook", "icm-post-tool"];
+
+        // SessionStart → same name in Gemini CLI
+        let status = inject_settings_hook(
+            &gemini_settings_path,
+            "SessionStart",
+            &format!("{} hook start", icm_bin_str),
+            None,
+            &["icm hook start", "icm hook", "icm-post-tool"],
+        )?;
+        println!("[hook] Gemini CLI SessionStart (wake-up pack): {status}");
+
+        // BeforeTool → equivalent of PreToolUse (auto-allow icm commands)
+        // Gemini CLI uses "run_shell_command" as the Bash tool name
+        let status = inject_settings_hook(
+            &gemini_settings_path,
+            "BeforeTool",
+            &format!("{} hook pre", icm_bin_str),
+            Some("run_shell_command"),
+            &["icm-pretool", "icm hook pre"],
+        )?;
+        println!("[hook] Gemini CLI BeforeTool (auto-allow): {status}");
+
+        // AfterTool → equivalent of PostToolUse (auto-extract context)
+        let status = inject_settings_hook(
+            &gemini_settings_path,
+            "AfterTool",
+            &format!("{} hook post", icm_bin_str),
+            None,
+            detect,
+        )?;
+        println!("[hook] Gemini CLI AfterTool (auto-extract): {status}");
+
+        // PreCompress → equivalent of PreCompact (extract from transcript)
+        let status = inject_settings_hook(
+            &gemini_settings_path,
+            "PreCompress",
+            &format!("{} hook compact", icm_bin_str),
+            None,
+            detect,
+        )?;
+        println!("[hook] Gemini CLI PreCompress (transcript extract): {status}");
+
+        // BeforeAgent → equivalent of UserPromptSubmit (auto-recall on each prompt)
+        let status = inject_settings_hook(
+            &gemini_settings_path,
+            "BeforeAgent",
+            &format!("{} hook prompt", icm_bin_str),
+            None,
+            detect,
+        )?;
+        println!("[hook] Gemini CLI BeforeAgent (auto-recall): {status}");
+
+        // --- Codex CLI hooks (separate hooks.json file) ---
+        let codex_hooks_path = PathBuf::from(&home).join(".codex/hooks.json");
+
+        let status = inject_codex_hook(
+            &codex_hooks_path,
+            "SessionStart",
+            &format!("{} hook start", icm_bin_str),
+            None,
+            &["icm hook start", "icm hook"],
+        )?;
+        println!("[hook] Codex CLI SessionStart (wake-up pack): {status}");
+
+        let status = inject_codex_hook(
+            &codex_hooks_path,
+            "PreToolUse",
+            &format!("{} hook pre", icm_bin_str),
+            Some("Bash"),
+            &["icm-pretool", "icm hook pre"],
+        )?;
+        println!("[hook] Codex CLI PreToolUse (auto-allow): {status}");
+
+        let status = inject_codex_hook(
+            &codex_hooks_path,
+            "PostToolUse",
+            &format!("{} hook post", icm_bin_str),
+            None,
+            detect,
+        )?;
+        println!("[hook] Codex CLI PostToolUse (auto-extract): {status}");
+
+        let status = inject_codex_hook(
+            &codex_hooks_path,
+            "UserPromptSubmit",
+            &format!("{} hook prompt", icm_bin_str),
+            None,
+            detect,
+        )?;
+        println!("[hook] Codex CLI UserPromptSubmit (auto-recall): {status}");
+
+        // --- Copilot CLI hooks (per-repo .github/hooks/icm.json) ---
+        let cwd = std::env::current_dir().context("failed to get current directory")?;
+        let copilot_status = inject_copilot_hooks(&cwd, &icm_bin_str)?;
+        println!("[hook] Copilot CLI (all hooks): {copilot_status}");
     }
 
     println!();
@@ -2191,10 +2346,11 @@ fn inject_icm_block(path: &PathBuf, block: &str) -> Result<String> {
     }
 }
 
-/// Inject ICM hook into Claude Code settings.json for a given event name.
+/// Inject ICM hook into a settings.json file (Claude Code or Gemini CLI) for a given event name.
+/// Both tools use the same JSON format: `{ "hooks": { "EventName": [ { "matcher": ..., "hooks": [...] } ] } }`.
 /// `matcher` is optional — if set (e.g. "Bash"), adds a matcher field to the hook entry.
 /// `detect_patterns` lists substrings to detect if the hook is already present.
-fn inject_claude_hook(
+fn inject_settings_hook(
     settings_path: &PathBuf,
     event_name: &str,
     hook_command: &str,
@@ -2261,6 +2417,82 @@ fn inject_claude_hook(
     let output = serde_json::to_string_pretty(&config)?;
     std::fs::write(settings_path, output)
         .with_context(|| format!("cannot write {}", settings_path.display()))?;
+
+    Ok("configured".into())
+}
+
+/// Inject ICM hook into Codex CLI hooks.json for a given event name.
+/// Codex uses a separate `~/.codex/hooks.json` file (not inside config.toml).
+/// Format is the same as Claude Code: `{ "hooks": { "EventName": [ { "matcher": ..., "hooks": [...] } ] } }`.
+fn inject_codex_hook(
+    hooks_path: &PathBuf,
+    event_name: &str,
+    hook_command: &str,
+    matcher: Option<&str>,
+    detect_patterns: &[&str],
+) -> Result<String> {
+    let mut config: Value = if hooks_path.exists() {
+        parse_json_config(hooks_path)?
+    } else {
+        if let Some(parent) = hooks_path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        serde_json::json!({})
+    };
+
+    let hooks = config
+        .as_object_mut()
+        .context("hooks.json is not a JSON object")?
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}));
+
+    let event_hooks = hooks
+        .as_object_mut()
+        .context("hooks is not a JSON object")?
+        .entry(event_name)
+        .or_insert_with(|| serde_json::json!([]));
+
+    let event_arr = event_hooks
+        .as_array_mut()
+        .with_context(|| format!("{event_name} is not an array"))?;
+
+    // Check if ICM hook already exists
+    let already = event_arr.iter().any(|entry| {
+        entry
+            .get("hooks")
+            .and_then(|h| h.as_array())
+            .map(|hooks| {
+                hooks.iter().any(|h| {
+                    h.get("command")
+                        .and_then(|c| c.as_str())
+                        .map(|c| detect_patterns.iter().any(|p| c.contains(p)))
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false)
+    });
+
+    if already {
+        return Ok("already configured".into());
+    }
+
+    let mut entry = serde_json::json!({
+        "hooks": [{
+            "type": "command",
+            "command": hook_command
+        }]
+    });
+    if let Some(m) = matcher {
+        entry
+            .as_object_mut()
+            .unwrap()
+            .insert("matcher".into(), serde_json::json!(m));
+    }
+    event_arr.push(entry);
+
+    let output = serde_json::to_string_pretty(&config)?;
+    std::fs::write(hooks_path, output)
+        .with_context(|| format!("cannot write {}", hooks_path.display()))?;
 
     Ok("configured".into())
 }
@@ -2451,6 +2683,104 @@ fn inject_zed_mcp_server(config_path: &PathBuf, name: &str, bin_path: &str) -> R
     let output = serde_json::to_string_pretty(&config)?;
     std::fs::write(config_path, output)
         .with_context(|| format!("cannot write {}", config_path.display()))?;
+
+    Ok("configured".into())
+}
+
+/// Inject ICM MCP server into Copilot CLI config (~/.copilot/mcp-config.json).
+/// Copilot CLI uses `mcpServers` key with explicit `"type": "local"`.
+fn inject_copilot_cli_mcp_server(
+    config_path: &PathBuf,
+    name: &str,
+    icm_bin: &str,
+) -> Result<String> {
+    let mut config: Value = if config_path.exists() {
+        parse_json_config(config_path)?
+    } else {
+        if let Some(parent) = config_path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        serde_json::json!({})
+    };
+
+    let servers = config
+        .as_object_mut()
+        .context("config is not a JSON object")?
+        .entry("mcpServers")
+        .or_insert_with(|| serde_json::json!({}));
+
+    if let Some(existing) = servers.get(name) {
+        if existing.get("command").and_then(|v| v.as_str()) == Some(icm_bin) {
+            return Ok("already configured".into());
+        }
+    }
+
+    servers
+        .as_object_mut()
+        .unwrap()
+        .insert(
+            name.to_string(),
+            serde_json::json!({
+                "type": "local",
+                "command": icm_bin,
+                "args": ["serve"],
+                "tools": ["*"]
+            }),
+        );
+
+    let output = serde_json::to_string_pretty(&config)?;
+    std::fs::write(config_path, output)
+        .with_context(|| format!("cannot write {}", config_path.display()))?;
+
+    Ok("configured".into())
+}
+
+/// Inject ICM hooks into Copilot CLI hooks file (.github/hooks/icm.json).
+/// Copilot CLI uses a per-repo hooks file with a different format:
+/// `{ "version": 1, "hooks": { "eventName": [{ "type": "command", "bash": "...", "timeoutSec": N }] } }`
+fn inject_copilot_hooks(cwd: &std::path::Path, icm_bin: &str) -> Result<String> {
+    let hooks_dir = cwd.join(".github/hooks");
+    let hooks_path = hooks_dir.join("icm.json");
+
+    if hooks_path.exists() {
+        let content = std::fs::read_to_string(&hooks_path)
+            .with_context(|| format!("cannot read {}", hooks_path.display()))?;
+        if content.contains("icm hook") {
+            return Ok("already configured".into());
+        }
+    }
+
+    std::fs::create_dir_all(&hooks_dir).ok();
+
+    let hooks_config = serde_json::json!({
+        "version": 1,
+        "hooks": {
+            "sessionStart": [{
+                "type": "command",
+                "bash": format!("{icm_bin} hook start"),
+                "timeoutSec": 10
+            }],
+            "preToolUse": [{
+                "type": "command",
+                "bash": format!("{icm_bin} hook pre"),
+                "timeoutSec": 5
+            }],
+            "postToolUse": [{
+                "type": "command",
+                "bash": format!("{icm_bin} hook post"),
+                "timeoutSec": 10
+            }],
+            "userPromptSubmitted": [{
+                "type": "command",
+                "bash": format!("{icm_bin} hook prompt"),
+                "timeoutSec": 10
+            }]
+        }
+    });
+
+    let output = serde_json::to_string_pretty(&hooks_config)?;
+    std::fs::write(&hooks_path, output)
+        .with_context(|| format!("cannot write {}", hooks_path.display()))?;
 
     Ok("configured".into())
 }

--- a/crates/icm-core/src/auto_link.rs
+++ b/crates/icm-core/src/auto_link.rs
@@ -1,0 +1,410 @@
+//! Automatic bidirectional linking of memories at store time.
+//!
+//! When a new memory is stored, `auto_link_memory` searches for the most
+//! similar existing memories (by embedding cosine similarity) above a
+//! threshold and populates the new memory's `related_ids` with their ids.
+//! `add_backrefs` then updates the linked memories so the edges are
+//! bidirectional.
+//!
+//! This turns ICM's manual knowledge graph into a self-growing associative
+//! network. No schema change is required — both the `Memory.related_ids`
+//! field and the `search_by_embedding` method already exist.
+
+use crate::error::IcmResult;
+use crate::memory::Memory;
+use crate::store::MemoryStore;
+
+/// Options controlling how auto-linking behaves.
+#[derive(Debug, Clone, Copy)]
+pub struct AutoLinkOptions {
+    /// Enable/disable auto-linking entirely.
+    pub enabled: bool,
+    /// Cosine similarity threshold above which a candidate becomes a link.
+    /// Typical value for `multilingual-e5-base` (768d): 0.75.
+    pub threshold: f32,
+    /// Maximum number of outgoing links from a newly stored memory.
+    pub max_links: usize,
+}
+
+impl Default for AutoLinkOptions {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            threshold: 0.75,
+            max_links: 5,
+        }
+    }
+}
+
+/// Find candidates similar to `new_memory` and populate its `related_ids`.
+///
+/// The new memory **must already have its embedding set**; otherwise this
+/// function returns `Ok(Vec::new())` without touching the memory. The store
+/// is queried via `search_by_embedding`.
+///
+/// Returns the list of memory ids that were added as forward links. The
+/// caller is expected to then `store(new_memory)` (persisting the forward
+/// links) and then call `add_backrefs` to complete the bidirectional graph.
+///
+/// Candidates that are the new memory itself are skipped (defensive, since
+/// the new memory is typically not yet in the store at this point).
+/// Candidates that are already in `related_ids` are not duplicated.
+pub fn auto_link_memory<S: MemoryStore + ?Sized>(
+    store: &S,
+    new_memory: &mut Memory,
+    opts: &AutoLinkOptions,
+) -> IcmResult<Vec<String>> {
+    if !opts.enabled || opts.max_links == 0 {
+        return Ok(Vec::new());
+    }
+
+    let Some(ref emb) = new_memory.embedding else {
+        // No embedding → no auto-link. This is expected when the embedder
+        // is disabled; callers should skip gracefully.
+        return Ok(Vec::new());
+    };
+
+    // Request one extra result so we can skip self-matches without running
+    // out of candidates.
+    let fetch_n = opts.max_links.saturating_add(1);
+    let candidates = store.search_by_embedding(emb, fetch_n)?;
+
+    let mut new_links: Vec<String> = Vec::new();
+    for (candidate, score) in candidates {
+        if score < opts.threshold {
+            continue;
+        }
+        if candidate.id == new_memory.id {
+            continue;
+        }
+        if new_memory.related_ids.contains(&candidate.id) {
+            continue;
+        }
+        new_memory.related_ids.push(candidate.id.clone());
+        new_links.push(candidate.id);
+        if new_links.len() >= opts.max_links {
+            break;
+        }
+    }
+
+    Ok(new_links)
+}
+
+/// Update each memory in `linked_ids` so that it points back to
+/// `new_memory_id` via its own `related_ids` list. Idempotent — if the
+/// back-ref is already present, the memory is left unchanged.
+///
+/// Best-effort: a failure on one back-ref is logged by the caller but does
+/// not roll back the others. The graph is allowed to be slightly asymmetric
+/// under error conditions rather than losing the whole operation.
+pub fn add_backrefs<S: MemoryStore + ?Sized>(
+    store: &S,
+    new_memory_id: &str,
+    linked_ids: &[String],
+) -> IcmResult<usize> {
+    let mut updated = 0usize;
+    for id in linked_ids {
+        if let Some(mut existing) = store.get(id)? {
+            if existing.related_ids.iter().any(|r| r == new_memory_id) {
+                continue;
+            }
+            existing.related_ids.push(new_memory_id.to_string());
+            store.update(&existing)?;
+            updated += 1;
+        }
+    }
+    Ok(updated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::IcmResult;
+    use crate::memory::{Importance, Memory, StoreStats, TopicHealth};
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    /// Minimal in-memory `MemoryStore` implementation for unit testing the
+    /// auto-link logic without pulling in the full sqlite store.
+    struct FakeStore {
+        memories: RefCell<HashMap<String, Memory>>,
+        /// Pre-seeded similarity scores keyed by memory id, used to fake
+        /// `search_by_embedding` deterministically.
+        similarity: RefCell<HashMap<String, f32>>,
+    }
+
+    impl FakeStore {
+        fn new() -> Self {
+            Self {
+                memories: RefCell::new(HashMap::new()),
+                similarity: RefCell::new(HashMap::new()),
+            }
+        }
+
+        fn insert(&self, mem: Memory, score: f32) {
+            self.similarity.borrow_mut().insert(mem.id.clone(), score);
+            self.memories.borrow_mut().insert(mem.id.clone(), mem);
+        }
+    }
+
+    impl MemoryStore for FakeStore {
+        fn store(&self, memory: Memory) -> IcmResult<String> {
+            let id = memory.id.clone();
+            self.memories.borrow_mut().insert(id.clone(), memory);
+            Ok(id)
+        }
+
+        fn get(&self, id: &str) -> IcmResult<Option<Memory>> {
+            Ok(self.memories.borrow().get(id).cloned())
+        }
+
+        fn update(&self, memory: &Memory) -> IcmResult<()> {
+            self.memories
+                .borrow_mut()
+                .insert(memory.id.clone(), memory.clone());
+            Ok(())
+        }
+
+        fn delete(&self, id: &str) -> IcmResult<()> {
+            self.memories.borrow_mut().remove(id);
+            Ok(())
+        }
+
+        fn search_by_keywords(&self, _keywords: &[&str], _limit: usize) -> IcmResult<Vec<Memory>> {
+            Ok(Vec::new())
+        }
+
+        fn search_fts(&self, _query: &str, _limit: usize) -> IcmResult<Vec<Memory>> {
+            Ok(Vec::new())
+        }
+
+        fn search_by_embedding(
+            &self,
+            _embedding: &[f32],
+            limit: usize,
+        ) -> IcmResult<Vec<(Memory, f32)>> {
+            // Return seeded memories sorted by their pre-set similarity desc.
+            let mut results: Vec<(Memory, f32)> = self
+                .memories
+                .borrow()
+                .values()
+                .cloned()
+                .map(|m| {
+                    let score = *self.similarity.borrow().get(&m.id).unwrap_or(&0.0);
+                    (m, score)
+                })
+                .collect();
+            results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            results.truncate(limit);
+            Ok(results)
+        }
+
+        fn search_hybrid(
+            &self,
+            _query: &str,
+            embedding: &[f32],
+            limit: usize,
+        ) -> IcmResult<Vec<(Memory, f32)>> {
+            self.search_by_embedding(embedding, limit)
+        }
+
+        fn update_access(&self, _id: &str) -> IcmResult<()> {
+            Ok(())
+        }
+        fn batch_update_access(&self, _ids: &[&str]) -> IcmResult<usize> {
+            Ok(0)
+        }
+        fn apply_decay(&self, _decay_factor: f32) -> IcmResult<usize> {
+            Ok(0)
+        }
+        fn prune(&self, _weight_threshold: f32) -> IcmResult<usize> {
+            Ok(0)
+        }
+        fn list_all(&self) -> IcmResult<Vec<Memory>> {
+            Ok(self.memories.borrow().values().cloned().collect())
+        }
+        fn get_by_topic(&self, topic: &str) -> IcmResult<Vec<Memory>> {
+            Ok(self
+                .memories
+                .borrow()
+                .values()
+                .filter(|m| m.topic == topic)
+                .cloned()
+                .collect())
+        }
+        fn list_topics(&self) -> IcmResult<Vec<(String, usize)>> {
+            Ok(Vec::new())
+        }
+        fn consolidate_topic(&self, _topic: &str, _consolidated: Memory) -> IcmResult<()> {
+            Ok(())
+        }
+        fn count(&self) -> IcmResult<usize> {
+            Ok(self.memories.borrow().len())
+        }
+        fn count_by_topic(&self, _topic: &str) -> IcmResult<usize> {
+            Ok(0)
+        }
+        fn stats(&self) -> IcmResult<StoreStats> {
+            Ok(StoreStats {
+                total_memories: self.memories.borrow().len(),
+                total_topics: 0,
+                avg_weight: 1.0,
+                oldest_memory: None,
+                newest_memory: None,
+            })
+        }
+        fn topic_health(&self, topic: &str) -> IcmResult<TopicHealth> {
+            Ok(TopicHealth {
+                topic: topic.to_string(),
+                entry_count: 0,
+                avg_weight: 1.0,
+                avg_access_count: 0.0,
+                oldest: None,
+                newest: None,
+                last_accessed: None,
+                needs_consolidation: false,
+                stale_count: 0,
+            })
+        }
+    }
+
+    fn mem_with_emb(topic: &str, summary: &str, imp: Importance) -> Memory {
+        let mut m = Memory::new(topic.into(), summary.into(), imp);
+        m.embedding = Some(vec![0.1; 8]); // dimensions don't matter with FakeStore
+        m
+    }
+
+    #[test]
+    fn disabled_returns_empty_and_mutates_nothing() {
+        let store = FakeStore::new();
+        let mut new_mem = mem_with_emb("decisions-icm", "new decision", Importance::High);
+        let opts = AutoLinkOptions {
+            enabled: false,
+            ..Default::default()
+        };
+        let links = auto_link_memory(&store, &mut new_mem, &opts).unwrap();
+        assert!(links.is_empty());
+        assert!(new_mem.related_ids.is_empty());
+    }
+
+    #[test]
+    fn no_embedding_skips_linking() {
+        let store = FakeStore::new();
+        let mut new_mem = Memory::new("t".into(), "summary".into(), Importance::High);
+        // No embedding set.
+        let links = auto_link_memory(&store, &mut new_mem, &AutoLinkOptions::default()).unwrap();
+        assert!(links.is_empty());
+        assert!(new_mem.related_ids.is_empty());
+    }
+
+    #[test]
+    fn links_candidates_above_threshold() {
+        let store = FakeStore::new();
+        let m1 = mem_with_emb("t", "related 1", Importance::High);
+        let m2 = mem_with_emb("t", "related 2", Importance::Medium);
+        let m3 = mem_with_emb("t", "unrelated", Importance::Low);
+        store.insert(m1.clone(), 0.92);
+        store.insert(m2.clone(), 0.81);
+        store.insert(m3.clone(), 0.40); // below threshold
+
+        let mut new_mem = mem_with_emb("t", "new", Importance::High);
+        let links = auto_link_memory(&store, &mut new_mem, &AutoLinkOptions::default()).unwrap();
+
+        assert_eq!(links.len(), 2);
+        assert!(links.contains(&m1.id));
+        assert!(links.contains(&m2.id));
+        assert!(!links.contains(&m3.id));
+        assert_eq!(new_mem.related_ids, links);
+    }
+
+    #[test]
+    fn respects_max_links_cap() {
+        let store = FakeStore::new();
+        for i in 0..10 {
+            let m = mem_with_emb("t", &format!("high-sim {i}"), Importance::High);
+            store.insert(m, 0.9);
+        }
+        let mut new_mem = mem_with_emb("t", "new", Importance::High);
+        let opts = AutoLinkOptions {
+            enabled: true,
+            threshold: 0.75,
+            max_links: 3,
+        };
+        let links = auto_link_memory(&store, &mut new_mem, &opts).unwrap();
+        assert_eq!(links.len(), 3);
+    }
+
+    #[test]
+    fn skips_candidate_matching_self_id() {
+        let store = FakeStore::new();
+        let self_mem = mem_with_emb("t", "self", Importance::High);
+        let self_id = self_mem.id.clone();
+        store.insert(self_mem, 0.99);
+
+        // Attempt to auto-link a memory with the SAME id (pathological).
+        let mut new_mem = mem_with_emb("t", "new", Importance::High);
+        new_mem.id = self_id.clone();
+        let links = auto_link_memory(&store, &mut new_mem, &AutoLinkOptions::default()).unwrap();
+        assert!(links.is_empty(), "should not self-link: {links:?}");
+    }
+
+    #[test]
+    fn does_not_duplicate_existing_related_ids() {
+        let store = FakeStore::new();
+        let m1 = mem_with_emb("t", "existing link", Importance::High);
+        store.insert(m1.clone(), 0.9);
+
+        let mut new_mem = mem_with_emb("t", "new", Importance::High);
+        new_mem.related_ids.push(m1.id.clone());
+
+        let links = auto_link_memory(&store, &mut new_mem, &AutoLinkOptions::default()).unwrap();
+        assert!(links.is_empty(), "should skip already-linked id");
+        assert_eq!(new_mem.related_ids.len(), 1);
+    }
+
+    #[test]
+    fn add_backrefs_is_symmetric() {
+        let store = FakeStore::new();
+        let m1 = mem_with_emb("t", "target 1", Importance::High);
+        let m2 = mem_with_emb("t", "target 2", Importance::High);
+        store.insert(m1.clone(), 0.0);
+        store.insert(m2.clone(), 0.0);
+
+        let new_id = "01NEWMEMORY";
+        let linked: Vec<String> = vec![m1.id.clone(), m2.id.clone()];
+        let updated = add_backrefs(&store, new_id, &linked).unwrap();
+        assert_eq!(updated, 2);
+
+        // Verify each linked memory now points back to new_id.
+        let m1_updated = store.get(&m1.id).unwrap().unwrap();
+        let m2_updated = store.get(&m2.id).unwrap().unwrap();
+        assert!(m1_updated.related_ids.contains(&new_id.to_string()));
+        assert!(m2_updated.related_ids.contains(&new_id.to_string()));
+    }
+
+    #[test]
+    fn add_backrefs_is_idempotent() {
+        let store = FakeStore::new();
+        let mut m1 = mem_with_emb("t", "already linked", Importance::High);
+        m1.related_ids.push("01NEW".into());
+        store.insert(m1.clone(), 0.0);
+
+        let updated = add_backrefs(&store, "01NEW", &[m1.id.clone()]).unwrap();
+        assert_eq!(
+            updated, 0,
+            "idempotent — should not re-add existing backref"
+        );
+
+        // And the related_ids should still have exactly one entry.
+        let reread = store.get(&m1.id).unwrap().unwrap();
+        assert_eq!(reread.related_ids.len(), 1);
+    }
+
+    #[test]
+    fn add_backrefs_silently_ignores_missing_targets() {
+        let store = FakeStore::new();
+        // No memories inserted — linked_ids point to ghosts.
+        let updated = add_backrefs(&store, "01NEW", &["ghost1".into(), "ghost2".into()]).unwrap();
+        assert_eq!(updated, 0);
+    }
+}

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auto_link;
 pub mod embedder;
 pub mod error;
 #[cfg(feature = "embeddings")]
@@ -14,6 +15,7 @@ pub mod wake_up;
 /// Default embedding vector dimensions (used when no embedder is configured).
 pub const DEFAULT_EMBEDDING_DIMS: usize = 384;
 
+pub use auto_link::{add_backrefs, auto_link_memory, AutoLinkOptions};
 pub use embedder::Embedder;
 pub use error::{IcmError, IcmResult};
 #[cfg(feature = "embeddings")]

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -2,9 +2,9 @@ use chrono::Utc;
 use serde_json::{json, Value};
 
 use icm_core::{
-    build_wake_up, keyword_matches, topic_matches, Concept, ConceptLink, Embedder, Feedback,
-    FeedbackStore, Label, Memoir, MemoirStore, Memory, MemoryStore, Relation, WakeUpFormat,
-    WakeUpOptions, MSG_NO_MEMORIES,
+    add_backrefs, auto_link_memory, build_wake_up, keyword_matches, topic_matches, AutoLinkOptions,
+    Concept, ConceptLink, Embedder, Feedback, FeedbackStore, Label, Memoir, MemoirStore, Memory,
+    MemoryStore, Relation, WakeUpFormat, WakeUpOptions, MSG_NO_MEMORIES,
 };
 use icm_store::SqliteStore;
 
@@ -801,16 +801,48 @@ fn tool_store(
         }
     }
 
+    // Auto-link: populate `related_ids` with similar existing memories BEFORE
+    // storing, so the new memory lands in the DB with its forward edges
+    // already set. Back-refs are added AFTER storing so the linked memories
+    // point to an id that exists in the DB.
+    let auto_link_opts = AutoLinkOptions::default();
+    let linked_ids = if memory.embedding.is_some() {
+        auto_link_memory(store, &mut memory, &auto_link_opts).unwrap_or_else(|e| {
+            tracing::warn!("auto-link failed: {e}");
+            Vec::new()
+        })
+    } else {
+        Vec::new()
+    };
+
     match store.store(memory) {
         Ok(id) => {
+            // Best-effort back-ref update. Failure here leaves an asymmetric
+            // edge (forward-only) but does not fail the store call.
+            if !linked_ids.is_empty() {
+                if let Err(e) = add_backrefs(store, &id, &linked_ids) {
+                    tracing::warn!("auto-link back-ref update failed: {e}");
+                }
+            }
+
+            let link_suffix = if linked_ids.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    " (+{} link{})",
+                    linked_ids.len(),
+                    if linked_ids.len() == 1 { "" } else { "s" }
+                )
+            };
+
             if compact {
                 // Try auto-consolidation even in compact mode
                 let consolidation_msg =
                     try_auto_consolidate(store, topic, AUTO_CONSOLIDATE_THRESHOLD);
                 if consolidation_msg.is_empty() {
-                    ToolResult::text(format!("ok:{id}"))
+                    ToolResult::text(format!("ok:{id}{link_suffix}"))
                 } else {
-                    ToolResult::text(format!("ok:{id}\n{consolidation_msg}"))
+                    ToolResult::text(format!("ok:{id}{link_suffix}\n{consolidation_msg}"))
                 }
             } else {
                 let consolidation_msg =
@@ -828,9 +860,11 @@ fn tool_store(
                     } else {
                         String::new()
                     };
-                    ToolResult::text(format!("Stored memory: {id}{hint}"))
+                    ToolResult::text(format!("Stored memory: {id}{link_suffix}{hint}"))
                 } else {
-                    ToolResult::text(format!("Stored memory: {id}\n{consolidation_msg}"))
+                    ToolResult::text(format!(
+                        "Stored memory: {id}{link_suffix}\n{consolidation_msg}"
+                    ))
                 }
             }
         }
@@ -900,15 +934,24 @@ fn tool_recall(
                     scored_results.retain(|(m, _)| keyword_matches(&m.keywords, kw));
                 }
 
-                // Batch update access counts
-                let ids: Vec<&str> = scored_results.iter().map(|(m, _)| m.id.as_str()).collect();
+                // Graph-aware expansion: follow `related_ids` one hop from
+                // each primary hit and fold neighbors into the result set.
+                // Neighbors carry a discounted score so they rank below
+                // direct matches but can displace weak primary results.
+                let max_neighbors = (limit / 3).max(1);
+                let expanded = store
+                    .expand_with_neighbors(&scored_results, max_neighbors, 0.5, limit)
+                    .unwrap_or(scored_results);
+
+                // Batch update access counts (includes expanded neighbors)
+                let ids: Vec<&str> = expanded.iter().map(|(m, _)| m.id.as_str()).collect();
                 let _ = store.batch_update_access(&ids);
 
-                if scored_results.is_empty() {
+                if expanded.is_empty() {
                     return ToolResult::text(MSG_NO_MEMORIES.into());
                 }
 
-                return ToolResult::text(format_memory_output(&scored_results, compact));
+                return ToolResult::text(format_memory_output(&expanded, compact));
             }
         }
     }
@@ -934,17 +977,30 @@ fn tool_recall(
         results.retain(|m| keyword_matches(&m.keywords, kw));
     }
 
-    // Batch update access counts
-    let ids: Vec<&str> = results.iter().map(|m| m.id.as_str()).collect();
+    // Convert to scored format with a sentinel score of 1.0 (FTS fallback
+    // doesn't expose a real similarity score, but we still want the graph
+    // expansion to score neighbors relative to their primary parent).
+    let scored: Vec<(Memory, f32)> = results.into_iter().map(|m| (m, 1.0)).collect();
+
+    // Graph-aware expansion also applies in the fallback path so that
+    // keyword-only deployments benefit from auto-linked memories.
+    let max_neighbors = (limit / 3).max(1);
+    let expanded = store
+        .expand_with_neighbors(&scored, max_neighbors, 0.5, limit)
+        .unwrap_or(scored);
+
+    // Batch update access counts (includes expanded neighbors)
+    let ids: Vec<&str> = expanded.iter().map(|(m, _)| m.id.as_str()).collect();
     let _ = store.batch_update_access(&ids);
 
-    if results.is_empty() {
+    if expanded.is_empty() {
         return ToolResult::text(MSG_NO_MEMORIES.into());
     }
 
-    // Convert to scored format (no score = -1.0)
-    let scored: Vec<(Memory, f32)> = results.into_iter().map(|m| (m, -1.0)).collect();
-    ToolResult::text(format_memory_output(&scored, compact))
+    // FTS-path results have synthetic scores — reset to -1.0 for display
+    // so we don't claim a hybrid-search confidence we didn't compute.
+    let for_display: Vec<(Memory, f32)> = expanded.into_iter().map(|(m, _)| (m, -1.0)).collect();
+    ToolResult::text(format_memory_output(&for_display, compact))
 }
 
 fn tool_forget(store: &SqliteStore, args: &Value) -> ToolResult {
@@ -3052,5 +3108,90 @@ description = "A test project"
             .filter_map(|t| t.get("name").and_then(|v| v.as_str()))
             .collect();
         assert!(names.contains(&"icm_wake_up"), "tool not listed: {names:?}");
+    }
+
+    // ── auto-link + graph-aware recall (integration) ─────────────────────
+    //
+    // Note: these tests run WITHOUT an embedder (`None`), so the auto-link
+    // code path is a no-op (it early-returns when `memory.embedding` is
+    // None). To verify the end-to-end graph flow we manually pre-populate
+    // `related_ids` via `icm_memory_update` OR by directly storing memories
+    // with related_ids set via the underlying store (done here through a
+    // helper that bypasses the MCP interface for link setup).
+
+    #[test]
+    fn test_mcp_recall_expands_via_graph_neighbors() {
+        use icm_core::{Importance, Memory};
+        let store = test_store();
+
+        // Build a small graph manually:
+        //   "sqlite-fts5" ←→ "fts5-bm25" ←→ "bm25-ranking"
+        // Query "sqlite-fts5" directly; expect "fts5-bm25" to come via hop.
+        let mut a = Memory::new(
+            "decisions-icm".into(),
+            "Use SQLite FTS5 for full-text search indexing".into(),
+            Importance::Critical,
+        );
+        let mut b = Memory::new(
+            "decisions-icm".into(),
+            "FTS5 provides BM25 ranking out of the box".into(),
+            Importance::High,
+        );
+        a.related_ids.push(b.id.clone());
+        b.related_ids.push(a.id.clone());
+
+        let unrelated = Memory::new(
+            "unrelated".into(),
+            "Totally different topic about network protocols".into(),
+            Importance::High,
+        );
+
+        store.store(a.clone()).unwrap();
+        store.store(b.clone()).unwrap();
+        store.store(unrelated).unwrap();
+
+        // Recall with a query that matches `a` strongly and `b` weakly or
+        // not at all. With graph expansion, `b` should surface via its
+        // `related_ids` link from `a`.
+        let result = call_tool(
+            &store,
+            None,
+            "icm_memory_recall",
+            &json!({"query": "SQLite FTS5 indexing", "limit": 5}),
+            false,
+        );
+        assert!(
+            !result.is_error,
+            "recall failed: {}",
+            result.content[0].text
+        );
+        let text = &result.content[0].text;
+        assert!(text.contains("SQLite FTS5"), "primary hit missing: {text}");
+        assert!(
+            text.contains("BM25 ranking"),
+            "graph-expanded neighbor should appear: {text}"
+        );
+    }
+
+    #[test]
+    fn test_mcp_store_reports_link_count_when_linking_occurs() {
+        // Without embeddings, auto-link is a no-op and the stored message
+        // has no "+N link" suffix. Verify the regular path still works.
+        let store = test_store();
+        let result = call_tool(
+            &store,
+            None,
+            "icm_memory_store",
+            &json!({"topic": "t", "content": "first entry", "importance": "high"}),
+            false,
+        );
+        assert!(!result.is_error);
+        let text = &result.content[0].text;
+        assert!(text.contains("Stored memory"));
+        // No link suffix when embeddings are off.
+        assert!(
+            !text.contains("(+"),
+            "should not claim links without embedder: {text}"
+        );
     }
 }

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -1793,6 +1793,63 @@ impl SqliteStore {
         Ok(true)
     }
 
+    /// Graph expansion: given a list of `(Memory, score)` results from a
+    /// primary search, follow each memory's `related_ids` one hop and fetch
+    /// the neighbors that are not already in the result set.
+    ///
+    /// Each neighbor is scored as `parent_score * hop_discount` (default
+    /// 0.5) so it ranks below its direct-match parent but above unrelated
+    /// low-score results. Returns the combined, deduped, score-descending
+    /// list capped at `max_total` (pass `usize::MAX` for no cap).
+    ///
+    /// This is the core of the graph-aware recall feature: it lets the
+    /// recall path surface memories that are semantically or causally
+    /// linked to the query's direct matches, even if they don't match the
+    /// query text themselves.
+    pub fn expand_with_neighbors(
+        &self,
+        initial: &[(Memory, f32)],
+        max_neighbors: usize,
+        hop_discount: f32,
+        max_total: usize,
+    ) -> IcmResult<Vec<(Memory, f32)>> {
+        if max_neighbors == 0 || initial.is_empty() {
+            let mut out = initial.to_vec();
+            out.truncate(max_total);
+            return Ok(out);
+        }
+
+        let initial_ids: HashSet<String> = initial.iter().map(|(m, _)| m.id.clone()).collect();
+        let mut neighbors: Vec<(Memory, f32)> = Vec::new();
+        let mut seen_neighbors: HashSet<String> = HashSet::new();
+
+        // Walk initial results in score order (they're already sorted).
+        for (mem, score) in initial {
+            for neighbor_id in &mem.related_ids {
+                if initial_ids.contains(neighbor_id) || seen_neighbors.contains(neighbor_id) {
+                    continue;
+                }
+                if let Some(n) = self.get(neighbor_id)? {
+                    seen_neighbors.insert(n.id.clone());
+                    neighbors.push((n, score * hop_discount));
+                    if neighbors.len() >= max_neighbors {
+                        break;
+                    }
+                }
+            }
+            if neighbors.len() >= max_neighbors {
+                break;
+            }
+        }
+
+        // Merge initial + neighbors, then sort descending by score.
+        let mut combined: Vec<(Memory, f32)> = initial.to_vec();
+        combined.extend(neighbors);
+        combined.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        combined.truncate(max_total);
+        Ok(combined)
+    }
+
     /// Get memories by topic prefix (e.g., "wshm" matches "wshm:owner/repo").
     ///
     /// If `topic` ends with `*`, uses LIKE matching. Otherwise exact match.
@@ -3791,6 +3848,188 @@ mod tests {
         store.store(make_memory("other", "unrelated")).unwrap();
         let results = store.get_by_topic_prefix("project:*").unwrap();
         assert_eq!(results.len(), 2);
+    }
+
+    // ── expand_with_neighbors ────────────────────────────────────────────
+
+    #[test]
+    fn test_expand_with_neighbors_brings_hop_1() {
+        let store = test_store();
+        // Create 3 memories. m1 is a direct query hit; m2 and m3 are
+        // related to m1 via related_ids; m3 is unrelated.
+        let mut m1 = make_memory("decisions", "primary hit");
+        let mut m2 = make_memory("decisions", "related neighbor");
+        let m3 = make_memory("unrelated", "far away");
+
+        // Set up the edges before storing.
+        m1.related_ids.push(m2.id.clone());
+        m2.related_ids.push(m1.id.clone());
+
+        let id1 = store.store(m1.clone()).unwrap();
+        let _id2 = store.store(m2.clone()).unwrap();
+        let _id3 = store.store(m3.clone()).unwrap();
+
+        let m1_full = store.get(&id1).unwrap().unwrap();
+        let initial = vec![(m1_full, 0.9_f32)];
+
+        let expanded = store.expand_with_neighbors(&initial, 5, 0.5, 10).unwrap();
+
+        assert_eq!(expanded.len(), 2, "primary + 1 neighbor");
+        assert!(expanded.iter().any(|(m, _)| m.id == m1.id));
+        assert!(
+            expanded.iter().any(|(m, _)| m.id == m2.id),
+            "neighbor should be pulled in"
+        );
+        assert!(
+            expanded.iter().all(|(m, _)| m.id != m3.id),
+            "unrelated memory must not be pulled in: {expanded:?}"
+        );
+    }
+
+    #[test]
+    fn test_expand_with_neighbors_dedupes_initial() {
+        let store = test_store();
+        let mut m1 = make_memory("t", "hit 1");
+        let mut m2 = make_memory("t", "hit 2");
+        m1.related_ids.push(m2.id.clone());
+        m2.related_ids.push(m1.id.clone());
+
+        let id1 = store.store(m1.clone()).unwrap();
+        let id2 = store.store(m2.clone()).unwrap();
+
+        // Both already in the initial set — no neighbor to add.
+        let m1_full = store.get(&id1).unwrap().unwrap();
+        let m2_full = store.get(&id2).unwrap().unwrap();
+        let initial = vec![(m1_full, 0.9_f32), (m2_full, 0.85_f32)];
+
+        let expanded = store.expand_with_neighbors(&initial, 5, 0.5, 10).unwrap();
+        assert_eq!(expanded.len(), 2, "no duplicates when both already present");
+    }
+
+    #[test]
+    fn test_expand_with_neighbors_respects_max_neighbors() {
+        let store = test_store();
+        // m1 has 5 neighbors. Cap max_neighbors at 2.
+        let mut m1 = make_memory("t", "hub");
+        let n1 = make_memory("t", "neighbor 1");
+        let n2 = make_memory("t", "neighbor 2");
+        let n3 = make_memory("t", "neighbor 3");
+        let n4 = make_memory("t", "neighbor 4");
+        let n5 = make_memory("t", "neighbor 5");
+        m1.related_ids.extend([
+            n1.id.clone(),
+            n2.id.clone(),
+            n3.id.clone(),
+            n4.id.clone(),
+            n5.id.clone(),
+        ]);
+
+        let id1 = store.store(m1.clone()).unwrap();
+        for n in [&n1, &n2, &n3, &n4, &n5] {
+            store.store(n.clone()).unwrap();
+        }
+
+        let m1_full = store.get(&id1).unwrap().unwrap();
+        let initial = vec![(m1_full, 0.9_f32)];
+
+        let expanded = store.expand_with_neighbors(&initial, 2, 0.5, 10).unwrap();
+        // 1 primary + 2 neighbors = 3.
+        assert_eq!(expanded.len(), 3);
+    }
+
+    #[test]
+    fn test_expand_with_neighbors_applies_discount() {
+        let store = test_store();
+        let mut m1 = make_memory("t", "primary");
+        let m2 = make_memory("t", "neighbor");
+        m1.related_ids.push(m2.id.clone());
+
+        let id1 = store.store(m1.clone()).unwrap();
+        store.store(m2.clone()).unwrap();
+
+        let m1_full = store.get(&id1).unwrap().unwrap();
+        let initial = vec![(m1_full, 0.9_f32)];
+
+        let expanded = store.expand_with_neighbors(&initial, 5, 0.5, 10).unwrap();
+
+        // Find neighbor score: should be 0.9 * 0.5 = 0.45
+        let neighbor_score = expanded
+            .iter()
+            .find(|(m, _)| m.id == m2.id)
+            .map(|(_, s)| *s)
+            .unwrap();
+        assert!(
+            (neighbor_score - 0.45).abs() < 1e-5,
+            "neighbor discount wrong: {neighbor_score}"
+        );
+    }
+
+    #[test]
+    fn test_expand_with_neighbors_respects_max_total() {
+        let store = test_store();
+        // 3 primaries + 3 neighbors, but max_total=4 caps output.
+        let mut m1 = make_memory("t", "p1");
+        let mut m2 = make_memory("t", "p2");
+        let mut m3 = make_memory("t", "p3");
+        let n1 = make_memory("t", "n1");
+        let n2 = make_memory("t", "n2");
+        let n3 = make_memory("t", "n3");
+        m1.related_ids.push(n1.id.clone());
+        m2.related_ids.push(n2.id.clone());
+        m3.related_ids.push(n3.id.clone());
+
+        let id1 = store.store(m1.clone()).unwrap();
+        let id2 = store.store(m2.clone()).unwrap();
+        let id3 = store.store(m3.clone()).unwrap();
+        store.store(n1).unwrap();
+        store.store(n2).unwrap();
+        store.store(n3).unwrap();
+
+        let initial = vec![
+            (store.get(&id1).unwrap().unwrap(), 0.9),
+            (store.get(&id2).unwrap().unwrap(), 0.85),
+            (store.get(&id3).unwrap().unwrap(), 0.8),
+        ];
+
+        let expanded = store.expand_with_neighbors(&initial, 5, 0.5, 4).unwrap();
+        assert_eq!(expanded.len(), 4, "must respect max_total cap");
+        // Top scorer remains first.
+        assert!((expanded[0].1 - 0.9).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_expand_with_neighbors_empty_initial_passthrough() {
+        let store = test_store();
+        let expanded = store.expand_with_neighbors(&[], 5, 0.5, 10).unwrap();
+        assert!(expanded.is_empty());
+    }
+
+    #[test]
+    fn test_expand_with_neighbors_zero_neighbors_disables() {
+        let store = test_store();
+        let mut m1 = make_memory("t", "primary");
+        let m2 = make_memory("t", "would-be neighbor");
+        m1.related_ids.push(m2.id.clone());
+
+        let id1 = store.store(m1.clone()).unwrap();
+        store.store(m2).unwrap();
+
+        let initial = vec![(store.get(&id1).unwrap().unwrap(), 0.9)];
+        let expanded = store.expand_with_neighbors(&initial, 0, 0.5, 10).unwrap();
+        assert_eq!(expanded.len(), 1, "max_neighbors=0 disables expansion");
+    }
+
+    #[test]
+    fn test_expand_with_neighbors_skips_missing_targets() {
+        let store = test_store();
+        // m1 points to a ghost id that no longer exists (e.g., deleted).
+        let mut m1 = make_memory("t", "has ghost link");
+        m1.related_ids.push("01GHOSTID".into());
+        let id1 = store.store(m1.clone()).unwrap();
+
+        let initial = vec![(store.get(&id1).unwrap().unwrap(), 0.9)];
+        let expanded = store.expand_with_neighbors(&initial, 5, 0.5, 10).unwrap();
+        assert_eq!(expanded.len(), 1, "ghost link must be silently skipped");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Graph-aware memory**: auto-link memories by embedding cosine similarity (>0.75) with bidirectional backrefs. Recall now expands results 1-hop via `related_ids` (0.5× score discount)
- **Multi-tool hooks**: add native hook support for Gemini CLI, Codex CLI, and Copilot CLI — all share unified ICM memory with Claude Code
- **Copilot MCP**: add `~/.copilot/mcp-config.json` support for Copilot CLI MCP server

### Hooks support matrix (after this PR)

| Tool | SessionStart | PreTool | PostTool | Compact | PromptRecall |
|------|-------------|---------|----------|---------|-------------|
| Claude Code | ✅ | ✅ | ✅ | ✅ | ✅ |
| Gemini CLI | ✅ | ✅ | ✅ | ✅ | ✅ |
| Codex CLI | ✅ | ✅ | ✅ | — | ✅ |
| Copilot CLI | ✅ | ✅ | ✅ | — | ✅ |
| OpenCode | ✅ (plugin) | — | — | — | — |

### Benchmark: 4 agents, 1 unified memory

Tested on a Rust axum API (`/tmp/pi-api`). Each agent recalled project context from ICM, found a seeded secret, and added an endpoint:

| Agent | Endpoint added | Recall OK | Secret found |
|-------|---------------|-----------|-------------|
| Claude | `GET /tau` | ✅ | ✅ |
| Gemini | `GET /e` | ✅ | ✅ |
| Codex | `GET /phi` | ✅ | ✅ |
| Copilot | `GET /sqrt2` | ✅ | ✅ |

All 268 tests pass. No regressions.

## Test plan
- [x] `cargo test` — 268/268 pass
- [x] `cargo build --release` — OK
- [x] `icm init --mode all` — idempotent, all tools configured
- [x] `claude -p` — SessionStart hook fires, wake-up pack injected
- [x] `gemini -p` — SessionStart hook fires, wake-up pack injected
- [x] `codex exec` — MCP recall works, store blocked by sandbox (expected)
- [x] `copilot -p` — recall + store works via CLI
- [x] Cross-agent memory verified (Gemini sees Claude's changes, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)