### PR TITLE
fix: improve recall coverage for Claude and Codex agents

### DIFF
--- a/crates/icm-cli/src/config.rs
+++ b/crates/icm-cli/src/config.rs
@@ -19,6 +19,7 @@ pub struct Config {
     pub embeddings: EmbeddingsConfig,
     pub extraction: ExtractionConfig,
     pub recall: RecallConfig,
+    pub wakeup: WakeUpConfig,
     pub mcp: McpConfig,
     pub cloud: CloudConfig,
 }
@@ -85,6 +86,25 @@ pub struct RecallConfig {
     pub enabled: bool,
     /// Maximum memories to inject.
     pub limit: usize,
+}
+
+/// Wake-up pack settings (SessionStart hook).
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct WakeUpConfig {
+    /// Maximum token budget for the wake-up pack (~4 chars/token).
+    pub max_tokens: usize,
+    /// Include preference/identity memories regardless of project filter.
+    pub include_preferences: bool,
+}
+
+impl Default for WakeUpConfig {
+    fn default() -> Self {
+        Self {
+            max_tokens: 500,
+            include_preferences: true,
+        }
+    }
 }
 
 /// MCP server settings.

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -410,8 +410,8 @@ enum HookCommands {
     Prompt,
     /// SessionStart hook: inject a wake-up pack of critical facts into the session
     Start {
-        /// Approximate token budget for the wake-up pack
-        #[arg(long, default_value = "200")]
+        /// Approximate token budget for the wake-up pack (0 = use config value)
+        #[arg(long, default_value = "0")]
         max_tokens: usize,
     },
 }
@@ -1025,7 +1025,14 @@ fn main() -> Result<()> {
             }
             HookCommands::Compact => cmd_hook_compact(&store),
             HookCommands::Prompt => cmd_hook_prompt(&store),
-            HookCommands::Start { max_tokens } => cmd_hook_start(&store, max_tokens),
+            HookCommands::Start { max_tokens } => {
+                let tokens = if max_tokens > 0 {
+                    max_tokens
+                } else {
+                    cfg.wakeup.max_tokens
+                };
+                cmd_hook_start(&store, tokens)
+            }
         },
         #[cfg(feature = "tui")]
         Commands::Dashboard => {

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -37,9 +37,14 @@ pub use learn::{learn_project, LearnResult};
 /// Common message for empty search results.
 pub const MSG_NO_MEMORIES: &str = "No memories found.";
 
-/// Check if a memory's topic matches a filter (supports prefix with ':').
+/// Check if a memory's topic matches a filter.
+/// Matching is case-insensitive and bidirectional: the filter can be a
+/// substring of the topic or vice-versa. This allows `"pi-api"` to match
+/// `"context-pi-api"` and `"context-pi-api"` to match `"pi-api"`.
 pub fn topic_matches(memory_topic: &str, filter: &str) -> bool {
-    memory_topic == filter || memory_topic.starts_with(&format!("{filter}:"))
+    let topic = memory_topic.to_lowercase();
+    let f = filter.to_lowercase();
+    topic == f || topic.contains(&f) || f.contains(&topic)
 }
 
 /// Check if any keyword contains the filter string.

--- a/crates/icm-core/src/wake_up.rs
+++ b/crates/icm-core/src/wake_up.rs
@@ -37,7 +37,7 @@ impl Default for WakeUpOptions<'_> {
     fn default() -> Self {
         Self {
             project: None,
-            max_tokens: 200,
+            max_tokens: 500,
             format: WakeUpFormat::Markdown,
             include_preferences: true,
         }


### PR DESCRIPTION
## Summary

- **Wake-up pack budget**: 200 → 500 tokens (configurable via `[wakeup] max_tokens` in config.toml)
- **Topic matching**: bidirectional substring — `"pi-api"` now matches `"context-pi-api"`
- **Config-driven**: `--max-tokens=0` (CLI default) falls back to TOML config value

## Before/After (4-agent benchmark on pi-api)

| Agent | Endpoints found | Secret found |
|-------|:-:|:-:|
| **Claude** | 1/5 → **5/5** | already OK |
| **Codex** | 1/5 → **5/5** | null → **found** |
| Gemini | 5/5 (unchanged) | OK |
| Copilot | 5/5 (unchanged) | OK |

## Config example

```toml
[wakeup]
max_tokens = 500        # default, ~2000 chars
include_preferences = true
```

## Test plan
- [x] 268/268 tests pass
- [x] `claude -p` — sees all 5 endpoints + secret
- [x] `codex exec` — sees all 5 endpoints + secret + all 4 agents
- [x] `copilot -p` — sees all endpoints + agents
- [x] Wake-up pack output: ~508 tokens (was ~179)

🤖 Generated with [Claude Code](https://claude.com/claude-code)