### PR TITLE
fix: persist hook counter in SQLite instead of /tmp file (fixes #83)

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1515,24 +1515,16 @@ fn cmd_hook_post(store: &SqliteStore, extract_every: usize, store_raw: bool) -> 
         return Ok(());
     }
 
-    // Counter file for tracking tool calls between invocations
-    let counter_file =
-        std::env::var("ICM_HOOK_COUNTER").unwrap_or_else(|_| "/tmp/icm-hook-counter".to_string());
-
-    let count: usize = std::fs::read_to_string(&counter_file)
-        .ok()
-        .and_then(|s| s.trim().parse().ok())
-        .unwrap_or(0)
-        + 1;
-    let _ = std::fs::write(&counter_file, count.to_string());
+    // Track tool calls in SQLite (atomic, persists across reboots)
+    let count = store.increment_hook_counter().unwrap_or(1);
 
     // Not time to extract yet
     if count < extract_every {
         return Ok(());
     }
 
-    // Reset counter
-    let _ = std::fs::write(&counter_file, "0");
+    // Reset counter after triggering extraction
+    let _ = store.reset_hook_counter();
 
     // Extract from tool output
     let tool_output = json

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -88,6 +88,33 @@ impl SqliteStore {
         Ok(())
     }
 
+    /// Atomically increment the hook call counter and return the new value.
+    pub fn increment_hook_counter(&self) -> IcmResult<usize> {
+        let count: usize = self
+            .conn
+            .query_row(
+                "INSERT INTO icm_metadata (key, value) VALUES ('hook_counter', '1')
+                 ON CONFLICT(key) DO UPDATE SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT)
+                 RETURNING CAST(value AS INTEGER)",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(db_err)?;
+        Ok(count)
+    }
+
+    /// Reset the hook call counter to 0.
+    pub fn reset_hook_counter(&self) -> IcmResult<()> {
+        self.conn
+            .execute(
+                "INSERT INTO icm_metadata (key, value) VALUES ('hook_counter', '0')
+                 ON CONFLICT(key) DO UPDATE SET value = '0'",
+                [],
+            )
+            .map_err(db_err)?;
+        Ok(())
+    }
+
     pub fn in_memory() -> IcmResult<Self> {
         ensure_sqlite_vec();
         let conn = Connection::open_in_memory()


### PR DESCRIPTION
Fixes #83

The hook post counter was stored in `/tmp/icm-hook-counter` which resets on reboot and is not atomic across concurrent invocations. Now stored in the `icm_metadata` SQLite table.

- `increment_hook_counter()`: atomic INSERT...ON CONFLICT...RETURNING
- `reset_hook_counter()`: resets to 0 after extraction triggers
- Based on @lucachitayat's PR #90, rebased on latest main

## Test plan
- [x] 268/268 tests pass
- [x] `cargo build` OK