### PR TITLE
fix(cli): apply UTF-8 safe truncation to remaining byte-slicing sites

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2006,7 +2006,7 @@ fn cmd_hook_compact(store: &SqliteStore) -> Result<()> {
 /// UTF-8 char boundary. Result length is always `<= max_bytes`. Never panics —
 /// bare `&s[..max_bytes]` does when the offset lands inside a multi-byte char
 /// (Cyrillic=2B, CJK=3B, emoji=4B). See issue #110.
-fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
+pub(crate) fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
     if s.len() <= max_bytes {
         return s;
     }
@@ -2023,7 +2023,6 @@ fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
 /// Reads JSON from stdin with `user_message`, recalls relevant memories,
 /// and prints context to stdout (Claude Code appends it as system-reminder).
 fn cmd_hook_prompt(store: &SqliteStore) -> Result<()> {
-
     use std::io::Read;
     let mut input = String::new();
     std::io::stdin().read_to_string(&mut input)?;
@@ -3992,7 +3991,7 @@ fn cmd_bench_recall(model: &str, runs: usize, verbose: bool) -> Result<()> {
         let total_expected = all_scores_wo[0][i].1;
 
         let q_short = if q.prompt.len() > 38 {
-            format!("{}...", &q.prompt[..35])
+            format!("{}...", truncate_at_char_boundary(&q.prompt, 35))
         } else {
             q.prompt.to_string()
         };
@@ -5364,7 +5363,6 @@ mod truncate_tests {
 mod hook_start_tests {
     use super::*;
     use icm_core::Importance;
-
 
     fn seed_store() -> SqliteStore {
         let store = SqliteStore::in_memory().unwrap();

--- a/crates/icm-cli/src/web.rs
+++ b/crates/icm-cli/src/web.rs
@@ -19,6 +19,7 @@ use icm_core::{FeedbackStore, MemoirStore, MemoryStore};
 use icm_store::SqliteStore;
 
 use crate::config::WebConfig;
+use crate::truncate_at_char_boundary;
 
 // ---------------------------------------------------------------------------
 // Embedded SPA assets (compiled SvelteKit output)
@@ -446,7 +447,7 @@ async fn api_topic_consolidate(
         .collect::<Vec<_>>()
         .join(" | ");
     let truncated = if summary.len() > 500 {
-        format!("{}...", &summary[..500])
+        format!("{}...", truncate_at_char_boundary(&summary, 500))
     } else {
         summary
     };


### PR DESCRIPTION
## Summary

- Follow-up to #111 — applies `truncate_at_char_boundary` to the 2 remaining `&s[..N]` byte-slicing sites that can receive non-ASCII content
- `main.rs`: bench-recall prompt display (`&q.prompt[..35]`)
- `web.rs`: consolidation summary truncation (`&summary[..500]`)
- Also fixes stray blank lines left by #111 (cargo fmt)

Fixes #110

## Test plan

- [x] `cargo check -p icm-cli` — clean
- [x] `cargo test -p icm-cli truncate_tests` — 6/6 pass
- [x] `cargo fmt -- --check` — clean