### PR TITLE
fix(ci): use manifest-mode output names for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,8 +24,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs['crates/icm-cli--tag_name'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release


### PR DESCRIPTION
## Problem

`release-please-action@v4` in **manifest mode** exposes outputs as:
- `releases_created` (plural)
- `<package-path>--tag_name` (per-component)

The current workflow reads `release_created` (singular) and `tag_name` — neither exists in manifest mode, so the `build-release` job's `if` gate is always false and gets **skipped**.

## Evidence

Run [#24502434261](https://github.com/rtk-ai/icm/actions/runs/24502434261) (release of v0.10.25):
- `release-please`: success
- `Build and upload release assets`: **skipped**
- `Update 'latest' tag`: **skipped**

→ Release v0.10.25 was created with **zero binary assets**, breaking `brew upgrade icm`.

Every prior release was patched manually via `workflow_dispatch` on `Release.yml`.

## Fix

Map the outputs to the actual manifest-mode keys:

```yaml
release_created: ${{ steps.release.outputs.releases_created }}
tag_name: ${{ steps.release.outputs['crates/icm-cli--tag_name'] }}
```

## Test plan

- [ ] Merge this PR (no release expected — only modifies workflow file)
- [ ] On the next release-please PR merge, verify `build-release` runs (not skipped) and uploads tarballs/.deb/.rpm
- [ ] Verify homebrew formula auto-bumps and `brew upgrade icm` works without manual intervention