### PR TITLE
fix(ci): detect workflow_call via inputs.tag instead of event_name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,10 +168,12 @@ jobs:
 
       - name: Get version
         id: version
+        # inputs.tag is set for both workflow_call and workflow_dispatch.
+        # github.event_name in a reusable workflow reflects the PARENT's event
+        # (e.g. 'push' when release-please.yml calls us), so we cannot branch
+        # on it to detect workflow_call — check inputs.tag first instead.
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "workflow_call" ]; then
+          if [ -n "${{ inputs.tag }}" ]; then
             echo "version=${{ inputs.tag }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "release" ]; then
             echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
@@ -188,7 +190,9 @@ jobs:
           sha256sum * > checksums.txt
 
       - name: Upload Release Assets
-        if: github.event_name == 'release' || github.event_name == 'workflow_call'
+        # Runs for release (direct event), workflow_call (inputs.tag set),
+        # and falls through for workflow_dispatch (handled by Create Release).
+        if: steps.version.outputs.version != '' && github.event_name != 'workflow_dispatch'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Problem

When `release-please.yml` invokes `release.yml` via `workflow_call`, GitHub sets `github.event_name` inside the reusable workflow to the **parent's** event (here, `push`), not `workflow_call`. The existing logic branches on `github.event_name`, so none of its conditions matched:

```yaml
if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then      # "push" ≠ workflow_dispatch
  echo "version=..." >> $GITHUB_OUTPUT
elif [ "${{ github.event_name }}" = "workflow_call" ]; then        # "push" ≠ workflow_call
  echo "version=..." >> $GITHUB_OUTPUT
elif [ "${{ github.event_name }}" = "release" ]; then              # "push" ≠ release
  ...
fi
```

Result: `version=""` and the upload step's `if: github.event_name == 'release' || github.event_name == 'workflow_call'` also evaluated false → no assets uploaded. Downstream `Update Homebrew formula` failed with `no assets to download`.

This just happened on release **icm-v0.10.26**, despite my prior fix (#115) correctly triggering the reusable workflow. Manual `workflow_dispatch` on the tag is a workaround but defeats the auto-release.

## Fix

Detect `workflow_call` / `workflow_dispatch` via the presence of `inputs.tag`, which is defined for both. Fall back to `github.event.release.tag_name` for a direct `release` event:

```yaml
if [ -n "${{ inputs.tag }}" ]; then
  echo "version=${{ inputs.tag }}" >> $GITHUB_OUTPUT
elif [ "${{ github.event_name }}" = "release" ]; then
  echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
fi
```

Gate the upload step on `steps.version.outputs.version` rather than on the misleading `event_name`, and explicitly skip it on `workflow_dispatch` (handled by the separate `Create Release` step).

## Test plan

- [ ] Manual `workflow_dispatch` of this workflow still creates a release + uploads assets (test by triggering on icm-v0.10.26 after merge to confirm it still works). Already verified pre-merge.
- [ ] On the next release-please merge, `build-release` runs AND uploads assets AND the homebrew formula auto-bumps.
- [ ] `icm-v0.10.26` currently has no assets — handled by manual workflow_dispatch ran separately; this PR prevents the same failure on icm-v0.10.27 and onwards.