### PR TITLE
Add operational memory wiring and fix Windows debug startup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,32 +1,36 @@
-# ICM — Persistent Memory for AI Agents
+<!-- icm:start -->
+## Persistent memory (ICM) — MANDATORY
 
 This project uses [ICM](https://github.com/rtk-ai/icm) for persistent memory across sessions.
+You MUST use it actively. Not optional.
 
-## Recall (before starting work)
-
-Search for relevant past context before each task:
-
+### Recall (before starting work)
 ```bash
 icm recall "query"                        # search memories
 icm recall "query" -t "topic-name"        # filter by topic
+icm recall-context "query" --limit 5      # formatted for prompt injection
 ```
 
-## Store (MANDATORY triggers)
+Prioritize durable operational facts: resolved errors, working commands, environment constraints,
+project decisions, and user preferences.
 
+### Store — MANDATORY triggers
 You MUST call `icm store` when ANY of the following happens:
-
 1. **Error resolved** → `icm store -t errors-resolved -c "description" -i high -k "keyword1,keyword2"`
 2. **Architecture/design decision** → `icm store -t decisions-{project} -c "description" -i high`
 3. **User preference discovered** → `icm store -t preferences -c "description" -i critical`
-4. **Significant task completed** → `icm store -t context-{project} -c "summary" -i high`
+4. **Significant task completed** → `icm store -t context-{project} -c "summary of work done" -i high`
+5. **Conversation exceeds ~20 tool calls without a store** → store a progress summary
 
-Do this BEFORE responding to the user. Not optional.
+Do this BEFORE responding to the user. Not after. Not later. Immediately.
 
-## Other commands
+Do NOT store: trivial details, info already in CLAUDE.md, ephemeral state (build logs, git status).
 
+### Other commands
 ```bash
-icm topics                                # list all topics
+icm update <id> -c "updated content"     # edit memory in-place
 icm health                                # topic hygiene audit
-icm update <id> -c "updated content"      # edit memory in-place
+icm topics                                # list all topics
 icm forget <id>                           # delete a memory
 ```
+<!-- icm:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -759,3 +759,39 @@ Les tools ICM sont **deferred** — sans ToolSearch préalable, ils n'existent p
 - Contenu de fichiers lisibles dans le code
 - Historique git (utiliser `git log`)
 - État temporaire ou en cours de session uniquement
+
+<!-- icm:start -->
+    ## Persistent memory (ICM) — MANDATORY
+
+    This project uses [ICM](https://github.com/rtk-ai/icm) for persistent memory across sessions.
+    You MUST use it actively. Not optional.
+
+    ### Recall (before starting work)
+    ```bash
+    icm recall "query"                        # search memories
+    icm recall "query" -t "topic-name"        # filter by topic
+    icm recall-context "query" --limit 5      # formatted for prompt injection
+    ```
+
+    Prioritize durable operational facts: resolved errors, working commands, environment constraints,
+    project decisions, and user preferences.
+
+    ### Store — MANDATORY triggers
+    You MUST call `icm store` when ANY of the following happens:
+    1. **Error resolved** → `icm store -t errors-resolved -c "description" -i high -k "keyword1,keyword2"`
+    2. **Architecture/design decision** → `icm store -t decisions-{project} -c "description" -i high`
+    3. **User preference discovered** → `icm store -t preferences -c "description" -i critical`
+    4. **Significant task completed** → `icm store -t context-{project} -c "summary of work done" -i high`
+    5. **Conversation exceeds ~20 tool calls without a store** → store a progress summary
+
+    Do this BEFORE responding to the user. Not after. Not later. Immediately.
+
+    Do NOT store: trivial details, info already in CLAUDE.md, ephemeral state (build logs, git status).
+
+    ### Other commands
+    ```bash
+    icm update <id> -c "updated content"     # edit memory in-place
+    icm health                                # topic hygiene audit
+    icm topics                                # list all topics
+    ```
+    <!-- icm:end -->

--- a/crates/icm-cli/src/cloud.rs
+++ b/crates/icm-cli/src/cloud.rs
@@ -448,6 +448,7 @@ pub fn pull_memories(
                 access_count: cm.access_count,
                 related_ids: cm.related_ids,
                 embedding: None,
+                context: None,
                 created_at: cm
                     .created_at
                     .and_then(|s| s.parse::<chrono::DateTime<chrono::Utc>>().ok())

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -21,8 +21,8 @@ use serde_json::Value;
 
 use icm_core::{
     build_wake_up, keyword_matches, topic_matches, Concept, ConceptLink, Feedback, FeedbackStore,
-    Importance, Label, Memoir, MemoirStore, Memory, MemoryStore, Relation, WakeUpFormat,
-    WakeUpOptions, MSG_NO_MEMORIES,
+    Importance, Label, Memoir, MemoirStore, Memory, MemoryContext, MemoryKind, MemoryStore,
+    Relation, WakeUpFormat, WakeUpOptions, MSG_NO_MEMORIES,
 };
 use icm_store::SqliteStore;
 
@@ -86,6 +86,30 @@ enum Commands {
         /// Filter results by keyword
         #[arg(short = 'k', long)]
         keyword: Option<String>,
+
+        /// Optional project/repo filter used for contextual ranking
+        #[arg(long)]
+        project: Option<String>,
+
+        /// Optional platform filter such as windows, linux, macos
+        #[arg(long)]
+        platform: Option<String>,
+
+        /// Optional command filter used for contextual ranking
+        #[arg(long)]
+        command: Option<String>,
+
+        /// Optional file path filter used for contextual ranking
+        #[arg(long)]
+        file_path: Option<String>,
+
+        /// Optional symbol filter used for contextual ranking
+        #[arg(long)]
+        symbol: Option<String>,
+
+        /// Optional normalized error fingerprint used for contextual ranking
+        #[arg(long)]
+        error_fingerprint: Option<String>,
     },
 
     /// List memories
@@ -432,7 +456,7 @@ enum Commands {
 enum HookCommands {
     /// PreToolUse hook: auto-allow `icm` CLI commands (no permission prompt)
     Pre,
-    /// PostToolUse hook: auto-extract context every N tool calls
+    /// PostToolUse hook: extract durable operational facts every N tool calls
     Post {
         /// Extract every N tool calls (default from config, fallback: 10)
         #[arg(long, default_value = "15")]
@@ -442,7 +466,7 @@ enum HookCommands {
     Compact,
     /// UserPromptSubmit hook: inject recalled context at the start of each prompt
     Prompt,
-    /// SessionStart hook: inject a wake-up pack of critical facts into the session
+    /// SessionStart hook: inject an operational wake-up pack into the session
     Start {
         /// Approximate token budget for the wake-up pack (0 = use config value)
         #[arg(long, default_value = "0")]
@@ -859,7 +883,7 @@ enum InitMode {
     Cli,
     /// Claude Code slash commands /recall and /remember
     Skill,
-    /// Claude Code PostToolUse hook (auto-extract context)
+    /// Hook suite for wake-up, recall, extraction, and compaction
     Hook,
     /// All integration modes
     All,
@@ -887,6 +911,24 @@ fn init_embedder(_model: &str) -> Option<()> {
 }
 
 fn main() -> Result<()> {
+    #[cfg(all(target_os = "windows", debug_assertions))]
+    {
+        return std::thread::Builder::new()
+            .name("icm-main".into())
+            .stack_size(8 * 1024 * 1024)
+            .spawn(run_main)
+            .context("failed to spawn icm main thread")?
+            .join()
+            .map_err(|_| anyhow::anyhow!("icm main thread panicked"))?;
+    }
+
+    #[cfg(not(all(target_os = "windows", debug_assertions)))]
+    {
+        run_main()
+    }
+}
+
+fn run_main() -> Result<()> {
     // Reset SIGPIPE to default so piped commands (e.g. `icm export | head`)
     // don't panic on broken pipe.
     #[cfg(unix)]
@@ -948,6 +990,12 @@ fn main() -> Result<()> {
             topic,
             limit,
             keyword,
+            project,
+            platform,
+            command,
+            file_path,
+            symbol,
+            error_fingerprint,
         } => {
             #[cfg(feature = "embeddings")]
             let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
@@ -960,6 +1008,12 @@ fn main() -> Result<()> {
                 topic.as_deref(),
                 limit,
                 keyword.as_deref(),
+                project.as_deref(),
+                platform.as_deref(),
+                command.as_deref(),
+                file_path.as_deref(),
+                symbol.as_deref(),
+                error_fingerprint.as_deref(),
             )
         }
         Commands::List { topic, all, sort } => cmd_list(&store, topic.as_deref(), all, sort),
@@ -1253,6 +1307,7 @@ fn cmd_store(
     raw: Option<String>,
 ) -> Result<()> {
     let mut memory = Memory::new(topic.clone(), content.clone(), importance);
+    memory.context = Some(build_auto_context(None, None));
     if let Some(kw) = keywords {
         memory.keywords = kw.split(',').map(|s| s.trim().to_string()).collect();
     }
@@ -1306,16 +1361,32 @@ fn cmd_recall(
     topic: Option<&str>,
     limit: usize,
     keyword: Option<&str>,
+    project: Option<&str>,
+    platform: Option<&str>,
+    command: Option<&str>,
+    file_path: Option<&str>,
+    symbol: Option<&str>,
+    error_fingerprint: Option<&str>,
 ) -> Result<()> {
     // Auto-decay if >24h since last decay
     if let Err(e) = store.maybe_auto_decay() {
         tracing::warn!(error = %e, "auto-decay failed during recall");
     }
 
+    let recall_context = CliRecallContext {
+        project,
+        platform,
+        command,
+        file_path,
+        symbol,
+        error_fingerprint,
+    };
+    let candidate_limit = cli_recall_candidate_limit(limit, recall_context);
+
     // Try hybrid search if embedder is available
     if let Some(emb) = embedder {
         if let Ok(query_emb) = emb.embed(query) {
-            if let Ok(results) = store.search_hybrid(query, &query_emb, limit) {
+            if let Ok(results) = store.search_hybrid(query, &query_emb, candidate_limit) {
                 let mut scored = results;
                 if let Some(t) = topic {
                     scored.retain(|(m, _)| topic_matches(&m.topic, t));
@@ -1323,6 +1394,7 @@ fn cmd_recall(
                 if let Some(kw) = keyword {
                     scored.retain(|(m, _)| keyword_matches(&m.keywords, kw));
                 }
+                let scored = cli_rerank_contextual_results(scored, recall_context, limit);
 
                 // Graph-aware expansion: follow related_ids one hop and
                 // fold neighbors into results (discounted 0.5× score).
@@ -1347,11 +1419,11 @@ fn cmd_recall(
     }
 
     // Fallback: FTS then keywords
-    let mut results = store.search_fts(query, limit)?;
+    let mut results = store.search_fts(query, candidate_limit)?;
 
     if results.is_empty() {
         let keywords: Vec<&str> = query.split_whitespace().collect();
-        results = store.search_by_keywords(&keywords, limit)?;
+        results = store.search_by_keywords(&keywords, candidate_limit)?;
     }
 
     if let Some(t) = topic {
@@ -1362,7 +1434,13 @@ fn cmd_recall(
     }
 
     // Graph-aware expansion also runs in the keyword-only fallback path.
-    let scored: Vec<(Memory, f32)> = results.into_iter().map(|m| (m, 1.0)).collect();
+    let total = results.len() as f32;
+    let scored: Vec<(Memory, f32)> = results
+        .into_iter()
+        .enumerate()
+        .map(|(index, memory)| (memory, total - index as f32))
+        .collect();
+    let scored = cli_rerank_contextual_results(scored, recall_context, limit);
     let max_neighbors = (limit / 3).max(1);
     let expanded = store
         .expand_with_neighbors(&scored, max_neighbors, 0.5, limit)
@@ -1380,6 +1458,99 @@ fn cmd_recall(
     }
 
     Ok(())
+}
+
+#[derive(Clone, Copy)]
+struct CliRecallContext<'a> {
+    project: Option<&'a str>,
+    platform: Option<&'a str>,
+    command: Option<&'a str>,
+    file_path: Option<&'a str>,
+    symbol: Option<&'a str>,
+    error_fingerprint: Option<&'a str>,
+}
+
+impl CliRecallContext<'_> {
+    fn has_filters(self) -> bool {
+        self.project.is_some()
+            || self.platform.is_some()
+            || self.command.is_some()
+            || self.file_path.is_some()
+            || self.symbol.is_some()
+            || self.error_fingerprint.is_some()
+    }
+}
+
+fn cli_recall_candidate_limit(limit: usize, context: CliRecallContext<'_>) -> usize {
+    if context.has_filters() {
+        (limit.max(10)).saturating_mul(5).min(100)
+    } else {
+        limit
+    }
+}
+
+fn cli_contextual_boost(memory: &Memory, context: CliRecallContext<'_>) -> f32 {
+    let Some(meta) = memory.context.as_ref() else {
+        return 0.0;
+    };
+
+    let mut boost = 0.0;
+    if context.project == meta.project.as_deref() {
+        boost += 3.0;
+    }
+    if context.platform == meta.platform.as_deref() {
+        boost += 2.0;
+    }
+    if context.command == meta.command.as_deref() {
+        boost += 4.0;
+    }
+    if context.file_path == meta.file_path.as_deref() {
+        boost += 1.5;
+    }
+    if context.symbol == meta.symbol.as_deref() {
+        boost += 1.5;
+    }
+    if context.error_fingerprint == meta.error_fingerprint.as_deref() {
+        boost += 4.0;
+    }
+    boost += match meta.kind {
+        MemoryKind::WorkingCommand | MemoryKind::ResolvedError | MemoryKind::Decision => 0.25,
+        _ => 0.0,
+    };
+    boost
+}
+
+fn cli_rerank_contextual_results(
+    mut results: Vec<(Memory, f32)>,
+    context: CliRecallContext<'_>,
+    limit: usize,
+) -> Vec<(Memory, f32)> {
+    if context.has_filters() {
+        for (memory, score) in &mut results {
+            *score += cli_contextual_boost(memory, context);
+        }
+        results.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    }
+    results.truncate(limit);
+    results
+}
+
+fn build_auto_context(command: Option<&str>, file_path: Option<&str>) -> MemoryContext {
+    MemoryContext {
+        project: Some(detect_project()),
+        repo_root: std::env::current_dir()
+            .ok()
+            .map(|path| path.display().to_string()),
+        platform: Some(std::env::consts::OS.to_string()),
+        command: command.map(str::to_string),
+        file_path: file_path.map(str::to_string),
+        symbol: None,
+        error_fingerprint: None,
+        kind: MemoryKind::Note,
+    }
 }
 
 fn cmd_list(store: &SqliteStore, topic: Option<&str>, all: bool, sort: SortField) -> Result<()> {
@@ -1856,7 +2027,7 @@ fn is_icm_command(cmd: &str) -> bool {
     false
 }
 
-/// PostToolUse hook: auto-extract context every N tool calls.
+/// PostToolUse hook: extract durable operational facts every N tool calls.
 /// Reads JSON from stdin. Runs extraction asynchronously.
 fn cmd_hook_post(store: &SqliteStore, extract_every: usize, store_raw: bool) -> Result<()> {
     use std::io::Read;
@@ -2431,39 +2602,41 @@ fn cmd_init(mode: InitMode, force: bool) -> Result<()> {
     if do_cli {
         let cwd = std::env::current_dir().context("failed to get current directory")?;
 
-        let icm_block = "\
-<!-- icm:start -->\n\
-## Persistent memory (ICM) — MANDATORY\n\
-\n\
-This project uses [ICM](https://github.com/rtk-ai/icm) for persistent memory across sessions.\n\
-You MUST use it actively. Not optional.\n\
-\n\
-### Recall (before starting work)\n\
-```bash\n\
-icm recall \"query\"                        # search memories\n\
-icm recall \"query\" -t \"topic-name\"        # filter by topic\n\
-icm recall-context \"query\" --limit 5      # formatted for prompt injection\n\
-```\n\
-\n\
-### Store — MANDATORY triggers\n\
-You MUST call `icm store` when ANY of the following happens:\n\
-1. **Error resolved** → `icm store -t errors-resolved -c \"description\" -i high -k \"keyword1,keyword2\"`\n\
-2. **Architecture/design decision** → `icm store -t decisions-{project} -c \"description\" -i high`\n\
-3. **User preference discovered** → `icm store -t preferences -c \"description\" -i critical`\n\
-4. **Significant task completed** → `icm store -t context-{project} -c \"summary of work done\" -i high`\n\
-5. **Conversation exceeds ~20 tool calls without a store** → store a progress summary\n\
-\n\
-Do this BEFORE responding to the user. Not after. Not later. Immediately.\n\
-\n\
-Do NOT store: trivial details, info already in CLAUDE.md, ephemeral state (build logs, git status).\n\
-\n\
-### Other commands\n\
-```bash\n\
-icm update <id> -c \"updated content\"     # edit memory in-place\n\
-icm health                                # topic hygiene audit\n\
-icm topics                                # list all topics\n\
-```\n\
-<!-- icm:end -->";
+        let icm_block = r#"<!-- icm:start -->
+    ## Persistent memory (ICM) — MANDATORY
+
+    This project uses [ICM](https://github.com/rtk-ai/icm) for persistent memory across sessions.
+    You MUST use it actively. Not optional.
+
+    ### Recall (before starting work)
+    ```bash
+    icm recall "query"                        # search memories
+    icm recall "query" -t "topic-name"        # filter by topic
+    icm recall-context "query" --limit 5      # formatted for prompt injection
+    ```
+
+    Prioritize durable operational facts: resolved errors, working commands, environment constraints,
+    project decisions, and user preferences.
+
+    ### Store — MANDATORY triggers
+    You MUST call `icm store` when ANY of the following happens:
+    1. **Error resolved** → `icm store -t errors-resolved -c "description" -i high -k "keyword1,keyword2"`
+    2. **Architecture/design decision** → `icm store -t decisions-{project} -c "description" -i high`
+    3. **User preference discovered** → `icm store -t preferences -c "description" -i critical`
+    4. **Significant task completed** → `icm store -t context-{project} -c "summary of work done" -i high`
+    5. **Conversation exceeds ~20 tool calls without a store** → store a progress summary
+
+    Do this BEFORE responding to the user. Not after. Not later. Immediately.
+
+    Do NOT store: trivial details, info already in CLAUDE.md, ephemeral state (build logs, git status).
+
+    ### Other commands
+    ```bash
+    icm update <id> -c "updated content"     # edit memory in-place
+    icm health                                # topic hygiene audit
+    icm topics                                # list all topics
+    ```
+    <!-- icm:end -->"#;
 
         // Each AI tool uses its own instruction file
         let instruction_files: Vec<(&str, PathBuf)> = vec![
@@ -2531,6 +2704,9 @@ This project uses ICM (Infinite Context Memory) for persistent memory. Usage is 
 icm recall \"query\"
 ```
 
+Prioritize durable operational facts: resolved errors, working commands,
+environment constraints, project decisions, and user preferences.
+
 **Store** — you MUST store when any of these happens:
 1. Error resolved → `icm store -t errors-resolved -c \"description\" -i high`
 2. Architecture decision → `icm store -t decisions-{project} -c \"description\" -i high`
@@ -2562,7 +2738,7 @@ Do this BEFORE responding to the user. Not optional.
         )?;
     }
 
-    // --- Hook mode: install Claude Code hooks (full Rust, no shell scripts) ---
+    // --- Hook mode: install multi-tool hooks (full Rust, no shell scripts) ---
     if do_hook {
         let claude_settings_path = PathBuf::from(&home).join(".claude/settings.json");
 
@@ -2578,7 +2754,7 @@ Do this BEFORE responding to the user. Not optional.
         )?;
         println!("[hook] Claude Code PreToolUse (auto-allow): {pre_status}");
 
-        // PostToolUse hook: `icm hook post` (auto-extract context)
+        // PostToolUse hook: `icm hook post` (extract durable operational facts)
         let post_cmd = format!("{} hook post", icm_bin_str);
         let post_status = inject_settings_hook(
             &claude_settings_path,
@@ -2588,9 +2764,11 @@ Do this BEFORE responding to the user. Not optional.
             &["icm hook", "icm-post-tool"],
             force,
         )?;
-        println!("[hook] Claude Code PostToolUse (auto-extract): {post_status}");
+        println!(
+            "[hook] Claude Code PostToolUse (durable fact extraction): {post_status}"
+        );
 
-        // PreCompact hook: `icm hook compact` (extract from transcript before compression)
+        // PreCompact hook: `icm hook compact` (extract durable facts before compression)
         let compact_cmd = format!("{} hook compact", icm_bin_str);
         let compact_status = inject_settings_hook(
             &claude_settings_path,
@@ -2600,9 +2778,11 @@ Do this BEFORE responding to the user. Not optional.
             &["icm hook", "icm-post-tool"],
             force,
         )?;
-        println!("[hook] Claude Code PreCompact (transcript extract): {compact_status}");
+        println!(
+            "[hook] Claude Code PreCompact (transcript fact extraction): {compact_status}"
+        );
 
-        // UserPromptSubmit hook: `icm hook prompt` (recall context on each prompt)
+        // UserPromptSubmit hook: `icm hook prompt` (recall matching context on each prompt)
         let prompt_cmd = format!("{} hook prompt", icm_bin_str);
         let prompt_status = inject_settings_hook(
             &claude_settings_path,
@@ -2612,9 +2792,11 @@ Do this BEFORE responding to the user. Not optional.
             &["icm hook", "icm-post-tool"],
             force,
         )?;
-        println!("[hook] Claude Code UserPromptSubmit (auto-recall): {prompt_status}");
+        println!(
+            "[hook] Claude Code UserPromptSubmit (project-aware recall): {prompt_status}"
+        );
 
-        // SessionStart hook: `icm hook start` (inject wake-up pack of critical facts)
+        // SessionStart hook: `icm hook start` (inject operational wake-up pack)
         let start_cmd = format!("{} hook start", icm_bin_str);
         let start_status = inject_settings_hook(
             &claude_settings_path,
@@ -2624,7 +2806,9 @@ Do this BEFORE responding to the user. Not optional.
             &["icm hook start", "icm hook", "icm-post-tool"],
             force,
         )?;
-        println!("[hook] Claude Code SessionStart (wake-up pack): {start_status}");
+        println!(
+            "[hook] Claude Code SessionStart (operational wake-up): {start_status}"
+        );
 
         // OpenCode plugin: install TS plugin using native @opencode-ai/plugin SDK
         let opencode_plugins_dir = PathBuf::from(&home).join(".config/opencode/plugins");
@@ -2657,7 +2841,7 @@ Do this BEFORE responding to the user. Not optional.
             &["icm hook start", "icm hook", "icm-post-tool"],
             force,
         )?;
-        println!("[hook] Gemini CLI SessionStart (wake-up pack): {status}");
+        println!("[hook] Gemini CLI SessionStart (operational wake-up): {status}");
 
         // BeforeTool → equivalent of PreToolUse (auto-allow icm commands)
         // Gemini CLI uses "run_shell_command" as the Bash tool name
@@ -2671,7 +2855,7 @@ Do this BEFORE responding to the user. Not optional.
         )?;
         println!("[hook] Gemini CLI BeforeTool (auto-allow): {status}");
 
-        // AfterTool → equivalent of PostToolUse (auto-extract context)
+        // AfterTool → equivalent of PostToolUse (extract durable operational facts)
         let status = inject_settings_hook(
             &gemini_settings_path,
             "AfterTool",
@@ -2680,7 +2864,7 @@ Do this BEFORE responding to the user. Not optional.
             detect,
             force,
         )?;
-        println!("[hook] Gemini CLI AfterTool (auto-extract): {status}");
+        println!("[hook] Gemini CLI AfterTool (durable fact extraction): {status}");
 
         // PreCompress → equivalent of PreCompact (extract from transcript)
         let status = inject_settings_hook(
@@ -2691,9 +2875,9 @@ Do this BEFORE responding to the user. Not optional.
             detect,
             force,
         )?;
-        println!("[hook] Gemini CLI PreCompress (transcript extract): {status}");
+        println!("[hook] Gemini CLI PreCompress (transcript fact extraction): {status}");
 
-        // BeforeAgent → equivalent of UserPromptSubmit (auto-recall on each prompt)
+        // BeforeAgent → equivalent of UserPromptSubmit (project-aware recall on each prompt)
         let status = inject_settings_hook(
             &gemini_settings_path,
             "BeforeAgent",
@@ -2702,7 +2886,7 @@ Do this BEFORE responding to the user. Not optional.
             detect,
             force,
         )?;
-        println!("[hook] Gemini CLI BeforeAgent (auto-recall): {status}");
+        println!("[hook] Gemini CLI BeforeAgent (project-aware recall): {status}");
 
         // --- Codex CLI hooks (separate hooks.json file) ---
         let codex_hooks_path = PathBuf::from(&home).join(".codex/hooks.json");
@@ -2714,7 +2898,7 @@ Do this BEFORE responding to the user. Not optional.
             None,
             &["icm hook start", "icm hook"],
         )?;
-        println!("[hook] Codex CLI SessionStart (wake-up pack): {status}");
+        println!("[hook] Codex CLI SessionStart (operational wake-up): {status}");
 
         let status = inject_codex_hook(
             &codex_hooks_path,
@@ -2732,7 +2916,7 @@ Do this BEFORE responding to the user. Not optional.
             None,
             detect,
         )?;
-        println!("[hook] Codex CLI PostToolUse (auto-extract): {status}");
+        println!("[hook] Codex CLI PostToolUse (durable fact extraction): {status}");
 
         let status = inject_codex_hook(
             &codex_hooks_path,
@@ -2741,7 +2925,7 @@ Do this BEFORE responding to the user. Not optional.
             None,
             detect,
         )?;
-        println!("[hook] Codex CLI UserPromptSubmit (auto-recall): {status}");
+        println!("[hook] Codex CLI UserPromptSubmit (project-aware recall): {status}");
 
         // --- Copilot CLI hooks (per-repo .github/hooks/icm.json) ---
         let cwd = std::env::current_dir().context("failed to get current directory")?;
@@ -2757,8 +2941,8 @@ Do this BEFORE responding to the user. Not optional.
 
     if !do_hook {
         println!();
-        println!("Tip: run `icm init --mode hook` to also install Claude Code hooks");
-        println!("     for automatic memory extraction and context recall.");
+        println!("Tip: run `icm init --mode hook` to also install wake-up, recall,");
+        println!("     and durable-fact extraction hooks for supported tools.");
     }
 
     Ok(())
@@ -2867,7 +3051,9 @@ fn cmd_doctor() -> Result<()> {
 
     println!();
     if checked == 0 {
-        println!("No ICM hooks found. Run `icm init --mode hook` to install them.");
+        println!(
+            "No ICM hooks found. Run `icm init --mode hook` to install wake-up, recall, and extraction hooks."
+        );
     } else if broken == 0 {
         println!("All {checked} ICM hook entries are healthy.");
     } else {
@@ -5765,6 +5951,21 @@ mod hook_start_tests {
         // call does not panic and returns a valid, non-empty pack.
         assert!(!pack.is_empty());
         assert!(pack.starts_with("# ICM Wake-up"));
+    }
+}
+
+#[cfg(test)]
+mod auto_context_tests {
+    use super::*;
+
+    #[test]
+    fn build_auto_context_sets_platform_and_command() {
+        let context = build_auto_context(Some("cargo test -p icm-cli"), None);
+        assert_eq!(context.platform.as_deref(), Some(std::env::consts::OS));
+        assert_eq!(context.command.as_deref(), Some("cargo test -p icm-cli"));
+        assert!(context.project.is_some());
+        assert!(context.repo_root.is_some());
+        assert_eq!(context.kind, MemoryKind::Note);
     }
 }
 

--- a/crates/icm-cli/tests/windows_debug_startup.rs
+++ b/crates/icm-cli/tests/windows_debug_startup.rs
@@ -1,0 +1,20 @@
+#![cfg(target_os = "windows")]
+
+use std::process::Command;
+
+#[test]
+fn debug_binary_handles_help_without_stack_overflow() {
+    let binary = env!("CARGO_BIN_EXE_icm");
+    let output = Command::new(binary)
+        .arg("--help")
+        .output()
+        .expect("failed to launch icm --help");
+
+    assert!(
+        output.status.success(),
+        "expected icm --help to succeed, status={:?}, stderr={} stdout={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+}

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -27,7 +27,8 @@ pub use feedback_store::FeedbackStore;
 pub use memoir::{Concept, ConceptLink, Label, Memoir, MemoirStats, Relation};
 pub use memoir_store::MemoirStore;
 pub use memory::{
-    Importance, Memory, MemorySource, PatternCluster, Scope, StoreStats, TopicHealth,
+    Importance, Memory, MemoryContext, MemoryKind, MemorySource, PatternCluster, Scope,
+    StoreStats, TopicHealth,
 };
 pub use store::MemoryStore;
 pub use transcript::{Message, Role, Session, TranscriptHit, TranscriptStats};

--- a/crates/icm-core/src/memory.rs
+++ b/crates/icm-core/src/memory.rs
@@ -24,6 +24,9 @@ pub struct Memory {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub embedding: Option<Vec<f32>>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<MemoryContext>,
+
     /// Cloud scope: user (local default), project, or org.
     #[serde(default)]
     pub scope: Scope,
@@ -52,9 +55,36 @@ impl Memory {
             source: MemorySource::Manual,
             related_ids: Vec::new(),
             embedding: None,
+            context: None,
             scope: Scope::User,
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MemoryContext {
+    pub project: Option<String>,
+    pub repo_root: Option<String>,
+    pub platform: Option<String>,
+    pub command: Option<String>,
+    pub file_path: Option<String>,
+    pub symbol: Option<String>,
+    pub error_fingerprint: Option<String>,
+    #[serde(default)]
+    pub kind: MemoryKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryKind {
+    Decision,
+    ResolvedError,
+    WorkingCommand,
+    Constraint,
+    Preference,
+    Progress,
+    #[default]
+    Note,
 }
 
 /// Memory scope for cloud sync.

--- a/crates/icm-core/src/wake_up.rs
+++ b/crates/icm-core/src/wake_up.rs
@@ -7,7 +7,7 @@
 use chrono::{DateTime, Utc};
 
 use crate::error::IcmResult;
-use crate::memory::{Importance, Memory};
+use crate::memory::{Importance, Memory, MemoryKind};
 use crate::store::MemoryStore;
 
 /// Output format for the wake-up pack.
@@ -48,6 +48,8 @@ impl Default for WakeUpOptions<'_> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum Category {
     Identity,
+    WorkingCommands,
+    KnownTraps,
     Decision,
     Constraint,
     Error,
@@ -60,6 +62,8 @@ impl Category {
     fn label(self) -> &'static str {
         match self {
             Self::Identity => "Identity & preferences",
+            Self::WorkingCommands => "Working commands",
+            Self::KnownTraps => "Known traps",
             Self::Decision => "Critical decisions",
             Self::Constraint => "Active constraints",
             Self::Error => "Recent errors resolved",
@@ -68,9 +72,11 @@ impl Category {
         }
     }
 
-    fn all_ordered() -> [Category; 6] {
+    fn all_ordered() -> [Category; 8] {
         [
             Self::Identity,
+            Self::WorkingCommands,
+            Self::KnownTraps,
             Self::Decision,
             Self::Constraint,
             Self::Error,
@@ -112,7 +118,7 @@ pub fn build_wake_up_from_memories(memories: Vec<Memory>, opts: &WakeUpOptions<'
             // when the option is set (they may be medium-importance).
             matches!(m.importance, Importance::Critical | Importance::High) || is_pref
         })
-        .filter(|m| project_matches(&m.topic, opts.project))
+        .filter(|m| memory_matches_project(m, opts.project))
         .map(|m| {
             let score = compute_score(&m, now);
             let category = categorize(&m);
@@ -187,6 +193,21 @@ fn project_matches(topic: &str, project: Option<&str>) -> bool {
     proj_segs.iter().all(|ps| topic_segs.contains(ps))
 }
 
+fn memory_matches_project(memory: &Memory, project: Option<&str>) -> bool {
+    if project_matches(&memory.topic, project) {
+        return true;
+    }
+
+    let Some(meta) = memory.context.as_ref() else {
+        return false;
+    };
+
+    match project {
+        Some(project) if !project.is_empty() => meta.project.as_deref() == Some(project),
+        _ => true,
+    }
+}
+
 fn compute_score(m: &Memory, now: DateTime<Utc>) -> f32 {
     let importance_weight = match m.importance {
         Importance::Critical => 10.0,
@@ -201,10 +222,28 @@ fn compute_score(m: &Memory, now: DateTime<Utc>) -> f32 {
     // Recency factor: 1.0 at day 0, ~0.5 at day 30, ~0.25 at day 90.
     let recency = 1.0 / (1.0 + days / 30.0);
     let stored_weight = m.weight.max(0.01);
-    importance_weight * recency * stored_weight
+    let kind_boost = match m.context.as_ref().map(|meta| meta.kind) {
+        Some(MemoryKind::WorkingCommand) => 1.4,
+        Some(MemoryKind::ResolvedError) => 1.25,
+        Some(MemoryKind::Decision) => 1.2,
+        _ => 1.0,
+    };
+    importance_weight * recency * stored_weight * kind_boost
 }
 
 fn categorize(m: &Memory) -> Category {
+    if let Some(meta) = m.context.as_ref() {
+        match meta.kind {
+            MemoryKind::Preference => return Category::Identity,
+            MemoryKind::WorkingCommand => return Category::WorkingCommands,
+            MemoryKind::ResolvedError => return Category::KnownTraps,
+            MemoryKind::Decision => return Category::Decision,
+            MemoryKind::Constraint => return Category::Constraint,
+            MemoryKind::Progress => return Category::Milestone,
+            MemoryKind::Note => {}
+        }
+    }
+
     let t = m.topic.to_lowercase();
     let s = m.summary.to_lowercase();
 

--- a/crates/icm-install/src/main.rs
+++ b/crates/icm-install/src/main.rs
@@ -105,7 +105,7 @@ fn run() -> Result<()> {
     println!();
     println!("  Next steps:");
     println!("    1. icm init            # configure your AI tools (MCP)");
-    println!("    2. icm init --mode hook  # install Claude Code hooks");
+    println!("    2. icm init --mode hook  # install wake-up, recall, and extraction hooks");
     println!("    3. Restart your AI tool to activate");
     println!();
 

--- a/crates/icm-mcp/src/server.rs
+++ b/crates/icm-mcp/src/server.rs
@@ -124,7 +124,8 @@ const ICM_INSTRUCTIONS: &str = "\
 Use ICM (Infinite Context Memory) proactively to maintain long-term memory across sessions.\n\
 \n\
 RECALL (icm_memory_recall): At the start of a task, search for relevant past context — decisions, \
-resolved errors, user preferences. Search only what is relevant, do not dump everything.\n\
+resolved errors, working commands, environment constraints, and user preferences. Search only what \
+is relevant, do not dump everything.\n\
 \n\
 STORE (icm_memory_store): You MUST store when ANY of these triggers occur:\n\
 1. Error resolved → topic: \"errors-resolved\", importance: high\n\
@@ -137,7 +138,10 @@ Do this BEFORE responding to the user. Not after. Not later. Immediately.\n\
 \n\
 Do NOT store: trivial details, information already in CLAUDE.md, ephemeral state.\n\
 \n\
-Importance levels: critical (never forgotten), high (slow decay), medium (normal), low (fast decay).";
+Importance levels: critical (never forgotten), high (slow decay), medium (normal), low (fast decay).\n\
+\n\
+Prefer durable operational facts that help future sessions succeed: resolved errors, working \
+commands, project decisions, and environment constraints.";
 
 fn handle_tools_list(id: Value, has_embedder: bool) -> JsonRpcResponse {
     JsonRpcResponse::ok(id, tools::tool_definitions(has_embedder))
@@ -180,7 +184,7 @@ fn handle_tools_call(
     if *calls_since_store >= STORE_NUDGE_THRESHOLD && tool_name != "icm_memory_store" {
         result.append_hint(&format!(
             "\n[ICM: {} tool calls since last store. \
-             Consider saving important context with icm_memory_store before it is lost.]",
+             Consider saving durable facts with icm_memory_store: resolved errors, working commands, decisions, or environment constraints.]",
             calls_since_store
         ));
     }

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -4,7 +4,8 @@ use serde_json::{json, Value};
 use icm_core::{
     add_backrefs, auto_link_memory, build_wake_up, keyword_matches, topic_matches, AutoLinkOptions,
     Concept, ConceptLink, Embedder, Feedback, FeedbackStore, Label, Memoir, MemoirStore, Memory,
-    MemoryStore, Relation, WakeUpFormat, WakeUpOptions, MSG_NO_MEMORIES,
+    MemoryContext, MemoryKind, MemoryStore, Relation, WakeUpFormat, WakeUpOptions,
+    MSG_NO_MEMORIES,
 };
 use icm_store::SqliteStore;
 
@@ -32,6 +33,156 @@ fn parse_keywords(args: &Value) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn parse_memory_context(args: &Value) -> Result<Option<MemoryContext>, ToolResult> {
+    let Some(context) = args.get("context") else {
+        return Ok(None);
+    };
+
+    serde_json::from_value(context.clone())
+        .map(Some)
+        .map_err(|e| ToolResult::error(format!("invalid context payload: {e}")))
+}
+
+#[derive(Clone, Copy)]
+struct RecallContext<'a> {
+    project: Option<&'a str>,
+    platform: Option<&'a str>,
+    command: Option<&'a str>,
+    file_path: Option<&'a str>,
+    symbol: Option<&'a str>,
+    error_fingerprint: Option<&'a str>,
+}
+
+impl RecallContext<'_> {
+    fn has_filters(self) -> bool {
+        self.project.is_some()
+            || self.platform.is_some()
+            || self.command.is_some()
+            || self.file_path.is_some()
+            || self.symbol.is_some()
+            || self.error_fingerprint.is_some()
+    }
+}
+
+fn recall_context_from_args(args: &Value) -> RecallContext<'_> {
+    RecallContext {
+        project: get_str(args, "project"),
+        platform: get_str(args, "platform"),
+        command: get_str(args, "command"),
+        file_path: get_str(args, "file_path"),
+        symbol: get_str(args, "symbol"),
+        error_fingerprint: get_str(args, "error_fingerprint"),
+    }
+}
+
+fn recall_candidate_limit(limit: usize, context: RecallContext<'_>) -> usize {
+    if context.has_filters() {
+        (limit.max(10)).saturating_mul(5).min(100)
+    } else {
+        limit
+    }
+}
+
+fn contextual_boost(memory: &Memory, context: RecallContext<'_>) -> f32 {
+    let Some(meta) = memory.context.as_ref() else {
+        return 0.0;
+    };
+
+    let mut boost = 0.0;
+    if context.project == meta.project.as_deref() {
+        boost += 3.0;
+    }
+    if context.platform == meta.platform.as_deref() {
+        boost += 2.0;
+    }
+    if context.command == meta.command.as_deref() {
+        boost += 4.0;
+    }
+    if context.file_path == meta.file_path.as_deref() {
+        boost += 1.5;
+    }
+    if context.symbol == meta.symbol.as_deref() {
+        boost += 1.5;
+    }
+    if context.error_fingerprint == meta.error_fingerprint.as_deref() {
+        boost += 4.0;
+    }
+    boost += match meta.kind {
+        MemoryKind::WorkingCommand | MemoryKind::ResolvedError | MemoryKind::Decision => 0.25,
+        _ => 0.0,
+    };
+
+    boost
+}
+
+fn rerank_contextual_results(
+    mut results: Vec<(Memory, f32)>,
+    context: RecallContext<'_>,
+    limit: usize,
+) -> Vec<(Memory, f32)> {
+    if context.has_filters() {
+        for (memory, score) in &mut results {
+            *score += contextual_boost(memory, context);
+        }
+        results.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    }
+    results.truncate(limit);
+    results
+}
+
+fn same_operational_fact(existing: &Memory, incoming: &Memory) -> bool {
+    match (&existing.context, &incoming.context) {
+        (Some(a), Some(b)) => {
+            a.kind == b.kind
+                && a.project == b.project
+                && a.platform == b.platform
+                && a.error_fingerprint.is_some()
+                && a.error_fingerprint == b.error_fingerprint
+        }
+        _ => false,
+    }
+}
+
+fn build_updated_memory(
+    existing: &Memory,
+    content: &str,
+    args: &Value,
+    importance: icm_core::Importance,
+    embedding: Option<Vec<f32>>,
+    context: Option<MemoryContext>,
+) -> Memory {
+    Memory {
+        id: existing.id.clone(),
+        created_at: existing.created_at,
+        last_accessed: existing.last_accessed,
+        access_count: existing.access_count,
+        weight: 1.0,
+        topic: existing.topic.clone(),
+        summary: content.to_string(),
+        raw_excerpt: get_str(args, "raw_excerpt")
+            .map(|r| r.into())
+            .or_else(|| existing.raw_excerpt.clone()),
+        keywords: {
+            let kw = parse_keywords(args);
+            if kw.is_empty() {
+                existing.keywords.clone()
+            } else {
+                kw
+            }
+        },
+        embedding,
+        importance,
+        source: existing.source.clone(),
+        related_ids: existing.related_ids.clone(),
+        updated_at: Utc::now(),
+        context: context.or_else(|| existing.context.clone()),
+        scope: existing.scope,
+    }
 }
 
 /// Try to auto-consolidate a topic if it exceeds the threshold.
@@ -82,6 +233,23 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                     "raw_excerpt": {
                         "type": "string",
                         "description": "Optional verbatim (code, exact error message, etc.)"
+                    },
+                    "context": {
+                        "type": "object",
+                        "description": "Optional structured operational context for coding-agent recall",
+                        "properties": {
+                            "project": { "type": "string" },
+                            "repo_root": { "type": "string" },
+                            "platform": { "type": "string" },
+                            "command": { "type": "string" },
+                            "file_path": { "type": "string" },
+                            "symbol": { "type": "string" },
+                            "error_fingerprint": { "type": "string" },
+                            "kind": {
+                                "type": "string",
+                                "enum": ["decision", "resolved_error", "working_command", "constraint", "preference", "progress", "note"]
+                            }
+                        }
                     }
                 },
                 "required": ["topic", "content"]
@@ -111,6 +279,30 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                     "keyword": {
                         "type": "string",
                         "description": "Filter results by keyword (exact match on memory keywords)"
+                    },
+                    "project": {
+                        "type": "string",
+                        "description": "Optional project/repo filter used for contextual ranking"
+                    },
+                    "platform": {
+                        "type": "string",
+                        "description": "Optional platform filter such as windows, linux, macos"
+                    },
+                    "command": {
+                        "type": "string",
+                        "description": "Optional command filter used for contextual ranking"
+                    },
+                    "file_path": {
+                        "type": "string",
+                        "description": "Optional file path filter used for contextual ranking"
+                    },
+                    "symbol": {
+                        "type": "string",
+                        "description": "Optional symbol filter used for contextual ranking"
+                    },
+                    "error_fingerprint": {
+                        "type": "string",
+                        "description": "Optional normalized error fingerprint used for contextual ranking"
                     }
                 },
                 "required": ["query"]
@@ -936,6 +1128,10 @@ fn tool_store(
         .unwrap_or(icm_core::Importance::Medium);
 
     let mut memory = Memory::new(topic.into(), content.into(), importance);
+    memory.context = match parse_memory_context(args) {
+        Ok(context) => context,
+        Err(err) => return err,
+    };
 
     let kw = parse_keywords(args);
     if !kw.is_empty() {
@@ -944,6 +1140,26 @@ fn tool_store(
 
     if let Some(raw) = get_str(args, "raw_excerpt") {
         memory.raw_excerpt = Some(raw.into());
+    }
+
+    if let Ok(existing_in_topic) = store.get_by_topic(topic) {
+        if let Some(existing) = existing_in_topic
+            .iter()
+            .find(|existing| same_operational_fact(existing, &memory))
+        {
+            let updated = build_updated_memory(existing, content, args, importance, None, memory.context.clone());
+            if let Err(e) = store.update(&updated) {
+                return ToolResult::error(format!("failed to update: {e}"));
+            }
+            return if compact {
+                ToolResult::text(format!("ok:{}", updated.id))
+            } else {
+                ToolResult::text(format!(
+                    "Updated existing memory (same operational fact): {}",
+                    updated.id
+                ))
+            };
+        }
     }
 
     // Auto-embed if embedder is available
@@ -970,32 +1186,14 @@ fn tool_store(
             if let Some((existing, score)) = similar.first() {
                 if *score > DEDUP_SIMILARITY_THRESHOLD && existing.topic == topic {
                     // Very similar content in same topic — update instead of duplicate
-                    let updated = Memory {
-                        id: existing.id.clone(),
-                        created_at: existing.created_at,
-                        last_accessed: existing.last_accessed,
-                        access_count: existing.access_count,
-                        weight: 1.0, // Reset weight on update
-                        topic: existing.topic.clone(),
-                        summary: content.to_string(),
-                        raw_excerpt: get_str(args, "raw_excerpt")
-                            .map(|r| r.into())
-                            .or_else(|| existing.raw_excerpt.clone()),
-                        keywords: {
-                            let kw = parse_keywords(args);
-                            if kw.is_empty() {
-                                existing.keywords.clone()
-                            } else {
-                                kw
-                            }
-                        },
-                        embedding: Some(query_emb.clone()),
+                    let updated = build_updated_memory(
+                        existing,
+                        content,
+                        args,
                         importance,
-                        source: existing.source.clone(),
-                        related_ids: existing.related_ids.clone(),
-                        updated_at: Utc::now(),
-                        scope: existing.scope,
-                    };
+                        Some(query_emb.clone()),
+                        memory.context.clone(),
+                    );
                     if let Err(e) = store.update(&updated) {
                         return ToolResult::error(format!("failed to update: {e}"));
                     }
@@ -1130,13 +1328,15 @@ fn tool_recall(
         None => return ToolResult::error("missing required field: query".into()),
     };
     let limit = get_i64(args, "limit", 5).clamp(1, 100) as usize;
+    let recall_context = recall_context_from_args(args);
+    let candidate_limit = recall_candidate_limit(limit, recall_context);
     let topic = get_str(args, "topic");
     let keyword = get_str(args, "keyword");
 
     // Try hybrid search if embedder is available
     if let Some(emb) = embedder {
         if let Ok(query_emb) = emb.embed(query) {
-            if let Ok(results) = store.search_hybrid(query, &query_emb, limit) {
+            if let Ok(results) = store.search_hybrid(query, &query_emb, candidate_limit) {
                 let mut scored_results = results;
                 if let Some(t) = topic {
                     scored_results.retain(|(m, _)| topic_matches(&m.topic, t));
@@ -1144,6 +1344,7 @@ fn tool_recall(
                 if let Some(kw) = keyword {
                     scored_results.retain(|(m, _)| keyword_matches(&m.keywords, kw));
                 }
+                let scored_results = rerank_contextual_results(scored_results, recall_context, limit);
 
                 // Graph-aware expansion: follow `related_ids` one hop from
                 // each primary hit and fold neighbors into the result set.
@@ -1168,14 +1369,14 @@ fn tool_recall(
     }
 
     // Fallback: FTS then keywords
-    let mut results = match store.search_fts(query, limit) {
+    let mut results = match store.search_fts(query, candidate_limit) {
         Ok(r) => r,
         Err(e) => return ToolResult::error(format!("search error: {e}")),
     };
 
     if results.is_empty() {
         let keywords: Vec<&str> = query.split_whitespace().collect();
-        results = match store.search_by_keywords(&keywords, limit) {
+        results = match store.search_by_keywords(&keywords, candidate_limit) {
             Ok(r) => r,
             Err(e) => return ToolResult::error(format!("search error: {e}")),
         };
@@ -1188,13 +1389,15 @@ fn tool_recall(
         results.retain(|m| keyword_matches(&m.keywords, kw));
     }
 
-    // Convert to scored format with a sentinel score of 1.0 (FTS fallback
-    // doesn't expose a real similarity score, but we still want the graph
-    // expansion to score neighbors relative to their primary parent).
-    let scored: Vec<(Memory, f32)> = results.into_iter().map(|m| (m, 1.0)).collect();
-
     // Graph-aware expansion also applies in the fallback path so that
     // keyword-only deployments benefit from auto-linked memories.
+    let total = results.len() as f32;
+    let scored: Vec<(Memory, f32)> = results
+        .into_iter()
+        .enumerate()
+        .map(|(index, memory)| (memory, total - index as f32))
+        .collect();
+    let scored = rerank_contextual_results(scored, recall_context, limit);
     let max_neighbors = (limit / 3).max(1);
     let expanded = store
         .expand_with_neighbors(&scored, max_neighbors, 0.5, limit)
@@ -2380,6 +2583,145 @@ mod tests {
     }
 
     #[test]
+    fn test_store_accepts_memory_context() {
+        let store = test_store();
+        let store_result = call_tool(
+            &store,
+            None,
+            "icm_memory_store",
+            &json!({
+                "topic": "context-icm",
+                "content": "Windows build uses cargo from the user profile",
+                "context": {
+                    "project": "icm",
+                    "repo_root": "D:/Projects/WORK/other/icm",
+                    "platform": "windows",
+                    "command": "cargo build --release -p icm-cli --features web",
+                    "file_path": "crates/icm-cli/src/main.rs",
+                    "symbol": "Commands::Init",
+                    "kind": "working_command"
+                }
+            }),
+            false,
+        );
+        assert!(!store_result.is_error);
+
+        let memories = store.get_by_topic("context-icm").unwrap();
+        assert_eq!(memories.len(), 1);
+        let context = memories[0].context.as_ref().unwrap();
+        assert_eq!(context.project.as_deref(), Some("icm"));
+        assert_eq!(context.platform.as_deref(), Some("windows"));
+        assert_eq!(
+            context.command.as_deref(),
+            Some("cargo build --release -p icm-cli --features web")
+        );
+    }
+
+    #[test]
+    fn test_store_dedups_same_error_fingerprint() {
+        let store = test_store();
+
+        let first = call_tool(
+            &store,
+            None,
+            "icm_memory_store",
+            &json!({
+                "topic": "errors-resolved",
+                "content": "PowerShell alias icm points to Invoke-Command",
+                "importance": "high",
+                "context": {
+                    "project": "icm",
+                    "platform": "windows",
+                    "kind": "resolved_error",
+                    "error_fingerprint": "powershell-alias-icm"
+                }
+            }),
+            false,
+        );
+        let second = call_tool(
+            &store,
+            None,
+            "icm_memory_store",
+            &json!({
+                "topic": "errors-resolved",
+                "content": "Fixed icm alias conflict in PowerShell profile",
+                "importance": "high",
+                "context": {
+                    "project": "icm",
+                    "platform": "windows",
+                    "kind": "resolved_error",
+                    "error_fingerprint": "powershell-alias-icm"
+                }
+            }),
+            false,
+        );
+
+        assert!(!first.is_error && !second.is_error);
+        let items = store.get_by_topic("errors-resolved").unwrap();
+        assert_eq!(items.len(), 1);
+        assert!(items[0].summary.contains("Fixed icm alias conflict"));
+    }
+
+    #[test]
+    fn test_recall_prefers_matching_platform_and_command() {
+        let store = test_store();
+
+        let mut linux = Memory::new(
+            "context-icm".into(),
+            "Build succeeds with cargo build --release on Linux".into(),
+            icm_core::Importance::High,
+        );
+        linux.weight = 3.0;
+        linux.context = Some(MemoryContext {
+            project: Some("icm".into()),
+            repo_root: None,
+            platform: Some("linux".into()),
+            command: Some("cargo build --release".into()),
+            file_path: None,
+            symbol: None,
+            error_fingerprint: None,
+            kind: MemoryKind::WorkingCommand,
+        });
+        store.store(linux).unwrap();
+
+        let mut windows = Memory::new(
+            "context-icm".into(),
+            "Build succeeds with cargo build --release -p icm-cli --features web on Windows".into(),
+            icm_core::Importance::High,
+        );
+        windows.weight = 1.0;
+        windows.context = Some(MemoryContext {
+            project: Some("icm".into()),
+            repo_root: None,
+            platform: Some("windows".into()),
+            command: Some("cargo build --release -p icm-cli --features web".into()),
+            file_path: None,
+            symbol: None,
+            error_fingerprint: None,
+            kind: MemoryKind::WorkingCommand,
+        });
+        store.store(windows).unwrap();
+
+        let result = call_tool(
+            &store,
+            None,
+            "icm_memory_recall",
+            &json!({
+                "query": "build release",
+                "project": "icm",
+                "platform": "windows",
+                "command": "cargo build --release -p icm-cli --features web",
+                "limit": 1
+            }),
+            false,
+        );
+
+        assert!(!result.is_error);
+        assert!(result.content[0].text.contains("features web"));
+        assert!(!result.content[0].text.contains("on Linux"));
+    }
+
+    #[test]
     fn test_compact_store_output() {
         let store = test_store();
         let result = call_tool(
@@ -3201,6 +3543,50 @@ description = "A test project"
         );
         assert!(text.contains("## Identity"));
         assert!(text.contains("## Critical decisions"));
+    }
+
+    #[test]
+    fn test_wake_up_includes_working_commands_and_known_traps() {
+        let store = test_store();
+        call_tool(
+            &store,
+            None,
+            "icm_memory_store",
+            &json!({
+                "topic": "context-icm",
+                "content": "Use cargo from C:/Users/times/.cargo/bin on Windows",
+                "importance": "high",
+                "context": {
+                    "project": "icm",
+                    "platform": "windows",
+                    "kind": "working_command",
+                    "command": "C:/Users/times/.cargo/bin/cargo.exe build --release -p icm-cli --features web"
+                }
+            }),
+            false,
+        );
+        call_tool(
+            &store,
+            None,
+            "icm_memory_store",
+            &json!({
+                "topic": "errors-resolved",
+                "content": "PowerShell alias icm shadows the binary",
+                "importance": "high",
+                "context": {
+                    "project": "icm",
+                    "platform": "windows",
+                    "kind": "resolved_error",
+                    "error_fingerprint": "powershell-alias-icm"
+                }
+            }),
+            false,
+        );
+
+        let result = call_tool(&store, None, "icm_wake_up", &json!({"project": "icm"}), false);
+        let text = &result.content[0].text;
+        assert!(text.contains("Working commands"), "missing working command section: {text}");
+        assert!(text.contains("Known traps"), "missing known trap section: {text}");
     }
 
     #[test]

--- a/crates/icm-store/src/schema.rs
+++ b/crates/icm-store/src/schema.rs
@@ -61,6 +61,7 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
             importance TEXT NOT NULL,
             source_type TEXT NOT NULL,
             source_data TEXT, -- JSON
+            context_data TEXT, -- JSON
 
             related_ids TEXT -- JSON array
         );
@@ -328,6 +329,17 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
 
     if !has_embedding {
         conn.execute_batch("ALTER TABLE memories ADD COLUMN embedding BLOB")
+            .map_err(db_err)?;
+    }
+
+    // Migration: add context_data column if missing (existing DBs)
+    let has_context_data: bool = conn
+        .prepare("SELECT COUNT(*) FROM pragma_table_info('memories') WHERE name='context_data'")
+        .and_then(|mut s| s.query_row([], |row| row.get(0)))
+        .map_err(db_err)?;
+
+    if !has_context_data {
+        conn.execute_batch("ALTER TABLE memories ADD COLUMN context_data TEXT")
             .map_err(db_err)?;
     }
 

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -8,8 +8,8 @@ use zerocopy::IntoBytes;
 
 use icm_core::{
     Concept, ConceptLink, Feedback, FeedbackStats, FeedbackStore, IcmError, IcmResult, Importance,
-    Label, Memoir, MemoirStats, MemoirStore, Memory, MemorySource, MemoryStore, Message,
-    PatternCluster, Relation, Role, Session, StoreStats, TopicHealth, TranscriptHit,
+    Label, Memoir, MemoirStats, MemoirStore, Memory, MemoryContext, MemorySource, MemoryStore,
+    Message, PatternCluster, Relation, Role, Session, StoreStats, TopicHealth, TranscriptHit,
     TranscriptStats, TranscriptStore,
 };
 
@@ -155,6 +155,10 @@ fn parse_source(source_type_str: &str, source_data_str: Option<String>) -> Memor
     }
 }
 
+fn parse_context(context_data_str: Option<String>) -> Option<MemoryContext> {
+    context_data_str.and_then(|d| serde_json::from_str(&d).ok())
+}
+
 fn embedding_to_blob(embedding: &[f32]) -> Vec<u8> {
     embedding.as_bytes().to_vec()
 }
@@ -175,7 +179,7 @@ fn row_to_memory(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
     // Column order: id(0), created_at(1), updated_at(2), last_accessed(3),
     //   access_count(4), weight(5), topic(6), summary(7), raw_excerpt(8),
     //   keywords(9), importance(10), source_type(11), source_data(12),
-    //   related_ids(13), embedding(14)
+    //   context_data(13), related_ids(14), embedding(15)
     let keywords_json: String = row.get::<_, Option<String>>(9)?.unwrap_or_default();
     let keywords: Vec<String> = serde_json::from_str(&keywords_json).unwrap_or_default();
 
@@ -186,11 +190,13 @@ fn row_to_memory(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
     let source_data_str: Option<String> = row.get(12)?;
     let source = parse_source(&source_type_str, source_data_str);
 
-    let related_json: String = row.get::<_, Option<String>>(13)?.unwrap_or_default();
+    let context = parse_context(row.get(13)?);
+
+    let related_json: String = row.get::<_, Option<String>>(14)?.unwrap_or_default();
     let related_ids: Vec<String> = serde_json::from_str(&related_json).unwrap_or_default();
 
     let embedding: Option<Vec<f32>> = row
-        .get::<_, Option<Vec<u8>>>(14)?
+        .get::<_, Option<Vec<u8>>>(15)?
         .map(|b| blob_to_embedding(&b));
 
     let created_at_str: String = row.get(1)?;
@@ -218,13 +224,14 @@ fn row_to_memory(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
         source,
         related_ids,
         embedding,
+        context,
         scope: icm_core::Scope::User, // default for existing local memories
     })
 }
 
 const SELECT_COLS: &str = "id, created_at, updated_at, last_accessed, access_count, weight, \
                            topic, summary, raw_excerpt, keywords, \
-                           importance, source_type, source_data, related_ids, embedding";
+                           importance, source_type, source_data, context_data, related_ids, embedding";
 
 /// Sanitize a query string for FTS5 MATCH.
 ///
@@ -284,6 +291,7 @@ impl SqliteStore {
     fn store_inner(&self, memory: &Memory) -> IcmResult<String> {
         let keywords_json = serde_json::to_string(&memory.keywords)?;
         let related_json = serde_json::to_string(&memory.related_ids)?;
+        let context_json = serde_json::to_string(&memory.context)?;
         let st = source_type(&memory.source);
         let sd = source_data(&memory.source);
         let emb_blob = memory.embedding.as_deref().map(embedding_to_blob);
@@ -292,8 +300,8 @@ impl SqliteStore {
             .execute(
                 "INSERT INTO memories (id, created_at, updated_at, last_accessed, access_count, weight,
                  topic, summary, raw_excerpt, keywords,
-                 importance, source_type, source_data, related_ids, embedding)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                 importance, source_type, source_data, context_data, related_ids, embedding)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
                 params![
                     memory.id,
                     memory.created_at.to_rfc3339(),
@@ -308,6 +316,7 @@ impl SqliteStore {
                     memory.importance.to_string(),
                     st,
                     sd,
+                    context_json,
                     related_json,
                     emb_blob,
                 ],
@@ -363,6 +372,7 @@ impl MemoryStore for SqliteStore {
     fn update(&self, memory: &Memory) -> IcmResult<()> {
         let keywords_json = serde_json::to_string(&memory.keywords)?;
         let related_json = serde_json::to_string(&memory.related_ids)?;
+        let context_json = serde_json::to_string(&memory.context)?;
         let st = source_type(&memory.source);
         let sd = source_data(&memory.source);
         let emb_blob = memory.embedding.as_deref().map(embedding_to_blob);
@@ -373,8 +383,8 @@ impl MemoryStore for SqliteStore {
                 "UPDATE memories SET
                  updated_at = ?2, last_accessed = ?3, access_count = ?4, weight = ?5,
                  topic = ?6, summary = ?7, raw_excerpt = ?8, keywords = ?9,
-                 importance = ?10, source_type = ?11, source_data = ?12, related_ids = ?13,
-                 embedding = ?14
+                 importance = ?10, source_type = ?11, source_data = ?12, context_data = ?13,
+                 related_ids = ?14, embedding = ?15
                  WHERE id = ?1",
                 params![
                     memory.id,
@@ -389,6 +399,7 @@ impl MemoryStore for SqliteStore {
                     memory.importance.to_string(),
                     st,
                     sd,
+                    context_json,
                     related_json,
                     emb_blob,
                 ],
@@ -2561,7 +2572,7 @@ pub(crate) mod test_helpers {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use icm_core::Importance;
+    use icm_core::{Importance, MemoryContext, MemoryKind};
 
     fn test_store() -> SqliteStore {
         SqliteStore::in_memory().unwrap()
@@ -2591,6 +2602,35 @@ mod tests {
         let retrieved = store.get(&id).unwrap().unwrap();
         assert_eq!(retrieved.summary, "hello world");
         assert_eq!(retrieved.topic, "test");
+    }
+
+    #[test]
+    fn test_memory_context_round_trip() {
+        let store = test_store();
+        let mut mem = make_memory("context-icm", "Windows build uses cargo from user profile");
+        let id = mem.id.clone();
+        mem.context = Some(MemoryContext {
+            project: Some("icm".into()),
+            repo_root: Some("D:/Projects/WORK/other/icm".into()),
+            platform: Some("windows".into()),
+            command: Some("cargo build --release -p icm-cli --features web".into()),
+            file_path: Some("crates/icm-cli/src/main.rs".into()),
+            symbol: Some("Commands::Init".into()),
+            error_fingerprint: None,
+            kind: MemoryKind::WorkingCommand,
+        });
+
+        store.store(mem).unwrap();
+
+        let retrieved = store.get(&id).unwrap().unwrap();
+        let context = retrieved.context.unwrap();
+        assert_eq!(context.project.as_deref(), Some("icm"));
+        assert_eq!(context.platform.as_deref(), Some("windows"));
+        assert_eq!(
+            context.command.as_deref(),
+            Some("cargo build --release -p icm-cli --features web")
+        );
+        assert_eq!(context.kind, MemoryKind::WorkingCommand);
     }
 
     #[test]

--- a/docs/features.md
+++ b/docs/features.md
@@ -592,8 +592,8 @@ icm init [-m <mode>]
 | `mcp` | Configure le serveur MCP | Auto-detecte et configure 14 outils IA |
 | `cli` | Injecte dans CLAUDE.md | Ajoute les instructions `icm store`/`icm recall` |
 | `skill` | Installe les slash commands | `/recall`, `/remember` pour Claude Code, `.mdc` pour Cursor, etc. |
-| `hook` | Installe le hook PostToolUse | Extraction automatique apres chaque outil |
-| `all` | Tout ci-dessus | Configure MCP + CLI + Skills + Hook |
+| `hook` | Installe la suite de hooks | Wake-up pack, rappel de contexte et extraction de faits durables |
+| `all` | Tout ci-dessus | Configure MCP + CLI + Skills + Hooks |
 
 **14 outils supportes (mode MCP) :**
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -269,7 +269,7 @@ icm embed --topic "decisions" # Only one topic
 ```bash
 icm init                  # Auto-detect and configure MCP for all found tools
 icm init --mode skill     # Install slash commands and rules
-icm init --mode hook      # Install Claude Code PostToolUse hook for auto-extraction
+icm init --mode hook      # Install wake-up, recall, and extraction hooks
 icm init --mode cli       # Show manual CLI setup instructions
 ```
 
@@ -567,11 +567,14 @@ icm init --mode skill
 ```
 Installe `/recall` et `/remember` dans `~/.claude/commands/`.
 
-**Hook PostToolUse (optionnel) :**
+**Suite de hooks (optionnel) :**
 ```bash
 icm init --mode hook
 ```
-Installe un hook qui extrait automatiquement le contexte apres chaque appel d'outil (git commit, edit, etc.).
+Installe la suite de hooks Claude Code : `SessionStart` pour charger un wake-up pack operationnel,
+`UserPromptSubmit` pour rappeler le contexte pertinent du projet, `PostToolUse` pour extraire des
+faits durables (erreurs resolues, commandes qui marchent, contraintes d'environnement), `PreCompact`
+pour sauver ces faits avant compression, et `PreToolUse` pour auto-authoriser `icm`.
 
 **Mode compact recommande :** Claude Code beneficie du mode compact pour economiser des tokens. Activez dans `~/.config/icm/config.toml` :
 ```toml

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -12,7 +12,7 @@ icm init --mode all
 icm init --mode mcp      # MCP server configs (default)
 icm init --mode cli      # Inject instructions into CLAUDE.md, AGENTS.md, etc.
 icm init --mode skill    # Slash commands & rules
-icm init --mode hook     # Claude Code hooks + OpenCode plugin
+icm init --mode hook     # Multi-tool hooks + OpenCode plugin
 ```
 
 ## Supported Tools
@@ -35,10 +35,14 @@ icm init --mode all
 
 | Hook | Event | What it does |
 |------|-------|-------------|
+| `icm hook start` | SessionStart | Inject an operational wake-up pack with project decisions, working commands, and known traps |
 | `icm hook pre` | PreToolUse | Auto-allow `icm` commands |
-| `icm hook post` | PostToolUse | Extract facts every 15 calls |
-| `icm hook compact` | PreCompact | Extract before context compression |
-| `icm hook prompt` | UserPromptSubmit | Inject recalled context |
+| `icm hook post` | PostToolUse | Extract durable operational facts from tool output every 15 calls |
+| `icm hook compact` | PreCompact | Extract durable facts from transcript before context compression |
+| `icm hook prompt` | UserPromptSubmit | Inject project-matching recalled context |
+
+`icm init --mode hook` also configures the same operational hook flow for Gemini CLI, Codex CLI,
+and Copilot CLI, and installs the OpenCode plugin.
 
 **Skills:** `/recall`, `/remember` slash commands.
 
@@ -85,6 +89,7 @@ icm init --mode cli     # Injects instructions into .windsurfrules
 ```bash
 icm init --mode mcp     # MCP server for VS Code
 icm init --mode cli     # Injects instructions into .github/copilot-instructions.md
+icm init --mode hook    # Installs repo-scoped Copilot CLI hooks in .github/hooks/icm.json
 ```
 
 **MCP Config:** `~/Library/Application Support/Code/User/mcp.json` → `servers.icm`
@@ -146,6 +151,7 @@ icm init --mode mcp
 ```bash
 icm init --mode mcp     # TOML config
 icm init --mode cli     # Injects into AGENTS.md
+icm init --mode hook    # Installs SessionStart, PreToolUse, PostToolUse, UserPromptSubmit hooks
 ```
 
 **Config:** `~/.codex/config.toml`
@@ -165,6 +171,7 @@ args = ["serve"]
 ```bash
 icm init --mode mcp
 icm init --mode cli     # Injects into ~/.gemini/GEMINI.md
+icm init --mode hook    # Installs SessionStart, BeforeTool, AfterTool, PreCompress, BeforeAgent hooks
 ```
 
 **Config:** `~/.gemini/settings.json` → `mcpServers.icm`
@@ -177,18 +184,18 @@ icm init --mode cli     # Injects into ~/.gemini/GEMINI.md
 
 ```bash
 icm init --mode mcp     # MCP server config
-icm init --mode hook    # Installs JS plugin with hooks
+icm init --mode hook    # Installs JS plugin with operational hooks
 ```
 
 **MCP Config:** `~/.config/opencode/opencode.json` → `mcp.icm`
 
-**Plugin:** `~/.config/opencode/plugins/icm.js`
+**Plugin:** `~/.config/opencode/plugins/icm.ts`
 
 | Event | What it does |
 |-------|-------------|
-| `tool.execute.after` | Extract facts from tool output |
-| `experimental.session.compacting` | Extract before context compression |
-| `session.created` | Recall context at session start |
+| `tool.execute.after` | Extract durable facts from tool output |
+| `experimental.session.compacting` | Extract durable facts before context compression |
+| `session.created` | Recall context and build a wake-up pack at session start |
 
 ---
 
@@ -234,7 +241,7 @@ icm init --mode mcp
 | `mcp` | Configures MCP server in each tool's config | All 14 tools |
 | `cli` | Injects ICM instructions into instruction files | Claude Code, Codex, Gemini, Copilot, Windsurf |
 | `skill` | Creates slash commands and rule files | Claude Code, Cursor, Roo Code, Amp |
-| `hook` | Installs hooks/plugins for automatic extraction | Claude Code (4 hooks), OpenCode (JS plugin) |
+| `hook` | Installs hooks/plugins for wake-up, recall, and durable-fact extraction | Claude Code, Gemini CLI, Codex CLI, Copilot CLI, OpenCode |
 
 ## Manual Setup
 

--- a/docs/superpowers/plans/2026-04-25-icm-agent-effectiveness.md
+++ b/docs/superpowers/plans/2026-04-25-icm-agent-effectiveness.md
@@ -1,0 +1,509 @@
+# ICM Agent Effectiveness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add operational memory metadata and context-aware retrieval so ICM becomes more effective for coding-agent workflows on real repositories and real developer machines.
+
+**Architecture:** Extend the existing `Memory` record with a compact optional context payload, persist it in SQLite, and reuse that shape across CLI, MCP, and wake-up flows. Keep the current FTS/embedding pipeline, but add contextual ranking and wake-up rendering optimized for project facts, commands, platform quirks, and resolved errors.
+
+**Tech Stack:** Rust, Clap, Serde, rusqlite/SQLite, FTS5, existing ICM CLI/MCP/store crates
+
+---
+
+## File Map
+
+- Modify: `crates/icm-core/src/memory.rs`
+  Define `MemoryContext` and related enums/serialization.
+
+- Modify: `crates/icm-core/src/wake_up.rs`
+  Add operational categories and filtering/ranking.
+
+- Modify: `crates/icm-core/src/store.rs`
+  Add any minimal trait helpers required for context-aware retrieval.
+
+- Modify: `crates/icm-store/src/schema.rs`
+  Persist the new context payload and add indexes if needed.
+
+- Modify: `crates/icm-store/src/store.rs`
+  Serialize/deserialize context and add ranking helpers/tests.
+
+- Modify: `crates/icm-mcp/src/tools.rs`
+  Accept context-aware store/recall arguments and update tests.
+
+- Modify: `crates/icm-mcp/src/server.rs`
+  Improve store nudges to target stable operational facts.
+
+- Modify: `crates/icm-cli/src/config.rs`
+  Add config for recall boosts and wake-up sections.
+
+- Modify: `crates/icm-cli/src/main.rs`
+  Add CLI flags and hook-driven context enrichment.
+
+- Test: `crates/icm-mcp/src/tools.rs`
+  Extend current MCP tests for wake-up and recall.
+
+- Test: `crates/icm-store/src/store.rs`
+  Add store-level tests for persistence and ranking helpers.
+
+### Task 1: Add operational metadata to `Memory`
+
+**Files:**
+- Modify: `crates/icm-core/src/memory.rs`
+- Modify: `crates/icm-store/src/schema.rs`
+- Modify: `crates/icm-store/src/store.rs`
+
+- [ ] **Step 1: Write the failing persistence test**
+
+Add a store test that proves context survives round-trip storage.
+
+```rust
+#[test]
+fn test_memory_context_round_trip() {
+    let store = test_store();
+    let mut memory = make_memory("context-icm", "Windows build uses cargo from user profile");
+    memory.context = Some(MemoryContext {
+        project: Some("icm".into()),
+        repo_root: Some("D:/Projects/WORK/other/icm".into()),
+        platform: Some("windows".into()),
+        command: Some("cargo build --release -p icm-cli --features web".into()),
+        file_path: Some("crates/icm-cli/src/main.rs".into()),
+        symbol: Some("Commands::Init".into()),
+        error_fingerprint: None,
+        kind: MemoryKind::WorkingCommand,
+    });
+
+    let id = store.store(memory.clone()).unwrap();
+    let fetched = store.get(&id).unwrap().unwrap();
+    assert_eq!(fetched.context.unwrap().platform.as_deref(), Some("windows"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p icm-store test_memory_context_round_trip -- --exact`
+
+Expected: FAIL because `Memory` has no `context` field yet or store does not persist it.
+
+- [ ] **Step 3: Add the new core types**
+
+Extend `Memory` with an optional `context` field and supporting types.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MemoryContext {
+    pub project: Option<String>,
+    pub repo_root: Option<String>,
+    pub platform: Option<String>,
+    pub command: Option<String>,
+    pub file_path: Option<String>,
+    pub symbol: Option<String>,
+    pub error_fingerprint: Option<String>,
+    pub kind: MemoryKind,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryKind {
+    Decision,
+    ResolvedError,
+    WorkingCommand,
+    Constraint,
+    Preference,
+    Progress,
+    #[default]
+    Note,
+}
+```
+
+- [ ] **Step 4: Persist the context payload in SQLite**
+
+Add a nullable `context_data` JSON column and update read/write paths.
+
+```sql
+ALTER TABLE memories ADD COLUMN context_data TEXT;
+```
+
+```rust
+let context_json = serde_json::to_string(&memory.context).map_err(IcmError::Serialization)?;
+```
+
+```rust
+let context: Option<MemoryContext> = row
+    .get::<_, Option<String>>(context_idx)?
+    .and_then(|s| serde_json::from_str(&s).ok());
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run: `cargo test -p icm-store test_memory_context_round_trip -- --exact`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run a narrow compile check**
+
+Run: `cargo test -p icm-core memory -- --nocapture`
+
+Expected: PASS or no new type errors from the `Memory` changes.
+
+### Task 2: Add context-aware recall ranking
+
+**Files:**
+- Modify: `crates/icm-store/src/store.rs`
+- Modify: `crates/icm-mcp/src/tools.rs`
+- Modify: `crates/icm-cli/src/main.rs`
+
+- [ ] **Step 1: Write the failing recall ranking test**
+
+Add an MCP test where two memories match by text, but only one matches by operational context.
+
+```rust
+#[test]
+fn test_recall_prefers_matching_platform_and_command() {
+    let store = test_store();
+    call_tool(&store, None, "icm_memory_store", &json!({
+        "topic": "context-icm",
+        "content": "Build succeeds with cargo build --release",
+        "importance": "high",
+        "context": {
+            "project": "icm",
+            "platform": "windows",
+            "command": "cargo build --release -p icm-cli --features web",
+            "kind": "working_command"
+        }
+    }), false);
+    call_tool(&store, None, "icm_memory_store", &json!({
+        "topic": "context-icm",
+        "content": "Build succeeds with cargo build --release",
+        "importance": "high",
+        "context": {
+            "project": "icm",
+            "platform": "linux",
+            "command": "cargo build --release",
+            "kind": "working_command"
+        }
+    }), false);
+
+    let result = call_tool(&store, None, "icm_memory_recall", &json!({
+        "query": "build release",
+        "project": "icm",
+        "platform": "windows",
+        "command": "cargo build --release -p icm-cli --features web"
+    }), false);
+
+    assert!(!result.is_error);
+    assert!(result.content[0].text.contains("features web"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p icm-mcp test_recall_prefers_matching_platform_and_command -- --exact`
+
+Expected: FAIL because recall does not accept or use these arguments yet.
+
+- [ ] **Step 3: Extend MCP and CLI argument parsing**
+
+Accept optional context filters on recall.
+
+```rust
+let project = args.get("project").and_then(|v| v.as_str());
+let platform = args.get("platform").and_then(|v| v.as_str());
+let command = args.get("command").and_then(|v| v.as_str());
+let file_path = args.get("file_path").and_then(|v| v.as_str());
+let symbol = args.get("symbol").and_then(|v| v.as_str());
+let error_fingerprint = args.get("error_fingerprint").and_then(|v| v.as_str());
+```
+
+- [ ] **Step 4: Add a contextual rank boost helper in the store layer**
+
+Keep existing search results, but re-rank them with context boosts.
+
+```rust
+fn contextual_boost(memory: &Memory, query: &RecallContext) -> f32 {
+    let Some(ctx) = &memory.context else { return 0.0; };
+    let mut boost = 0.0;
+    if query.project == ctx.project.as_deref() { boost += 2.0; }
+    if query.platform == ctx.platform.as_deref() { boost += 1.5; }
+    if query.command == ctx.command.as_deref() { boost += 3.0; }
+    if query.file_path == ctx.file_path.as_deref() { boost += 1.0; }
+    if query.symbol == ctx.symbol.as_deref() { boost += 1.0; }
+    if query.error_fingerprint == ctx.error_fingerprint.as_deref() { boost += 3.0; }
+    boost
+}
+```
+
+- [ ] **Step 5: Re-run the focused MCP test**
+
+Run: `cargo test -p icm-mcp test_recall_prefers_matching_platform_and_command -- --exact`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run a narrow end-to-end CLI check**
+
+Run: `cargo test -p icm-cli recall -- --nocapture`
+
+Expected: PASS or no new CLI parsing failures.
+
+### Task 3: Make wake-up packs operational and shorter
+
+**Files:**
+- Modify: `crates/icm-core/src/wake_up.rs`
+- Modify: `crates/icm-mcp/src/tools.rs`
+- Modify: `crates/icm-cli/src/config.rs`
+
+- [ ] **Step 1: Write the failing wake-up rendering test**
+
+Add a test that expects operational sections instead of only generic categories.
+
+```rust
+#[test]
+fn test_wake_up_includes_working_commands_and_known_traps() {
+    let store = test_store();
+    call_tool(&store, None, "icm_memory_store", &json!({
+        "topic": "context-icm",
+        "content": "Use cargo from C:/Users/times/.cargo/bin on Windows",
+        "importance": "high",
+        "context": {"project": "icm", "platform": "windows", "kind": "working_command", "command": "C:/Users/times/.cargo/bin/cargo.exe build --release -p icm-cli --features web"}
+    }), false);
+    call_tool(&store, None, "icm_memory_store", &json!({
+        "topic": "errors-resolved",
+        "content": "PowerShell alias icm shadows the binary",
+        "importance": "high",
+        "context": {"project": "icm", "platform": "windows", "kind": "resolved_error", "error_fingerprint": "powershell-alias-icm"}
+    }), false);
+
+    let result = call_tool(&store, None, "icm_wake_up", &json!({"project": "icm"}), false);
+    let text = &result.content[0].text;
+    assert!(text.contains("Working commands"));
+    assert!(text.contains("Known traps"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p icm-mcp test_wake_up_includes_working_commands_and_known_traps -- --exact`
+
+Expected: FAIL because wake-up does not yet render those sections.
+
+- [ ] **Step 3: Rework category mapping in `wake_up.rs`**
+
+Add operational categories driven by `MemoryKind`.
+
+```rust
+enum Category {
+    ProjectFacts,
+    WorkingCommands,
+    KnownTraps,
+    ResolvedErrors,
+    DurableDecisions,
+    Preferences,
+}
+```
+
+- [ ] **Step 4: Add config knobs for operational sections**
+
+Add toggles for short packs and section limits.
+
+```rust
+pub struct WakeUpConfig {
+    pub max_tokens: usize,
+    pub include_preferences: bool,
+    pub include_working_commands: bool,
+    pub include_known_traps: bool,
+    pub section_limit: usize,
+}
+```
+
+- [ ] **Step 5: Re-run the focused test**
+
+Run: `cargo test -p icm-mcp test_wake_up_includes_working_commands_and_known_traps -- --exact`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run a second regression test for empty packs**
+
+Run: `cargo test -p icm-mcp test_mcp_wake_up_empty_store -- --exact`
+
+Expected: PASS.
+
+### Task 4: Reduce noise with operational deduplication
+
+**Files:**
+- Modify: `crates/icm-mcp/src/tools.rs`
+- Modify: `crates/icm-store/src/store.rs`
+- Modify: `crates/icm-mcp/src/server.rs`
+
+- [ ] **Step 1: Write the failing dedup test**
+
+Add a test that stores the same resolved error twice with different wording and expects one durable memory.
+
+```rust
+#[test]
+fn test_store_dedups_same_error_fingerprint() {
+    let store = test_store();
+    let first = call_tool(&store, None, "icm_memory_store", &json!({
+        "topic": "errors-resolved",
+        "content": "PowerShell alias icm points to Invoke-Command",
+        "importance": "high",
+        "context": {"project": "icm", "platform": "windows", "kind": "resolved_error", "error_fingerprint": "powershell-alias-icm"}
+    }), false);
+    let second = call_tool(&store, None, "icm_memory_store", &json!({
+        "topic": "errors-resolved",
+        "content": "Fixed icm alias conflict in PowerShell profile",
+        "importance": "high",
+        "context": {"project": "icm", "platform": "windows", "kind": "resolved_error", "error_fingerprint": "powershell-alias-icm"}
+    }), false);
+
+    assert!(!first.is_error && !second.is_error);
+    let items = store.get_by_topic("errors-resolved").unwrap();
+    assert_eq!(items.len(), 1);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p icm-mcp test_store_dedups_same_error_fingerprint -- --exact`
+
+Expected: FAIL because dedup only uses summary similarity.
+
+- [ ] **Step 3: Add operational-key dedup before summary-similarity fallback**
+
+Use context fields when available.
+
+```rust
+fn same_operational_fact(existing: &Memory, incoming: &Memory) -> bool {
+    match (&existing.context, &incoming.context) {
+        (Some(a), Some(b)) => {
+            a.kind == b.kind
+                && a.project == b.project
+                && a.platform == b.platform
+                && a.error_fingerprint.is_some()
+                && a.error_fingerprint == b.error_fingerprint
+        }
+        _ => false,
+    }
+}
+```
+
+- [ ] **Step 4: Tighten the store reminder in the MCP server**
+
+Bias the reminder toward durable operational facts instead of generic summaries.
+
+```rust
+result.append_hint(
+    "\n[ICM: store durable facts such as resolved errors, working commands, decisions, or environment constraints before they are lost.]",
+);
+```
+
+- [ ] **Step 5: Re-run the focused dedup test**
+
+Run: `cargo test -p icm-mcp test_store_dedups_same_error_fingerprint -- --exact`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run narrow regression coverage**
+
+Run: `cargo test -p icm-mcp wake_up -- --nocapture`
+
+Expected: PASS with no regression in current wake-up tool behavior.
+
+### Task 5: Hook-driven auto-context enrichment for CLI store flows
+
+**Files:**
+- Modify: `crates/icm-cli/src/main.rs`
+- Modify: `crates/icm-cli/src/config.rs`
+
+- [ ] **Step 1: Write the failing helper test**
+
+Add a test for a helper that enriches a memory with inferred project/platform context.
+
+```rust
+#[test]
+fn test_build_auto_context_from_current_project() {
+    let ctx = build_auto_context(Some("cargo test -p icm-cli"), None);
+    assert_eq!(ctx.project.as_deref(), Some("icm"));
+    assert!(ctx.platform.is_some());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p icm-cli test_build_auto_context_from_current_project -- --exact`
+
+Expected: FAIL because helper does not exist yet.
+
+- [ ] **Step 3: Add the helper and CLI flags**
+
+Allow explicit override, but default to automatic project and platform detection.
+
+```rust
+fn build_auto_context(command: Option<&str>, file_path: Option<&str>) -> MemoryContext {
+    MemoryContext {
+        project: Some(detect_project()),
+        repo_root: std::env::current_dir().ok().map(|p| p.display().to_string()),
+        platform: Some(std::env::consts::OS.to_string()),
+        command: command.map(str::to_string),
+        file_path: file_path.map(str::to_string),
+        symbol: None,
+        error_fingerprint: None,
+        kind: MemoryKind::Note,
+    }
+}
+```
+
+- [ ] **Step 4: Use the helper in stable save flows**
+
+Wire it into flows such as `cmd_save_project`, `hook start`, and future targeted store commands.
+
+```rust
+memory.context = Some(build_auto_context(command.as_deref(), file_path.as_deref()));
+```
+
+- [ ] **Step 5: Re-run the focused CLI helper test**
+
+Run: `cargo test -p icm-cli test_build_auto_context_from_current_project -- --exact`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run a compile-level validation for the touched crate**
+
+Run: `cargo test -p icm-cli --no-run`
+
+Expected: PASS.
+
+## Final Verification
+
+- [ ] **Step 1: Run targeted crate tests**
+
+Run: `cargo test -p icm-store`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run MCP tests**
+
+Run: `cargo test -p icm-mcp`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run CLI tests / compile check**
+
+Run: `cargo test -p icm-cli --no-run`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run workspace formatting and linting if already standard in the repo**
+
+Run: `cargo fmt --check`
+
+Expected: PASS.
+
+Run: `cargo clippy --all-targets --all-features -- -D warnings`
+
+Expected: PASS or pre-existing warnings only.
+
+## Notes
+
+- Keep the new context payload optional so existing databases remain readable.
+- Do not block plain-text usage: topic/summary/keywords must still work when no context is supplied.
+- Keep wake-up compact; operational value matters more than completeness.
+- Do not move this work into memoirs yet. Make the common CLI/MCP memory path excellent first.

--- a/docs/superpowers/specs/2026-04-25-icm-agent-effectiveness-design.md
+++ b/docs/superpowers/specs/2026-04-25-icm-agent-effectiveness-design.md
@@ -1,0 +1,228 @@
+# ICM Agent Effectiveness Design
+
+## Goal
+
+Make ICM substantially more useful for coding agents by turning it from a generic long-term note store into an operational memory layer that is aware of repository, platform, command failures, resolved errors, and current project context.
+
+## Current State
+
+The repository already has the right primitives, but they are still loosely connected for coding-agent workflows:
+
+- `crates/icm-core/src/wake_up.rs` builds a compact session-start pack from stored memories.
+- `crates/icm-core/src/memory.rs` stores summary, topic, keywords, source, scope, and related IDs, but it lacks first-class operational metadata such as file path, command, platform, and error fingerprint.
+- `crates/icm-store/src/schema.rs` and `crates/icm-store/src/store.rs` provide SQLite + FTS storage and retrieval.
+- `crates/icm-mcp/src/tools.rs` exposes store/recall/wake-up tools and already contains a first dedup threshold.
+- `crates/icm-cli/src/main.rs` contains `store`, `recall`, `wake-up`, `init`, and hook entrypoints, but the hooks are still mostly generic.
+- `crates/icm-mcp/src/server.rs` nudges storing after many tool calls, but it does not yet distinguish between stable operational facts and ephemeral session noise.
+
+## Problem Statement
+
+For coding agents, the highest-value memories are not generic summaries. They are operational facts such as:
+
+- which command actually builds or tests the repo
+- which platform-specific quirk exists on the current machine
+- which failure signature was already resolved
+- which file or symbol owns the behavior
+- which decisions should always be injected at session start
+
+Without first-class support for those facts, recall quality is lower than it could be, wake-up packs are less actionable, and memory tends to become noisy.
+
+## Approaches
+
+### Approach A: Prompt-only discipline
+
+Keep the current schema and rely on agents to write better topics, keywords, and summaries.
+
+Pros:
+
+- no schema changes
+- lowest implementation cost
+
+Cons:
+
+- quality stays agent-dependent
+- weak matching for commands, errors, platform, and file ownership
+- wake-up remains mostly topic-driven instead of operationally driven
+
+### Approach B: Full graph-first operational memory
+
+Model all operational context as concepts and links in memoirs, then build recall on top of the graph layer.
+
+Pros:
+
+- richest long-term representation
+- strong future fit for visualization and architecture reasoning
+
+Cons:
+
+- too large for the next increment
+- overkill for common store/recall/wake-up flows
+- delays payoff on the CLI and MCP path
+
+### Approach C: Metadata-first operational memory on top of existing memory records
+
+Extend `Memory` and storage with a small `MemoryContext` payload for repo/platform/command/file/error metadata, then upgrade ranking, deduplication, and wake-up generation to use it.
+
+Pros:
+
+- immediate value for coding agents
+- fits current CLI, MCP, and hook surfaces
+- minimal conceptual change for users
+- supports a later graph-first expansion instead of blocking it
+
+Cons:
+
+- requires schema migration and retrieval/ranking updates
+- some matching will still be heuristic rather than fully semantic
+
+## Recommendation
+
+Use Approach C.
+
+It gives the biggest practical gain for the least architectural disruption. The existing repo already centers workflows around `Memory`, CLI commands, MCP tools, and wake-up packs. Adding a structured operational metadata layer there improves the highest-frequency paths immediately and leaves memoirs free for richer semantic knowledge later.
+
+## Proposed Design
+
+### 1. Add operational metadata to memory records
+
+Introduce a new optional `MemoryContext` structure on `Memory` with these fields:
+
+- `project`: normalized project or repo name
+- `repo_root`: canonical repo path when known
+- `platform`: OS name such as `windows`, `linux`, `macos`
+- `command`: command that reproduced, fixed, or verified something
+- `file_path`: primary file related to the memory
+- `symbol`: optional function/type/command name
+- `error_fingerprint`: compact normalized error signature
+- `kind`: enum-like string such as `decision`, `resolved_error`, `working_command`, `constraint`, `preference`, `progress`
+
+This keeps summaries readable while making recall more precise.
+
+### 2. Upgrade retrieval to favor operational matches
+
+Recall should score not only by topic, summary, embeddings, and weight, but also by contextual matches:
+
+- direct command match
+- direct error fingerprint match
+- project/repo match
+- platform match
+- file/symbol match
+- stable `kind` boost for `decision`, `resolved_error`, and `working_command`
+
+This should be additive, not a replacement for current search.
+
+### 3. Split stable vs ephemeral memory at capture time
+
+Not all memories should enter long-term recall equally.
+
+- Stable memories: decisions, resolved errors, environment facts, working commands, preferences.
+- Ephemeral memories: temporary status, transient progress, one-off experiments.
+
+Stable memories should be eligible for wake-up packs and stronger ranking. Ephemeral memories should still be storable, but lower-ranked by default and excluded from wake-up unless explicitly requested later.
+
+### 4. Make wake-up packs operational
+
+`wake_up` should produce a short startup pack optimized for coding work:
+
+- project facts
+- environment facts
+- working commands
+- known traps
+- recent resolved errors
+- durable decisions
+
+The pack should be intentionally short and explain why project-specific items matched.
+
+### 5. Improve deduplication and consolidation around operational keys
+
+Current deduplication is summary-similarity oriented. It should also merge or suppress near-duplicates that share the same:
+
+- `kind`
+- `project`
+- `platform`
+- `command`
+- `error_fingerprint`
+
+This reduces recall noise and improves wake-up quality.
+
+### 6. Expose the same model across CLI, MCP, and hooks
+
+The same memory shape and ranking rules should be available through:
+
+- CLI: `store`, `recall`, `wake-up`, hook entrypoints
+- MCP: `icm_memory_store`, `icm_memory_recall`, `icm_wake_up`
+- future web/API surfaces
+
+That avoids tool-specific behavior drift.
+
+## File Ownership
+
+- `crates/icm-core/src/memory.rs`
+  Add `MemoryContext`, context kind, and serialization support.
+
+- `crates/icm-core/src/wake_up.rs`
+  Re-rank and re-render the startup pack using operational categories.
+
+- `crates/icm-core/src/store.rs`
+  Extend trait surfaces only where operational retrieval needs new entrypoints.
+
+- `crates/icm-store/src/schema.rs`
+  Add persistent storage for the new context payload and any supporting indexes.
+
+- `crates/icm-store/src/store.rs`
+  Read/write the new metadata and implement context-aware ranking helpers.
+
+- `crates/icm-mcp/src/tools.rs`
+  Accept context-aware arguments and return higher-signal recall results.
+
+- `crates/icm-mcp/src/server.rs`
+  Keep store nudges, but nudge toward stable operational memories specifically.
+
+- `crates/icm-cli/src/main.rs`
+  Add CLI flags and hook-driven auto-context enrichment for store/recall/wake-up.
+
+- `crates/icm-cli/src/config.rs`
+  Add config knobs for operational ranking and wake-up sections.
+
+## Roadmap
+
+### Phase 1: Metadata foundation
+
+- add `MemoryContext`
+- persist it in SQLite
+- keep backward compatibility for old rows
+
+### Phase 2: Context-aware recall
+
+- parse optional context inputs in CLI and MCP
+- rank by project/platform/command/error/file/symbol
+- preserve current FTS and embedding behavior as fallback
+
+### Phase 3: Operational wake-up packs
+
+- render sections for commands, traps, errors, and decisions
+- exclude ephemeral memory kinds by default
+- show a compact match explanation when project filtering is active
+
+### Phase 4: Better dedup and auto-store quality
+
+- dedup by operational keys, not only summary similarity
+- add capture helpers for resolved errors and working commands
+- tighten prompts and server nudges around stable operational facts
+
+## Non-Goals For This Increment
+
+- replacing memories with a graph-only model
+- building the 3D memoir visualization
+- adding cloud-only agent memory features
+- broad UI redesign of the web dashboard
+
+## Success Criteria
+
+The design is successful when:
+
+- coding agents can recall the right build/test/fix command with less manual prompting
+- resolved errors on a specific platform are easier to find by exact failure shape
+- wake-up packs contain fewer generic summaries and more actionable project facts
+- duplicate operational memories collapse instead of spamming recall results
+- existing memory rows and existing tool consumers remain compatible


### PR DESCRIPTION
## Summary
- add operational memory context persistence, contextual recall ranking, wake-up categorization, and dedup support across core, store, MCP, and CLI
- align init, hook, installer, and integration docs with the new operational-memory workflow
- fix Windows debug startup stack overflow for icm-cli and add a regression test

## Test Plan
- cargo test -p icm-store
- cargo test -p icm-mcp --no-run
- cargo test -p icm-cli --test windows_debug_startup -- --nocapture
- cargo test -p icm-cli --no-run