### PR TITLE
fix(install): restore install.sh, add SHA256 verification to install.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,17 @@ ICM gives your AI agent a real memory — not a note-taking tool, not a context 
 # Homebrew (macOS / Linux)
 brew tap rtk-ai/tap && brew install icm
 
-# Quick install
+# Quick install (macOS / Linux) — verifies SHA256 against the release checksums
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+
+# Quick install (Windows PowerShell)
+irm https://raw.githubusercontent.com/rtk-ai/icm/main/install.ps1 | iex
 
 # From source
 cargo install --path crates/icm-cli
 ```
+
+Re-run the install command to upgrade to the latest release. To pin a version, pass `--version icm-vX.Y.Z` (sh: `sh -s -- --version …`).
 
 ## Setup
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -12,12 +12,17 @@ ICM gives your AI coding agent a persistent memory that survives across sessions
 # Homebrew
 brew tap rtk-ai/tap && brew install icm
 
-# Quick install
+# Quick install (macOS / Linux) — verifies SHA256 against the release checksums
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+
+# Quick install (Windows PowerShell)
+irm https://raw.githubusercontent.com/rtk-ai/icm/main/install.ps1 | iex
 
 # From source
 cargo install --path crates/icm-cli
 ```
+
+Re-running the install command upgrades an existing installation in place.
 
 ### 2. Setup
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,18 @@
-# icm installer for Windows - https://github.com/rtk-ai/icm
-# Usage: irm https://raw.githubusercontent.com/rtk-ai/icm/main/install.ps1 | iex
+# icm installer for Windows — https://github.com/rtk-ai/icm
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/rtk-ai/icm/main/install.ps1 | iex
+#
+# Re-run to upgrade. Pass arguments by downloading first:
+#   $script = irm https://raw.githubusercontent.com/rtk-ai/icm/main/install.ps1
+#   & ([ScriptBlock]::Create($script)) -Version "icm-v0.10.28"
+#
+# Every download is verified against the release's checksums.txt (SHA256).
+
+param(
+    [string]$Version = "",
+    [string]$InstallDir = ""
+)
 
 $ErrorActionPreference = "Stop"
 
@@ -19,31 +32,86 @@ function Get-LatestVersion {
     return $release.tag_name
 }
 
-$Arch = Get-Arch
-$Version = Get-LatestVersion
-$Target = "$Arch-pc-windows-msvc"
-$InstallDir = Join-Path $env:LOCALAPPDATA "icm\bin"
+function Get-CurrentVersion {
+    param([string]$BinaryPath)
+    if (Test-Path $BinaryPath) {
+        try {
+            $output = & $BinaryPath --version 2>$null
+            if ($output -match '\s+(\S+)$') {
+                return $Matches[1]
+            }
+        } catch { }
+    }
+    return $null
+}
 
-Write-Host "[INFO] Installing $BinaryName $Version ($Arch)..." -ForegroundColor Green
+# Parse "<sha256>  <filename>" lines from checksums.txt.
+function Get-ExpectedSha {
+    param([string]$ChecksumsPath, [string]$Filename)
+    foreach ($line in Get-Content $ChecksumsPath) {
+        $parts = $line.Trim() -split '\s+', 2
+        if ($parts.Length -eq 2 -and $parts[1] -eq $Filename) {
+            return $parts[0].ToLower()
+        }
+    }
+    throw "No checksum entry for $Filename in checksums.txt"
+}
+
+$Arch = Get-Arch
+if (-not $Version) {
+    Write-Host "[INFO] Fetching latest release..." -ForegroundColor Green
+    $Version = Get-LatestVersion
+}
+$Target = "$Arch-pc-windows-msvc"
+if (-not $InstallDir) {
+    $InstallDir = Join-Path $env:LOCALAPPDATA "icm\bin"
+}
+$BinaryPath = Join-Path $InstallDir "$BinaryName.exe"
+
+$PreviousVersion = Get-CurrentVersion -BinaryPath $BinaryPath
+if ($PreviousVersion) {
+    Write-Host "[INFO] Upgrading icm $PreviousVersion -> $Version ($Arch)" -ForegroundColor Green
+} else {
+    Write-Host "[INFO] Installing icm $Version ($Arch)" -ForegroundColor Green
+}
 
 # Create install directory
 New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
 
-# Download
-$Url = "https://github.com/$Repo/releases/download/$Version/$BinaryName-$Target.zip"
-$TempZip = Join-Path $env:TEMP "$BinaryName.zip"
-Write-Host "[INFO] Downloading from: $Url" -ForegroundColor Green
-Invoke-WebRequest -Uri $Url -OutFile $TempZip
+# Download binary archive
+$ArchiveName = "$BinaryName-$Target.zip"
+$BaseUrl = "https://github.com/$Repo/releases/download/$Version"
+$Url = "$BaseUrl/$ArchiveName"
+$TempZip = Join-Path $env:TEMP "$BinaryName-$([guid]::NewGuid()).zip"
+$TempChecksums = Join-Path $env:TEMP "icm-checksums-$([guid]::NewGuid()).txt"
+$TempDir = Join-Path $env:TEMP "$BinaryName-extract-$([guid]::NewGuid())"
 
-# Extract
-$TempDir = Join-Path $env:TEMP "$BinaryName-extract"
-if (Test-Path $TempDir) { Remove-Item -Recurse -Force $TempDir }
-Expand-Archive -Path $TempZip -DestinationPath $TempDir
-Copy-Item (Join-Path $TempDir "$BinaryName.exe") -Destination $InstallDir -Force
+try {
+    Write-Host "[INFO] Downloading $ArchiveName" -ForegroundColor Green
+    Invoke-WebRequest -Uri $Url -OutFile $TempZip -UseBasicParsing
 
-# Cleanup
-Remove-Item $TempZip -Force
-Remove-Item $TempDir -Recurse -Force
+    # SHA256 verification — mandatory, never skipped.
+    Write-Host "[INFO] Downloading checksums.txt" -ForegroundColor Green
+    Invoke-WebRequest -Uri "$BaseUrl/checksums.txt" -OutFile $TempChecksums -UseBasicParsing
+
+    $Expected = Get-ExpectedSha -ChecksumsPath $TempChecksums -Filename $ArchiveName
+    $Actual = (Get-FileHash -Path $TempZip -Algorithm SHA256).Hash.ToLower()
+    if ($Expected -ne $Actual) {
+        throw "SHA256 mismatch — refusing to install.`n  expected: $Expected`n  got:      $Actual`nThe download was tampered with or corrupted."
+    }
+    Write-Host "[INFO] SHA256 verified: $Actual" -ForegroundColor Green
+
+    # Extract
+    Write-Host "[INFO] Extracting" -ForegroundColor Green
+    if (Test-Path $TempDir) { Remove-Item -Recurse -Force $TempDir }
+    Expand-Archive -Path $TempZip -DestinationPath $TempDir
+    Copy-Item (Join-Path $TempDir "$BinaryName.exe") -Destination $InstallDir -Force
+} finally {
+    # Cleanup
+    if (Test-Path $TempZip) { Remove-Item $TempZip -Force }
+    if (Test-Path $TempChecksums) { Remove-Item $TempChecksums -Force }
+    if (Test-Path $TempDir) { Remove-Item -Recurse -Force $TempDir }
+}
 
 # Add to PATH if not already there
 $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
@@ -52,5 +120,14 @@ if ($UserPath -notlike "*$InstallDir*") {
     Write-Host "[INFO] Added $InstallDir to user PATH (restart terminal to apply)" -ForegroundColor Yellow
 }
 
-Write-Host "[INFO] Successfully installed to $InstallDir\$BinaryName.exe" -ForegroundColor Green
-Write-Host "[INFO] Run '$BinaryName --help' to get started." -ForegroundColor Green
+if ($PreviousVersion) {
+    Write-Host "[INFO] Upgrade complete: $PreviousVersion -> $Version" -ForegroundColor Green
+} else {
+    Write-Host "[INFO] Installation complete: $Version" -ForegroundColor Green
+}
+Write-Host ""
+Write-Host "  Next steps:" -ForegroundColor Green
+Write-Host "    1. icm init              # configure your AI tools (MCP)"
+Write-Host "    2. icm init --mode hook  # install Claude Code hooks"
+Write-Host "    3. Restart your AI tool to activate"
+Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,224 @@
+#!/bin/sh
+# icm installer — https://github.com/rtk-ai/icm
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh
+#
+# Re-run to upgrade. Pass flags via `sh -s --`:
+#   curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh -s -- --version icm-v0.10.28
+#   curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/main/install.sh | sh -s -- --dir /usr/local/bin
+#
+# Every download is verified against the release's checksums.txt (SHA256).
+
+set -eu
+
+REPO="rtk-ai/icm"
+BINARY_NAME="icm"
+INSTALL_DIR="${HOME}/.local/bin"
+VERSION=""
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info() { printf "${GREEN}[INFO]${NC} %s\n" "$1"; }
+warn() { printf "${YELLOW}[WARN]${NC} %s\n" "$1"; }
+error() { printf "${RED}[ERROR]${NC} %s\n" "$1" >&2; exit 1; }
+
+usage() {
+    cat <<EOF
+icm installer — installs or upgrades icm from GitHub releases.
+
+Usage: install.sh [--dir <path>] [--version <tag>] [--help]
+
+Options:
+  --dir <path>      Install directory (default: \$HOME/.local/bin)
+  --version <tag>   Release tag to install (default: latest, e.g. icm-v0.10.28)
+  -h, --help        Show this help
+
+Re-running this script upgrades an existing installation in place.
+Each download is verified against the release's checksums.txt (SHA256).
+EOF
+}
+
+parse_args() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --dir)
+                [ $# -ge 2 ] || error "--dir requires a path"
+                INSTALL_DIR="$2"
+                shift 2
+                ;;
+            --version)
+                [ $# -ge 2 ] || error "--version requires a tag"
+                VERSION="$2"
+                shift 2
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                error "Unknown argument: $1 (use --help)"
+                ;;
+        esac
+    done
+}
+
+detect_os() {
+    case "$(uname -s)" in
+        Darwin*) OS="darwin"; TARGET_SUFFIX="apple-darwin";;
+        Linux*)  OS="linux";  TARGET_SUFFIX="unknown-linux-gnu";;
+        MINGW*|MSYS*|CYGWIN*) OS="windows"; TARGET_SUFFIX="pc-windows-msvc";;
+        *)       error "Unsupported OS: $(uname -s). icm supports macOS, Linux and Windows.";;
+    esac
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64)  ARCH="x86_64";;
+        arm64|aarch64) ARCH="aarch64";;
+        *)             error "Unsupported architecture: $(uname -m)";;
+    esac
+}
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || error "$1 is required but not installed"
+}
+
+get_latest_version() {
+    if [ -n "$VERSION" ]; then
+        return
+    fi
+    VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+        | grep '"tag_name":' \
+        | head -1 \
+        | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+    [ -n "$VERSION" ] || error "Failed to determine latest release from GitHub API"
+}
+
+# Print currently installed version, or empty if not installed.
+current_version() {
+    if [ -x "${INSTALL_DIR}/${BINARY_NAME}" ]; then
+        "${INSTALL_DIR}/${BINARY_NAME}" --version 2>/dev/null | awk '{print $2}'
+    elif command -v "$BINARY_NAME" >/dev/null 2>&1; then
+        "$BINARY_NAME" --version 2>/dev/null | awk '{print $2}'
+    fi
+}
+
+verify_sha256() {
+    archive="$1"
+    expected="$2"
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$archive" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$archive" | awk '{print $1}')
+    else
+        error "Neither sha256sum nor shasum found — cannot verify integrity. Install one and retry."
+    fi
+    if [ "$expected" != "$actual" ]; then
+        error "SHA256 mismatch — refusing to install.
+  expected: ${expected}
+  got:      ${actual}
+The download was tampered with or corrupted."
+    fi
+    info "SHA256 verified: ${actual}"
+}
+
+install_binary() {
+    TARGET="${ARCH}-${TARGET_SUFFIX}"
+
+    if [ "$OS" = "windows" ]; then
+        EXT="zip"
+        : "${INSTALL_DIR:=${LOCALAPPDATA:-$HOME}/icm/bin}"
+    else
+        EXT="tar.gz"
+    fi
+
+    mkdir -p "$INSTALL_DIR" || error "Cannot create install directory: $INSTALL_DIR"
+
+    ARCHIVE_NAME="${BINARY_NAME}-${TARGET}.${EXT}"
+    BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+    TEMP_DIR=$(mktemp -d)
+    trap 'rm -rf "$TEMP_DIR"' EXIT
+
+    ARCHIVE="${TEMP_DIR}/${ARCHIVE_NAME}"
+    info "Downloading ${ARCHIVE_NAME}"
+    curl -fsSL "${BASE_URL}/${ARCHIVE_NAME}" -o "$ARCHIVE" \
+        || error "Failed to download ${BASE_URL}/${ARCHIVE_NAME}"
+
+    # SHA256 verification — mandatory, never skipped.
+    CHECKSUMS_FILE="${TEMP_DIR}/checksums.txt"
+    info "Downloading checksums.txt"
+    curl -fsSL "${BASE_URL}/checksums.txt" -o "$CHECKSUMS_FILE" \
+        || error "Failed to download checksums.txt (required for integrity verification)"
+
+    # checksums.txt format: "<sha256>  <filename>" (two spaces, sha256sum default).
+    EXPECTED_SHA=$(awk -v name="$ARCHIVE_NAME" '$2 == name {print $1; exit}' "$CHECKSUMS_FILE")
+    [ -n "$EXPECTED_SHA" ] || error "No checksum entry for ${ARCHIVE_NAME} in checksums.txt"
+    verify_sha256 "$ARCHIVE" "$EXPECTED_SHA"
+
+    info "Extracting"
+    if [ "$OS" = "windows" ]; then
+        require unzip
+        unzip -oq "$ARCHIVE" -d "$TEMP_DIR"
+        DEST="${INSTALL_DIR}/${BINARY_NAME}.exe"
+        mv -f "${TEMP_DIR}/${BINARY_NAME}.exe" "$DEST"
+    else
+        tar -xzf "$ARCHIVE" -C "$TEMP_DIR"
+        DEST="${INSTALL_DIR}/${BINARY_NAME}"
+        mv -f "${TEMP_DIR}/${BINARY_NAME}" "$DEST"
+        chmod +x "$DEST"
+    fi
+
+    info "Installed to ${DEST}"
+}
+
+print_path_warning() {
+    case ":${PATH:-}:" in
+        *":${INSTALL_DIR}:"*) ;;
+        *)
+            warn "${INSTALL_DIR} is not in your PATH. Add it with:"
+            printf '  export PATH="%s:$PATH"\n' "$INSTALL_DIR"
+            ;;
+    esac
+}
+
+main() {
+    parse_args "$@"
+    require curl
+    require uname
+
+    detect_os
+    detect_arch
+    info "Platform: ${OS} ${ARCH}"
+
+    PREVIOUS_VERSION=$(current_version || true)
+    get_latest_version
+    info "Target version: ${VERSION}"
+
+    if [ -n "$PREVIOUS_VERSION" ]; then
+        info "Upgrading icm (current: ${PREVIOUS_VERSION})"
+    else
+        info "Installing icm"
+    fi
+
+    install_binary
+
+    echo ""
+    if [ -n "$PREVIOUS_VERSION" ]; then
+        info "Upgrade complete: ${PREVIOUS_VERSION} → ${VERSION}"
+    else
+        info "Installation complete: ${VERSION}"
+    fi
+    echo ""
+    echo "  Next steps:"
+    echo "    1. icm init              # configure your AI tools (MCP)"
+    echo "    2. icm init --mode hook  # install Claude Code hooks"
+    echo "    3. Restart your AI tool to activate"
+    echo ""
+    print_path_warning
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Restore `install.sh` — the README's `curl ...install.sh | sh` one-liner has been 404ing since commit f18791c removed the file in favor of the `icm-install` Rust binary. Re-add it as a POSIX bootstrap so the documented quick-install works again.
- Add SHA256 verification to `install.ps1` — the Windows PowerShell installer never verified downloads against `checksums.txt`. Now it does, matching the existing `install.sh` and `icm-install` behavior.
- Document the Windows installer + upgrade-on-rerun in README and `docs/guide.md`.

Both scripts now: detect existing installs and report old → new version (so re-running = upgrade), support `--version` / `--dir` (PowerShell: `-Version` / `-InstallDir`) for parity with `icm-install`, and abort on SHA256 mismatch.

Tested end-to-end on Linux against the live `icm-v0.10.28` release: download, checksum verification (SHA `60f1bb…d143` matched), install, upgrade re-run, and `--version` pinning all work. PowerShell wasn't available locally so `install.ps1` is unverified at runtime — should be smoke-tested on Windows before relying on it.

## Test plan

- [ ] `curl -fsSL https://raw.githubusercontent.com/rtk-ai/icm/<branch>/install.sh | sh` installs latest icm
- [ ] Re-running the same command reports `Upgrading icm (current: X.Y.Z)` and `Upgrade complete: X.Y.Z → icm-vA.B.C`
- [ ] `sh -s -- --version icm-v0.10.27` installs the pinned version
- [ ] Tampering with the archive after download (or pointing at a wrong checksum) aborts with `SHA256 mismatch`
- [ ] On Windows: `irm .../install.ps1 | iex` installs, re-run upgrades, and SHA256 mismatch aborts

🤖 Generated with [Claude Code](https://claude.com/claude-code)