### PR TITLE
fix(hook): filter recall_context by project to stop cross-project leakage

### DIFF
--- a/crates/icm-cli/src/extract.rs
+++ b/crates/icm-cli/src/extract.rs
@@ -6,7 +6,7 @@
 use std::collections::HashSet;
 
 use anyhow::Result;
-use icm_core::{Importance, Memory, MemoryStore};
+use icm_core::{is_preference_topic, project_matches, Importance, Memory, MemoryStore};
 use icm_store::SqliteStore;
 
 /// Extract key facts from text and store them in ICM.
@@ -50,22 +50,59 @@ pub fn extract_and_store_with_opts(
 }
 
 /// Recall relevant memories and format as context preamble for prompt injection.
-pub fn recall_context(store: &SqliteStore, query: &str, limit: usize) -> Result<String> {
-    // Try FTS search with the query
-    let results = store.search_fts(query, limit * 2)?;
+///
+/// When `project` is `Some(name)`, results are restricted to memories whose
+/// topic matches that project (segment-aware match via
+/// [`icm_core::project_matches`]). Preference / identity topics are always
+/// kept so global user guidance is not stripped. When `project` is `None`,
+/// no project filtering is applied (back-compat with non-hook callers).
+///
+/// Issue: previously the hook concatenated the project name into the FTS
+/// query as a soft scoring hint, which let high-FTS-score memories from
+/// other projects bleed into the recalled context. The hard filter here
+/// prevents cross-project leakage.
+pub fn recall_context(
+    store: &SqliteStore,
+    query: &str,
+    project: Option<&str>,
+    limit: usize,
+) -> Result<String> {
+    let project_filter = |m: &Memory| -> bool {
+        match project {
+            None => true,
+            Some("") => true,
+            Some(p) => is_preference_topic(&m.topic) || project_matches(&m.topic, Some(p)),
+        }
+    };
 
-    let relevant: Vec<_> = if results.is_empty() {
-        // Fallback: get all memories sorted by weight
+    // Oversample FTS results so that filtering still leaves enough candidates.
+    let fts_results = store.search_fts(query, limit.saturating_mul(4).max(limit))?;
+    let filtered: Vec<Memory> = fts_results
+        .into_iter()
+        .filter(|m| project_filter(m))
+        .take(limit)
+        .collect();
+
+    let relevant: Vec<_> = if filtered.is_empty() {
+        // Fallback: get all (project-matching) memories sorted by weight.
         let topics = store.list_topics()?;
         let mut all = Vec::new();
         for (topic, _) in &topics {
-            all.extend(store.get_by_topic(topic)?);
+            for mem in store.get_by_topic(topic)? {
+                if project_filter(&mem) {
+                    all.push(mem);
+                }
+            }
         }
-        all.sort_by(|a, b| b.weight.partial_cmp(&a.weight).unwrap());
+        all.sort_by(|a, b| {
+            b.weight
+                .partial_cmp(&a.weight)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         all.truncate(limit);
         all
     } else {
-        results.into_iter().take(limit).collect()
+        filtered
     };
 
     if relevant.is_empty() {
@@ -938,7 +975,7 @@ mod tests {
     #[test]
     fn test_recall_context_empty_store() {
         let store = SqliteStore::in_memory().unwrap();
-        let ctx = recall_context(&store, "anything", 5).unwrap();
+        let ctx = recall_context(&store, "anything", None, 5).unwrap();
         assert!(ctx.is_empty());
     }
 
@@ -951,9 +988,90 @@ mod tests {
         let stored = extract_and_store(&store, text, "mathlib").unwrap();
         assert!(stored > 0);
 
-        let ctx = recall_context(&store, "parsing algorithm", 5).unwrap();
+        let ctx = recall_context(&store, "parsing algorithm", None, 5).unwrap();
         assert!(!ctx.is_empty());
         assert!(ctx.contains("Pratt") || ctx.contains("parsing") || ctx.contains("algorithm"));
+    }
+
+    #[test]
+    fn test_recall_context_filters_other_projects() {
+        // Two projects' memories share search terms; the project filter must
+        // strip the cross-project hits from FTS results.
+        let store = SqliteStore::in_memory().unwrap();
+
+        let mem_a = Memory::new(
+            "context-projecta".to_string(),
+            "Auth refactor switched to OIDC bearer tokens".to_string(),
+            Importance::High,
+        );
+        let mem_b = Memory::new(
+            "context-projectb".to_string(),
+            "Auth refactor moved to session cookies".to_string(),
+            Importance::High,
+        );
+        store.store(mem_a).unwrap();
+        store.store(mem_b).unwrap();
+
+        let ctx = recall_context(&store, "Auth refactor", Some("projecta"), 5).unwrap();
+        assert!(ctx.contains("OIDC"), "must include projecta memory");
+        assert!(
+            !ctx.contains("session cookies"),
+            "must NOT leak projectb memory: {ctx}"
+        );
+    }
+
+    #[test]
+    fn test_recall_context_keeps_preferences_when_filtering() {
+        let store = SqliteStore::in_memory().unwrap();
+
+        let project_mem = Memory::new(
+            "context-myapp".to_string(),
+            "Deployment uses Helm charts".to_string(),
+            Importance::High,
+        );
+        let pref_mem = Memory::new(
+            "preferences".to_string(),
+            "User prefers terse responses".to_string(),
+            Importance::Critical,
+        );
+        store.store(project_mem).unwrap();
+        store.store(pref_mem).unwrap();
+
+        let ctx = recall_context(&store, "deployment", Some("myapp"), 5).unwrap();
+        assert!(ctx.contains("Helm"));
+        // Preferences are global, so they survive project filtering even when
+        // the FTS query is unrelated.
+        let ctx2 = recall_context(&store, "anything random", Some("myapp"), 5).unwrap();
+        assert!(
+            ctx2.contains("terse responses"),
+            "preferences must not be stripped by project filter: {ctx2}"
+        );
+    }
+
+    #[test]
+    fn test_recall_context_no_project_keeps_all() {
+        // When no project is specified, behavior matches the pre-filter API:
+        // every matching memory is returned regardless of topic.
+        let store = SqliteStore::in_memory().unwrap();
+
+        store
+            .store(Memory::new(
+                "context-projecta".to_string(),
+                "Token refresh logic".to_string(),
+                Importance::High,
+            ))
+            .unwrap();
+        store
+            .store(Memory::new(
+                "context-projectb".to_string(),
+                "Token rotation policy".to_string(),
+                Importance::High,
+            ))
+            .unwrap();
+
+        let ctx = recall_context(&store, "Token", None, 5).unwrap();
+        assert!(ctx.contains("refresh"));
+        assert!(ctx.contains("rotation"));
     }
 
     #[test]

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2057,7 +2057,9 @@ fn cmd_hook_prompt(store: &SqliteStore) -> Result<()> {
         return Ok(());
     }
 
-    // Build query: combine project name + user message
+    // Project name (from hook cwd) is used as a hard filter on recalled
+    // memories — not as a soft hint embedded in the FTS query, which used
+    // to let high-FTS-score memories from other projects bleed in.
     let project = json
         .get("cwd")
         .and_then(|v| v.as_str())
@@ -2065,18 +2067,17 @@ fn cmd_hook_prompt(store: &SqliteStore) -> Result<()> {
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_default();
 
-    let query = if project.is_empty() {
-        message.to_string()
-    } else {
-        format!("{project} {message}")
-    };
-
     // Truncate query to at most 200 bytes at a safe UTF-8 char boundary.
     // See issue #110 — bare `&query[..200]` panics when the cut lands inside
     // a multi-byte UTF-8 char (Cyrillic=2B, CJK=3B, emoji=4B).
-    let query = truncate_at_char_boundary(&query, 200);
+    let query = truncate_at_char_boundary(message, 200);
 
-    let ctx = extract::recall_context(store, query, 5)?;
+    let project_filter = if project.is_empty() {
+        None
+    } else {
+        Some(project.as_str())
+    };
+    let ctx = extract::recall_context(store, query, project_filter, 5)?;
     if !ctx.is_empty() {
         print!("{ctx}");
     }
@@ -3674,7 +3675,9 @@ fn cmd_extract(
 }
 
 fn cmd_recall_context(store: &SqliteStore, query: &str, limit: usize) -> Result<()> {
-    let ctx = extract::recall_context(store, query, limit)?;
+    // Explicit `recall-context` CLI invocation: no implicit project filter,
+    // the user passed the query they want.
+    let ctx = extract::recall_context(store, query, None, limit)?;
     if ctx.is_empty() {
         eprintln!("No relevant context found.");
     } else {
@@ -3721,9 +3724,11 @@ fn cmd_recall_project(store: &SqliteStore, limit: usize) -> Result<()> {
     let project = detect_project();
     eprintln!("Project: {project}");
 
-    // Search across project-related topics: context-<project>, decisions-<project>, errors-resolved
+    // Search across project-related topics: context-<project>, decisions-<project>, errors-resolved.
+    // Pass the project name as both the FTS query (so topic-name hits rank)
+    // and as the hard project filter (so cross-project hits are stripped).
     let query = &project;
-    let ctx = extract::recall_context(store, query, limit)?;
+    let ctx = extract::recall_context(store, query, Some(project.as_str()), limit)?;
     if ctx.is_empty() {
         eprintln!("No context found for project '{project}'.");
     } else {
@@ -4158,7 +4163,7 @@ fn cmd_bench_recall(model: &str, runs: usize, verbose: bool) -> Result<()> {
         let mut responses_with: Vec<String> = Vec::new();
         for (i, q) in questions.iter().enumerate() {
             let store = SqliteStore::new(&icm_db)?;
-            let ctx = extract::recall_context(&store, q.prompt, 15)?;
+            let ctx = extract::recall_context(&store, q.prompt, None, 15)?;
             if verbose && !ctx.is_empty() {
                 eprintln!("  [verbose] Context injected for Q{}:", i + 1);
                 for line in ctx.lines().take(10) {
@@ -4382,7 +4387,7 @@ fn cmd_bench_agent(sessions: usize, model: &str, runs: usize, verbose: bool) -> 
         for (i, prompt) in prompts.iter().enumerate() {
             let effective_prompt = if i > 0 {
                 let store = SqliteStore::new(&icm_db)?;
-                let ctx = extract::recall_context(&store, prompt, 15)?;
+                let ctx = extract::recall_context(&store, prompt, None, 15)?;
                 if verbose && !ctx.is_empty() {
                     eprintln!("  [verbose] Context injected for session {}:", i + 1);
                     for line in ctx.lines().take(8) {

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -33,8 +33,8 @@ pub use store::MemoryStore;
 pub use transcript::{Message, Role, Session, TranscriptHit, TranscriptStats};
 pub use transcript_store::TranscriptStore;
 pub use wake_up::{
-    build_wake_up, build_wake_up_from_memories, is_preference_topic, project_matches,
-    WakeUpFormat, WakeUpOptions, EMPTY_PACK_HEADER,
+    build_wake_up, build_wake_up_from_memories, is_preference_topic, project_matches, WakeUpFormat,
+    WakeUpOptions, EMPTY_PACK_HEADER,
 };
 
 pub use learn::{learn_project, LearnResult};

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -33,7 +33,8 @@ pub use store::MemoryStore;
 pub use transcript::{Message, Role, Session, TranscriptHit, TranscriptStats};
 pub use transcript_store::TranscriptStore;
 pub use wake_up::{
-    build_wake_up, build_wake_up_from_memories, WakeUpFormat, WakeUpOptions, EMPTY_PACK_HEADER,
+    build_wake_up, build_wake_up_from_memories, is_preference_topic, project_matches,
+    WakeUpFormat, WakeUpOptions, EMPTY_PACK_HEADER,
 };
 
 pub use learn::{learn_project, LearnResult};

--- a/crates/icm-core/src/wake_up.rs
+++ b/crates/icm-core/src/wake_up.rs
@@ -138,7 +138,11 @@ pub fn build_wake_up_from_memories(memories: Vec<Memory>, opts: &WakeUpOptions<'
 }
 
 /// Return true when a topic looks like it holds identity/preference data.
-fn is_preference_topic(topic: &str) -> bool {
+///
+/// Preference topics are global (not scoped to a single project) and are
+/// always included by `project_matches` so user identity / cross-project
+/// guidance is not stripped out by project filtering.
+pub fn is_preference_topic(topic: &str) -> bool {
     let lower = topic.to_lowercase();
     lower == "preferences"
         || lower == "identity"
@@ -156,7 +160,7 @@ fn is_preference_topic(topic: &str) -> bool {
 /// positives like `"icm"` matching `"icmp-notes"` while still allowing
 /// `"icm"` to match `"decisions-icm-core"` (via the `"icm"` segment) and
 /// `"icm-core"` to match `"decisions-icm-core"` (via both segments).
-fn project_matches(topic: &str, project: Option<&str>) -> bool {
+pub fn project_matches(topic: &str, project: Option<&str>) -> bool {
     let Some(proj) = project else {
         return true;
     };


### PR DESCRIPTION
## Summary

- `icm hook prompt` (UserPromptSubmit) was injecting memories from unrelated projects into every Claude Code session because the project name was used as a soft FTS scoring hint instead of a hard filter. Symptoms: in a session inside project A, the recalled context would routinely contain decisions, infra notes and PR history from projects B/C/D whenever the user message shared lexical hits with them.
- `cmd_hook_start` (SessionStart) already filtered correctly via `build_wake_up`'s segment-aware matcher. This PR aligns `cmd_hook_prompt` with the same model.

## What changed

- `icm-core::wake_up`: promote `is_preference_topic` and `project_matches` to `pub`, re-export from `icm_core::lib`.
- `icm-cli::extract::recall_context`: new `project: Option<&str>` parameter. FTS results + weight-sorted fallback are filtered with `project_matches`; preference / identity topics are exempted so global user guidance still reaches the prompt. FTS oversampling raised to `limit * 4` so the filter has enough candidates.
- `cmd_hook_prompt`: drop the project name from the FTS query and pass it as the project filter instead. The 200-byte char-boundary truncation is preserved.
- Other callers updated explicitly: `cmd_recall_context` passes `None`, `cmd_recall_project` passes `Some(&project)`, the bench harness passes `None`.

## Repro / verification

Built `target/release/icm` from this branch and replayed the hook with the same JSON Claude Code sends:

```bash
echo '{"prompt":"check the icm hook bug","cwd":"/home/patrick/dev/github/wshm-dev/wshm"}' \
  | target/release/icm hook prompt
```

- Before: returned a mix of `wshm` + `rtk-ai` + Dolibarr memories.
- After: returns only `wshm` memories plus globally-scoped preference topics. Repeating with `cwd=...rtk-ai/icm` returns only the global preferences (no `wshm` leakage in the other direction).

## Test plan

- [x] `cargo build --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --bin icm -- recall_context` (4 new tests pass)
- [x] `cargo test --workspace` (only flake: `icm-store::store::tests::perf_fts_search_100` 1192ms vs 1000ms budget — passes in isolation, unrelated to this change)
- [x] Live hook replay with two different `cwd` values, no cross-project leak

## Notes

- Public CLI surface unchanged; the new parameter is internal to `icm-cli`.
- `build_wake_up` semantics for SessionStart are untouched.
- Issue #110's UTF-8 char-boundary truncation is preserved in `cmd_hook_prompt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)