### PR TITLE
feat(hook): SessionEnd handler so /exit and /clear flush memories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.28"
+version = "0.10.29"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -448,6 +448,8 @@ enum HookCommands {
         #[arg(long, default_value = "0")]
         max_tokens: usize,
     },
+    /// SessionEnd hook: extract memories from transcript before the session closes
+    End,
 }
 
 #[derive(Subcommand)]
@@ -1225,6 +1227,7 @@ fn main() -> Result<()> {
                 };
                 cmd_hook_start(&store, tokens)
             }
+            HookCommands::End => cmd_hook_end(&store),
         },
         #[cfg(feature = "tui")]
         Commands::Dashboard => {
@@ -1912,9 +1915,28 @@ fn cmd_hook_post(store: &SqliteStore, extract_every: usize, store_raw: bool) -> 
 }
 
 /// PreCompact hook (Layer 1): extract memories from transcript before context compression.
+fn cmd_hook_compact(store: &SqliteStore) -> Result<()> {
+    extract_from_hook_transcript(store, "pre-compact")
+}
+
+/// SessionEnd hook (Layer 1b): extract memories from transcript before the
+/// session terminates. Catches the `/exit`, `/clear`, and tool-quit paths
+/// that PreCompact misses (compaction does not fire on `/clear`).
+///
+/// Same transcript-parsing logic as PreCompact — the only difference is the
+/// log prefix. SqliteStore handles its own dedup so a session that triggers
+/// both PreCompact and SessionEnd back-to-back will not double-store facts.
+fn cmd_hook_end(store: &SqliteStore) -> Result<()> {
+    extract_from_hook_transcript(store, "session-end")
+}
+
+/// Read JSON from stdin, locate the transcript file, parse the last 100
+/// assistant messages, and extract facts. Used by both PreCompact and
+/// SessionEnd hooks. `source` is purely a log-prefix tag.
+///
 /// Reads JSON from stdin with `transcript_path`, reads the JSONL transcript,
 /// and extracts facts from assistant messages.
-fn cmd_hook_compact(store: &SqliteStore) -> Result<()> {
+fn extract_from_hook_transcript(store: &SqliteStore, source: &str) -> Result<()> {
     use std::io::Read;
     let mut input = String::new();
     std::io::stdin().read_to_string(&mut input)?;
@@ -2005,7 +2027,7 @@ fn cmd_hook_compact(store: &SqliteStore) -> Result<()> {
         .unwrap_or_else(|| "project".to_string());
 
     match extract::extract_and_store_with_opts(store, text, &project, true) {
-        Ok(n) if n > 0 => eprintln!("[icm] pre-compact: extracted {n} facts from transcript"),
+        Ok(n) if n > 0 => eprintln!("[icm] {source}: extracted {n} facts from transcript"),
         _ => {}
     }
 
@@ -2626,6 +2648,19 @@ Do this BEFORE responding to the user. Not optional.
             force,
         )?;
         println!("[hook] Claude Code SessionStart (wake-up pack): {start_status}");
+
+        // SessionEnd hook: `icm hook end` (extract from transcript before /exit, /clear, etc.)
+        // Catches the path PreCompact misses — compaction does not fire on /clear.
+        let end_cmd = format!("{} hook end", icm_bin_str);
+        let end_status = inject_settings_hook(
+            &claude_settings_path,
+            "SessionEnd",
+            &end_cmd,
+            None,
+            &["icm hook end", "icm hook", "icm-post-tool"],
+            force,
+        )?;
+        println!("[hook] Claude Code SessionEnd (transcript extract): {end_status}");
 
         // OpenCode plugin: install TS plugin using native @opencode-ai/plugin SDK
         let opencode_plugins_dir = PathBuf::from(&home).join(".config/opencode/plugins");


### PR DESCRIPTION
## Summary

- Adds `icm hook end` subcommand that extracts facts from the transcript when the AI tool fires its session-end event.
- Wires `SessionEnd` automatically in `icm init --mode hook` for Claude Code.
- Refactors the transcript-parsing core out of `cmd_hook_compact` into a shared `extract_from_hook_transcript(store, source)` helper used by both `Compact` and `End`.

## Why

Claude Code emits **`SessionEnd`** on `/exit`, `/clear`, and tool quit — paths that `PreCompact` never covers (compaction does not run on `/clear`). Without this hook, sessions that ended without an automatic compaction silently lost everything since the last `PostToolUse` extraction. In practice this hit users who finish a session with `/exit` or `/clear` instead of letting the context fill up to the compact threshold.

## Behaviour

- Same parse logic as PreCompact: read `transcript_path` from stdin JSON, walk the last 100 JSONL lines, gather assistant text, truncate to last 4000 chars, run `extract_and_store_with_opts(.., store_raw=true)`.
- If `SessionEnd` fires immediately after a `PreCompact` (e.g. `/compact` then `/clear`), facts are deduped at the `SqliteStore` layer — no double-store risk.
- Log prefix differs for ops visibility: `[icm] pre-compact: extracted N facts` vs `[icm] session-end: extracted N facts`.

## Other AI tools — scope of this PR

| Tool | Status |
|------|--------|
| Claude Code | Wired (`SessionEnd`) |
| Codex CLI | Not wired — Codex does emit `SessionEnd` but I prefer validating on a real install before injecting into `~/.codex/hooks.json`. |
| Gemini CLI | Not wired — no documented session-end event yet (events: `SessionStart`, `BeforeTool`, `AfterTool`, `PreCompress`, `BeforeAgent`). |
| OpenCode plugin | Not wired — SDK has `session.created` but no `session.removed`/end equivalent at the time of writing. |
| Copilot CLI | Not wired — same reason as Gemini. |

These are best treated as a follow-up once each tool's session-end event surface is confirmed.

## Test plan

- [x] `cargo check -p icm-cli` passes
- [x] `cargo test -p icm-cli` — 65/65 pass (no regressions, dispatch refactor verified by existing tests)
- [x] Smoke test with a fake transcript: `icm hook end` extracted 1 fact and logged `[icm] session-end: extracted 1 facts from transcript`
- [x] `icm init --mode hook` writes a `SessionEnd` entry to `~/.claude/settings.json` alongside the existing 5 hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)