### PR TITLE
fix: audit batch 1 — security, panics, and cross-platform paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.30"
+version = "0.10.31"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/icm-cli/src/cloud.rs
+++ b/crates/icm-cli/src/cloud.rs
@@ -41,15 +41,15 @@ pub fn load_credentials() -> Option<Credentials> {
     //    rtk-pro uses dirs::config_dir() which is:
     //    - macOS: ~/Library/Application Support/rtk/
     //    - Linux: ~/.config/rtk/
+    // Resolve home cross-platform — Windows uses %USERPROFILE%, not $HOME.
+    let home = directories::UserDirs::new().map(|d| d.home_dir().to_path_buf());
     let rtk_paths = [
         // macOS: ~/Library/Application Support/rtk/credentials.json
-        std::env::var("HOME")
-            .ok()
-            .map(|h| PathBuf::from(&h).join("Library/Application Support/rtk/credentials.json")),
+        home.as_ref()
+            .map(|h| h.join("Library/Application Support/rtk/credentials.json")),
         // Linux: ~/.config/rtk/credentials.json
-        std::env::var("HOME")
-            .ok()
-            .map(|h| PathBuf::from(&h).join(".config/rtk/credentials.json")),
+        home.as_ref()
+            .map(|h| h.join(".config/rtk/credentials.json")),
     ];
     for path in rtk_paths.into_iter().flatten() {
         if let Some(creds) = load_credentials_from_path(path) {

--- a/crates/icm-cli/src/import.rs
+++ b/crates/icm-cli/src/import.rs
@@ -173,7 +173,8 @@ pub fn parse_chatgpt(content: &str) -> Result<(Vec<Exchange>, String)> {
                 Some((ct, msg))
             })
             .collect();
-        nodes.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        // Guard against NaN create_time (would otherwise panic the import).
+        nodes.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
 
         for (_, msg) in &nodes {
             let role_str = msg

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1396,7 +1396,13 @@ fn cmd_list(store: &SqliteStore, topic: Option<&str>, all: bool, sort: SortField
     };
 
     match sort {
-        SortField::Weight => memories.sort_by(|a, b| b.weight.partial_cmp(&a.weight).unwrap()),
+        SortField::Weight => memories.sort_by(|a, b| {
+            // NaN should never appear in stored weights, but guard anyway —
+            // a single NaN would otherwise panic the whole `icm list` flow.
+            b.weight
+                .partial_cmp(&a.weight)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        }),
         SortField::Created => memories.sort_by_key(|b| std::cmp::Reverse(b.created_at)),
         SortField::Accessed => memories.sort_by_key(|b| std::cmp::Reverse(b.last_accessed)),
     }
@@ -2309,7 +2315,7 @@ fn cmd_extract_patterns(
 fn cmd_init(mode: InitMode, force: bool) -> Result<()> {
     let icm_bin = std::env::current_exe().context("cannot determine icm binary path")?;
     let icm_bin_str = icm_bin.to_string_lossy().to_string();
-    let home = std::env::var("HOME").context("HOME not set")?;
+    let home = home_dir_str()?;
 
     // Per-CLI config directories, with env var overrides honored.
     // Each tool documents its own override; we mirror that.
@@ -2826,7 +2832,7 @@ fn inject_icm_block(path: &Path, block: &str) -> Result<String> {
 }
 
 fn cmd_doctor() -> Result<()> {
-    let home = std::env::var("HOME").context("HOME not set")?;
+    let home = home_dir_str()?;
     let current_bin = std::env::current_exe().ok();
 
     let targets: Vec<(&str, PathBuf, &[&str])> = vec![
@@ -3210,6 +3216,28 @@ fn binary_in_path(name: &str) -> bool {
 /// used for tools without a CLI binary (e.g. Claude Desktop, VS Code extensions).
 /// Note: directory checks can yield false positives if a previous `icm init --force`
 /// already created the config path — use `--force` to bypass detection entirely.
+/// Resolve the user's home directory in a cross-platform way.
+///
+/// Unix uses `$HOME`, Windows uses `%USERPROFILE%`. We delegate to the
+/// `directories` crate so a single call site works everywhere instead of
+/// the previous Unix-only `env::var("HOME")` which silently broke `icm
+/// init` and `icm doctor` on Windows.
+pub(crate) fn home_dir_str() -> Result<String> {
+    if let Some(dirs) = directories::UserDirs::new() {
+        return Ok(dirs.home_dir().to_string_lossy().to_string());
+    }
+    // Fallback path: respect explicit env vars if `directories` failed to
+    // resolve (very unusual — typically only happens in stripped-down
+    // sandboxes without standard env vars).
+    if let Ok(h) = std::env::var("HOME") {
+        return Ok(h);
+    }
+    if let Ok(h) = std::env::var("USERPROFILE") {
+        return Ok(h);
+    }
+    bail!("cannot determine user home directory (HOME / USERPROFILE not set)")
+}
+
 /// Resolve the config directory for a CLI tool, respecting an env var override.
 /// Falls back to `$HOME/{default_subdir}` if the env var is unset or empty.
 /// Mirrors how each tool documents its own override (CLAUDE_CONFIG_DIR,

--- a/crates/icm-cli/src/web.rs
+++ b/crates/icm-cli/src/web.rs
@@ -96,7 +96,20 @@ pub fn resolve_password(cfg: &WebConfig) -> Result<String> {
         }
     }
 
-    eprintln!("[icm web] Generated admin password: {generated}");
+    // Don't print the password to stderr — it would land in CI logs, shell
+    // history, and `script(1)` recordings. Point the user at the 0600 file
+    // instead. If credentials_path() failed (no project dir), surface a
+    // single fallback line so the user still knows where to retrieve it.
+    match cred_path {
+        Some(path) => eprintln!(
+            "[icm web] Generated admin password (saved to {}). Run `cat {}` to read it.",
+            path.display(),
+            path.display()
+        ),
+        None => eprintln!(
+            "[icm web] Generated admin password — set ICM_WEB_PASSWORD or [web] password in config to control it."
+        ),
+    }
     Ok(generated)
 }
 

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -2,9 +2,10 @@ use chrono::Utc;
 use serde_json::{json, Value};
 
 use icm_core::{
-    add_backrefs, auto_link_memory, build_wake_up, keyword_matches, topic_matches, AutoLinkOptions,
-    Concept, ConceptLink, Embedder, Feedback, FeedbackStore, Label, Memoir, MemoirStore, Memory,
-    MemoryStore, Relation, WakeUpFormat, WakeUpOptions, MSG_NO_MEMORIES,
+    add_backrefs, auto_link_memory, build_wake_up, is_preference_topic, keyword_matches,
+    project_matches, topic_matches, AutoLinkOptions, Concept, ConceptLink, Embedder, Feedback,
+    FeedbackStore, Label, Memoir, MemoirStore, Memory, MemoryStore, Relation, WakeUpFormat,
+    WakeUpOptions, MSG_NO_MEMORIES,
 };
 use icm_store::SqliteStore;
 
@@ -111,6 +112,10 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                     "keyword": {
                         "type": "string",
                         "description": "Filter results by keyword (exact match on memory keywords)"
+                    },
+                    "project": {
+                        "type": "string",
+                        "description": "Project filter (segment-aware). Defaults to the server's cwd directory name. Pass an empty string to disable the filter and search across all projects."
                     }
                 },
                 "required": ["query"]
@@ -1133,11 +1138,33 @@ fn tool_recall(
     let topic = get_str(args, "topic");
     let keyword = get_str(args, "keyword");
 
+    // Project filter: same hard segment-aware filter applied to the CLI
+    // `recall_context` path (extract.rs) so MCP-side recall can't leak
+    // memories from other projects. Caller can override via the explicit
+    // `project` arg (empty string disables the filter); otherwise we
+    // derive it from the server's cwd.
+    let project_arg = get_str(args, "project");
+    let cwd_project = std::env::current_dir()
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()));
+    let project: Option<String> = match project_arg {
+        Some("") => None,
+        Some(p) => Some(p.to_string()),
+        None => cwd_project,
+    };
+    let project_filter = |m: &Memory| -> bool {
+        match project.as_deref() {
+            None => true,
+            Some(p) => is_preference_topic(&m.topic) || project_matches(&m.topic, Some(p)),
+        }
+    };
+
     // Try hybrid search if embedder is available
     if let Some(emb) = embedder {
         if let Ok(query_emb) = emb.embed(query) {
             if let Ok(results) = store.search_hybrid(query, &query_emb, limit) {
                 let mut scored_results = results;
+                scored_results.retain(|(m, _)| project_filter(m));
                 if let Some(t) = topic {
                     scored_results.retain(|(m, _)| topic_matches(&m.topic, t));
                 }
@@ -1181,6 +1208,7 @@ fn tool_recall(
         };
     }
 
+    results.retain(|m| project_filter(m));
     if let Some(t) = topic {
         results.retain(|m| topic_matches(&m.topic, t));
     }
@@ -2372,7 +2400,7 @@ mod tests {
             &store,
             None,
             "icm_memory_recall",
-            &json!({"query": "Rust SQLite"}),
+            &json!({"query": "Rust SQLite", "project": ""}),
             false,
         );
         assert!(!recall_result.is_error);
@@ -2407,7 +2435,7 @@ mod tests {
             &store,
             None,
             "icm_memory_recall",
-            &json!({"query": "Rust memory"}),
+            &json!({"query": "Rust memory", "project": ""}),
             true,
         );
         assert!(!result.is_error);
@@ -2519,7 +2547,7 @@ mod tests {
             &store,
             None,
             "icm_memory_recall",
-            &json!({"query": "script alert"}),
+            &json!({"query": "script alert", "project": ""}),
             false,
         );
         assert!(recall.content[0].text.contains("<script>"));
@@ -2603,11 +2631,13 @@ mod tests {
                 false,
             );
         }
+        // `project: ""` disables the cwd-based project filter so the test
+        // is deterministic regardless of where `cargo test` runs from.
         let result = call_tool(
             &store,
             None,
             "icm_memory_recall",
-            &json!({"query": "data", "topic": "beta"}),
+            &json!({"query": "data", "topic": "beta", "project": ""}),
             false,
         );
         assert!(!result.is_error);
@@ -2776,7 +2806,7 @@ mod tests {
             &store,
             None,
             "icm_memory_recall",
-            &json!({"query": "legit"}),
+            &json!({"query": "legit", "project": ""}),
             false,
         );
         assert!(!recall.is_error);
@@ -3368,7 +3398,7 @@ description = "A test project"
             &store,
             None,
             "icm_memory_recall",
-            &json!({"query": "SQLite FTS5 indexing", "limit": 5}),
+            &json!({"query": "SQLite FTS5 indexing", "limit": 5, "project": ""}),
             false,
         );
         assert!(
@@ -3381,6 +3411,110 @@ description = "A test project"
         assert!(
             text.contains("BM25 ranking"),
             "graph-expanded neighbor should appear: {text}"
+        );
+    }
+
+    #[test]
+    fn test_recall_filters_by_project_via_arg() {
+        // Two memories in distinct project topics. Recall with `project`
+        // arg pointing at one project must NOT surface the other's memory.
+        let store = test_store();
+        let a = Memory::new(
+            "context-projecta".into(),
+            "Project A: chose Postgres for transactional store".into(),
+            icm_core::Importance::High,
+        );
+        let b = Memory::new(
+            "context-projectb".into(),
+            "Project B: chose Mongo for document store".into(),
+            icm_core::Importance::High,
+        );
+        store.store(a).unwrap();
+        store.store(b).unwrap();
+
+        let res = call_tool(
+            &store,
+            None,
+            "icm_memory_recall",
+            &json!({"query": "store", "project": "projecta", "limit": 10}),
+            false,
+        );
+        assert!(!res.is_error);
+        let text = &res.content[0].text;
+        assert!(
+            text.contains("Postgres"),
+            "expected projecta memory to surface: {text}"
+        );
+        assert!(
+            !text.contains("Mongo"),
+            "projectb memory leaked through filter: {text}"
+        );
+    }
+
+    #[test]
+    fn test_recall_empty_project_arg_disables_filter() {
+        // Pass `project=""` to explicitly opt out of segment-aware filtering
+        // and search across all projects.
+        let store = test_store();
+        let a = Memory::new(
+            "context-alpha".into(),
+            "Alpha decision: rust workspace layout".into(),
+            icm_core::Importance::Medium,
+        );
+        let b = Memory::new(
+            "context-bravo".into(),
+            "Bravo decision: rust workspace layout".into(),
+            icm_core::Importance::Medium,
+        );
+        store.store(a).unwrap();
+        store.store(b).unwrap();
+
+        let res = call_tool(
+            &store,
+            None,
+            "icm_memory_recall",
+            &json!({"query": "rust workspace", "project": "", "limit": 10}),
+            false,
+        );
+        assert!(!res.is_error);
+        let text = &res.content[0].text;
+        assert!(text.contains("Alpha"), "Alpha missing: {text}");
+        assert!(text.contains("Bravo"), "Bravo missing: {text}");
+    }
+
+    #[test]
+    fn test_recall_preferences_bypass_project_filter() {
+        // Preferences are user-wide and must surface regardless of project.
+        let store = test_store();
+        let pref = Memory::new(
+            "preferences".into(),
+            "User prefers tabs over spaces in JS".into(),
+            icm_core::Importance::Critical,
+        );
+        let other = Memory::new(
+            "context-otherproject".into(),
+            "Project X: tabs over spaces in JS".into(),
+            icm_core::Importance::Medium,
+        );
+        store.store(pref).unwrap();
+        store.store(other).unwrap();
+
+        let res = call_tool(
+            &store,
+            None,
+            "icm_memory_recall",
+            &json!({"query": "tabs spaces", "project": "myproject", "limit": 10}),
+            false,
+        );
+        assert!(!res.is_error);
+        let text = &res.content[0].text;
+        assert!(
+            text.contains("User prefers"),
+            "preference memory should leak through project filter: {text}"
+        );
+        assert!(
+            !text.contains("Project X"),
+            "non-preference memory from a different project leaked: {text}"
         );
     }
 


### PR DESCRIPTION
## Summary

Cherry-picks the lowest-risk, highest-value items from the post-release audit pass.

### 🔴 Cross-project leakage via MCP (regression)
`icm_memory_recall` MCP tool was missing the segment-aware project filter that PR #130 added to the CLI's `recall_context`. Memories from project A surfaced in project B sessions whenever the agent called `mcp__icm__icm_memory_recall`.
- Apply the same `is_preference_topic || project_matches` filter used in `crates/icm-cli/src/extract.rs:74`.
- Add an explicit optional `project` arg: defaults to cwd-derived project, `""` opts out, explicit value overrides.
- 3 new tests for the filter / opt-out / preference bypass; 5 existing tests updated to pass `project: ""` so they're cwd-independent.

### 🔴 Password leak in `icm web`
`web.rs:99` printed the auto-generated admin password verbatim to stderr — would land in CI logs, shell history, and `script(1)` recordings. The credentials file is already written with mode 0600; the eprintln now points the user at the file instead of leaking the secret.

### 🔴 Panic-on-NaN guards
- `main.rs` `icm list --sort weight`: `partial_cmp().unwrap()` → `unwrap_or(Equal)` (a single NaN weight aborted the whole listing).
- Same fix on `import.rs` for the ChatGPT `create_time` sort.

### 🔴 Cross-platform home dir
`cmd_init`, `cmd_doctor`, and `cloud.rs` rtk-pro discovery used `env::var(\"HOME\")` — silently broken on Windows (which uses `%USERPROFILE%`). Replaced with `directories::UserDirs` via a new `home_dir_str()` helper.

## Why one bundled PR

The 30-agent audit surfaced ~50 issues across 30 dimensions. Splitting tier-1 fixes into 5 separate PRs would mean 5 CI roundtrips and 5 manual release dances (release-please can't open PRs in this repo's GH-Enterprise-restricted setup). These six fixes are independent of each other but all small and uncontroversial — bundling keeps reviewer overhead low without compromising bisectability (each is in a single file).

## What is NOT in this PR (planned follow-ups)

- B2 — Data integrity (transaction wrapping for the 75% of writes currently unwrapped, input validation, embedding dim wipe behavior)
- B3 — Test coverage for the 9 untested data-mutating commands
- B4 — README documentation drift (4 undocumented MCP tools, Dashboard section missing in 12 translations)
- B5 — Cargo dependency cleanup (tokio \"full\" features, ort pre-release, default features split)

## Test plan

- [x] `cargo test --workspace` — green (one pre-existing flaky perf test under parallel load, unrelated)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] 3 new project-filter tests pass; 5 existing recall tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)