### PR TITLE
docs: surface 4 missing MCP tools and document [wakeup] config section

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,21 +263,30 @@ Rust + SQLite + FTS5 — 0 Python, 0 ChromaDB, 0 external service. Writes are ~1
 ChromaDB-based verbatim stores; the whole transcript lives in the same SQLite file as your
 memories and memoirs.
 
-## MCP Tools (27)
+## MCP Tools (31)
 
 ### Memory tools
 
 | Tool | Description |
 |------|-------------|
 | `icm_memory_store` | Store with auto-dedup (>85% similarity → update instead of duplicate) |
-| `icm_memory_recall` | Search by query, filter by topic and/or keyword |
+| `icm_memory_recall` | Search by query, filter by topic / keyword / project |
 | `icm_memory_update` | Edit a memory in-place (content, importance, keywords) |
 | `icm_memory_forget` | Delete a memory by ID |
+| `icm_memory_forget_topic` | Delete all memories in a given topic |
 | `icm_memory_consolidate` | Merge all memories of a topic into one summary |
+| `icm_memory_extract_patterns` | Detect recurring patterns within a topic and surface them as concepts |
 | `icm_memory_list_topics` | List all topics with counts |
 | `icm_memory_stats` | Global memory statistics |
 | `icm_memory_health` | Per-topic hygiene audit (staleness, consolidation needs) |
 | `icm_memory_embed_all` | Backfill embeddings for vector search |
+
+### Session tools
+
+| Tool | Description |
+|------|-------------|
+| `icm_wake_up` | Build a project-scoped wake-up pack (critical/high memories + preferences) for SessionStart-style context injection |
+| `icm_learn` | Scan a project directory and seed a Memoir knowledge graph from its code/docs |
 
 ### Memoir tools (knowledge graphs)
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -51,6 +51,19 @@ enabled = true
 # Maximum memories to inject
 limit = 15
 
+[wakeup]
+# SessionStart hook (Layer 1): wake-up pack of critical/high-importance
+# memories injected at session start.
+
+# Token budget for the pack (~4 chars/token). Increase for richer context;
+# decrease if your tool's system prompt is already tight.
+max_tokens = 500
+
+# Include preference / identity memories regardless of project filter so
+# user-wide settings (style, language, conventions) leak through into
+# every project's wake-up.
+include_preferences = true
+
 [mcp]
 # MCP server transport: "stdio"
 transport = "stdio"


### PR DESCRIPTION
## Summary

Two doc gaps from the 30-agent audit pass:

1. **README undercounts MCP tools (27 vs 31)** — `icm_memory_forget_topic`, `icm_memory_extract_patterns`, `icm_wake_up`, and `icm_learn` are registered in `crates/icm-mcp/src/tools.rs` but absent from the README tables. Users couldn't discover them.
2. **`config/default.toml` omits the entire `[wakeup]` section** — the SessionStart hook reads `WakeUpConfig.max_tokens` and `include_preferences` but new users had no documented entry-point to tune those.

## Changes

**`README.md`:**
- Bump the section heading: \"MCP Tools (27)\" → \"MCP Tools (31)\".
- Add `icm_memory_forget_topic` (delete all memories in a topic) to the Memory tools table.
- Add `icm_memory_extract_patterns` (detect recurring patterns within a topic) to the Memory tools table.
- New \"Session tools\" subsection covering `icm_wake_up` and `icm_learn`. Neither fits the memory / memoir / feedback / transcript taxonomy.
- Note the new `project` filter on `icm_memory_recall` (lands in #141).

**`config/default.toml`:**
- Add a documented `[wakeup]` section with `max_tokens` and `include_preferences`. Defaults match the Rust `WakeUpConfig::default()`.

## Not in this PR

The 12 translated READMEs (`README_*.md`) all carry stale tool counts (most claim 22 or 27) and are missing the **Dashboard** section. Propagating these properly needs native-speaker review and is non-trivial in 12 languages — tracked as **follow-up B4b**.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p icm-cli config::tests` — 3/3 pass
- [x] No code changes; doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)