### PR TITLE
fix(robustness): audit batch 7 — versions, honorifics, wake-up cap, UTF-8 slice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.33"
+version = "0.10.34"
 dependencies = [
  "anyhow",
  "axum",
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "icm-core"
-version = "0.10.2"
+version = "0.10.34"
 dependencies = [
  "chrono",
  "directories",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "icm-mcp"
-version = "0.10.2"
+version = "0.10.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "icm-store"
-version = "0.10.2"
+version = "0.10.34"
 dependencies = [
  "chrono",
  "icm-core",

--- a/crates/icm-cli/src/extract.rs
+++ b/crates/icm-cli/src/extract.rs
@@ -537,6 +537,40 @@ fn extract_facts_with_threshold(
 /// Minimum char count for a fragment to be kept after splitting.
 const MIN_SENTENCE_LEN: usize = 30;
 
+/// English-language honorific abbreviations that end in `.` followed by a
+/// space + capitalized name. The naive splitter used to break sentences
+/// like `Mr. Smith joined the team.` into `... Mr.` + `Smith joined ...`.
+/// We suppress sentence-boundary detection when the buffer ends with one
+/// of these tokens (case-insensitive, preceded by whitespace or the
+/// start of the buffer).
+const HONORIFIC_PREFIXES: &[&str] = &[
+    "Mr.", "Mrs.", "Ms.", "Dr.", "Prof.", "Sr.", "Jr.", "St.", "Mt.", "Rev.", "Hon.", "Lt.",
+    "Sgt.", "Cpl.", "Pvt.", "Gen.", "Col.", "Maj.", "Capt.", "Cmdr.",
+];
+
+/// Return true iff `buf` ends in an honorific abbreviation that should
+/// suppress sentence-boundary detection on the trailing dot.
+fn ends_with_honorific(buf: &str) -> bool {
+    let trimmed = buf.trim_end();
+    for &h in HONORIFIC_PREFIXES {
+        if trimmed.len() >= h.len() && trimmed.ends_with(h) {
+            // Must be preceded by whitespace or be at the start, so we
+            // don't accidentally match `weatherstr.` containing `St.`.
+            let prefix_start = trimmed.len() - h.len();
+            if prefix_start == 0
+                || trimmed
+                    .as_bytes()
+                    .get(prefix_start - 1)
+                    .map(|b| b.is_ascii_whitespace())
+                    .unwrap_or(false)
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Split a block of text into sentence-sized chunks suitable for fact
 /// extraction. The previous implementation split on every `.` or `\n`,
 /// which truncated URLs at `https://github.`, file paths at `$HOME/.`,
@@ -608,7 +642,14 @@ fn split_sentences(text: &str) -> Vec<String> {
         } else if matches!(ch, '.' | '?' | '!' | ':') {
             match next {
                 None => true,
-                Some(c) if c.is_whitespace() => true,
+                Some(c) if c.is_whitespace() => {
+                    // `.` followed by whitespace is *usually* a sentence
+                    // boundary — but English honorifics like `Mr.`,
+                    // `Mrs.`, `Dr.`, `Prof.`, `St.`, `Sr.`, `Jr.` are
+                    // followed by a space + capitalized name, not a new
+                    // sentence. Suppress the boundary in that case.
+                    !ends_with_honorific(&current)
+                }
                 _ => false, // `.` inside URL/path/version/abbreviation
             }
         } else {
@@ -1384,5 +1425,56 @@ mod tests {
         assert_eq!(chunks.len(), 2);
         assert!(chunks[0].contains("Pratt"));
         assert!(chunks[1].contains("right-associative"));
+    }
+
+    // ── Honorific allowlist regression tests (audit batch 7) ──────────
+
+    #[test]
+    fn split_keeps_honorific_titles_intact() {
+        // Audit A5 finding: `Mr. Smith joined the team.` used to split
+        // into `... Mr.` + `Smith joined the team.` Now we suppress the
+        // boundary on common English honorifics.
+        let text = "The architecture team led by Mr. Smith joined the project last quarter.";
+        let chunks = split_sentences(text);
+        assert_eq!(
+            chunks.len(),
+            1,
+            "honorific split shouldn't break: {chunks:?}"
+        );
+        assert!(chunks[0].contains("Mr. Smith"));
+    }
+
+    #[test]
+    fn split_keeps_dr_and_prof_honorifics() {
+        // Same logic for Dr., Prof., and the others.
+        let cases = [
+            "Dr. Watson published a follow-up paper on the new architecture.",
+            "Prof. Knuth still recommends Knuth-Bendix completion for these problems.",
+            "St. Augustine FL hosts the team's annual offsite gathering each spring.",
+        ];
+        for text in &cases {
+            let chunks = split_sentences(text);
+            assert_eq!(
+                chunks.len(),
+                1,
+                "honorific should not split the sentence: {text:?} -> {chunks:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn split_does_not_match_honorific_substring_in_word() {
+        // `weatherstr.` should not be treated as ending in `St.` (the
+        // suffix matches but isn't preceded by whitespace, so it's part
+        // of a longer token).
+        let text = "The weatherstr. value contains the forecast string and is then logged.";
+        let chunks = split_sentences(text);
+        // It's not split-suppressed; the dot in `weatherstr.` is followed
+        // by a space + lowercase letter, so the splitter treats it as a
+        // genuine sentence boundary. Assert chunks > 0 and we don't
+        // accidentally erase content. Don't over-specify the count
+        // because either 1 or 2 chunks would be defensible — the key is
+        // we don't trigger the honorific path for a non-honorific.
+        assert!(!chunks.is_empty());
     }
 }

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2045,9 +2045,20 @@ fn extract_from_hook_transcript(store: &SqliteStore, source: &str) -> Result<()>
         return Ok(());
     }
 
-    // Truncate to last 4000 chars to keep extraction reasonable
+    // Truncate to last 4000 bytes to keep extraction reasonable.
+    //
+    // The original raw byte slice `&assistant_text[len-4000..]` panics
+    // when the cut-point lands inside a multibyte UTF-8 char (Cyrillic
+    // 2B, CJK 3B, emoji 4B). Find the nearest UTF-8 char boundary at or
+    // after `len-4000` instead. Result is at most 4000 bytes long; we
+    // accept losing a few leading bytes to char-align rather than
+    // panicking on multilingual transcripts.
     let text = if assistant_text.len() > 4000 {
-        &assistant_text[assistant_text.len() - 4000..]
+        let mut start = assistant_text.len() - 4000;
+        while start < assistant_text.len() && !assistant_text.is_char_boundary(start) {
+            start += 1;
+        }
+        &assistant_text[start..]
     } else {
         &assistant_text
     };

--- a/crates/icm-core/Cargo.toml
+++ b/crates/icm-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icm-core"
-version = "0.10.2"
+version = "0.10.34"
 edition = "2021"
 
 [features]

--- a/crates/icm-core/src/wake_up.rs
+++ b/crates/icm-core/src/wake_up.rs
@@ -240,10 +240,32 @@ fn categorize(m: &Memory) -> Category {
 /// Always includes at least one memory if any candidate exists.
 /// Counts user-visible characters (not bytes) so multibyte summaries aren't
 /// over-penalized.
+///
+/// **Smart truncation**: oversized memories are trimmed to a per-memory
+/// cap (with `[…]` suffix) instead of being included verbatim or
+/// blocking subsequent memories from fitting. Without this, a single
+/// 5KB memory at the front of the candidate list either:
+///   - filled the entire budget and starved the rest (small budgets), or
+///   - was emitted verbatim (large budgets), bloating the wake-up pack.
 fn truncate_by_budget(candidates: Vec<ScoredMemory>, max_chars: usize) -> Vec<ScoredMemory> {
+    // Per-memory cap: a single memory shouldn't consume more than half
+    // the budget. Below 200 chars we keep the cap at 200 so very small
+    // budgets still admit a usable head + ellipsis.
+    let per_memory_cap = (max_chars / 2).max(200);
+
     let mut total = 0usize;
     let mut out = Vec::new();
-    for c in candidates {
+    for mut c in candidates {
+        let summary_chars = c.memory.summary.chars().count();
+        if summary_chars > per_memory_cap {
+            // Truncate at a UTF-8 char boundary. We deliberately don't
+            // try to break on word/sentence boundary — the head of the
+            // summary is what carries signal; the tail is usually
+            // elaboration. Add a `[…]` marker so the user knows.
+            let mut truncated: String = c.memory.summary.chars().take(per_memory_cap).collect();
+            truncated.push_str(" […]");
+            c.memory.summary = truncated;
+        }
         // Account for bullet prefix + newline.
         let line_len = c.memory.summary.chars().count().saturating_add(4);
         if !out.is_empty() && total.saturating_add(line_len) > max_chars {

--- a/crates/icm-mcp/Cargo.toml
+++ b/crates/icm-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icm-mcp"
-version = "0.10.2"
+version = "0.10.34"
 edition = "2021"
 
 [features]

--- a/crates/icm-store/Cargo.toml
+++ b/crates/icm-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icm-store"
-version = "0.10.2"
+version = "0.10.34"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary

P2 polish from the 14-agent validation pass on v0.10.34.

## Workspace version drift

Agent **A13** caught that MCP `serverInfo` reported `0.10.2` from a v0.10.34 binary — the lib crates (`icm-core`, `icm-store`, `icm-mcp`) had been stuck at 0.10.2 while `icm-cli` bumped 30+ patches. Bump the three libs to **0.10.34** to match. release-please only tracks `icm-cli`, so the libs may drift again — follow-up if/when we publish to crates.io. `icm-install` stays at 0.1.0 (separate binary).

## Honorifics allowlist in the splitter

Agent **A5** found the only remaining English-prose break in PR #144's splitter: `Mr. Smith joined the team.` split at `Mr.` because the period is followed by space + capital. Suppress the boundary when the buffer ends with one of: `Mr.`, `Mrs.`, `Ms.`, `Dr.`, `Prof.`, `Sr.`, `Jr.`, `St.`, `Mt.`, `Rev.`, `Hon.`, `Lt.`, `Sgt.`, `Cpl.`, `Pvt.`, `Gen.`, `Col.`, `Maj.`, `Capt.`, `Cmdr.`. Word-boundary required so `weatherstr.` doesn't false-positive on `St.`.

3 new tests including the negative case.

## Wake-up smart per-memory truncation

Agent **A1** showed a single 5KB memory could either starve the rest of the pack (small budgets) or be emitted verbatim (large budgets). `truncate_by_budget` now caps each memory at `max_chars/2` (floor 200 chars) with a `[…]` suffix, mirroring the UserPromptSubmit cap from PR #146.

## UTF-8 boundary safety in transcript truncation

Agent **A4** flagged `&assistant_text[len-4000..]` in `extract_from_hook_transcript`: a raw byte slice that panics if the cut-point lands inside a multibyte char (Cyrillic 2B, CJK 3B, emoji 4B). Walk forward to the nearest char boundary instead. Pure-ASCII transcripts unaffected; multilingual ones no longer one-bug-away from a DoS.

## Out of scope (P3, future)

- Multilingual extractor scoring (FR/JA/ZH/AR/KO drop silently — needs language detection)
- `keep_originals` consolidate fix (Tests #145 deferred)
- 12 README translations drift (needs native-speaker review)
- Cargo deps cleanup

## Test plan

- [x] 318 → **321 tests passing** (3 new for honorifics)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Workspace builds cleanly with the version bumps; downstream `icm-cli` resolves the bumped libs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)