### PR TITLE
fix(consistency): audit batch 8 — auto-consolidate paths, embedding, cycles, feedback list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.34"
+version = "0.10.35"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -676,6 +676,22 @@ enum FeedbackCommands {
         limit: usize,
     },
 
+    /// List feedback entries (optionally filtered by topic).
+    ///
+    /// Mirror of `Search` without the FTS query — useful for browsing
+    /// all feedback under a single topic (e.g. all corrections to the
+    /// `predictions-deploy` topic) without having to come up with a
+    /// keyword that intersects every entry.
+    List {
+        /// Filter by topic (omit to list across all topics)
+        #[arg(short, long)]
+        topic: Option<String>,
+
+        /// Maximum results
+        #[arg(short, long, default_value = "20")]
+        limit: usize,
+    },
+
     /// Show feedback statistics
     Stats,
 }
@@ -938,6 +954,7 @@ fn main() -> Result<()> {
             cmd_store(
                 &store,
                 emb_ref,
+                &cfg.memory,
                 topic,
                 content,
                 importance.into(),
@@ -993,6 +1010,9 @@ fn main() -> Result<()> {
                 topic,
                 limit,
             } => cmd_feedback_search(&store, &query, topic.as_deref(), limit),
+            FeedbackCommands::List { topic, limit } => {
+                cmd_feedback_list(&store, topic.as_deref(), limit)
+            }
             FeedbackCommands::Stats => cmd_feedback_stats(&store),
         },
         Commands::Transcript { command } => match command {
@@ -1158,7 +1178,14 @@ fn main() -> Result<()> {
             keywords,
         } => {
             let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
-            cmd_save_project(&store, emb_ref, &content, importance.into(), keywords)
+            cmd_save_project(
+                &store,
+                emb_ref,
+                &cfg.memory,
+                &content,
+                importance.into(),
+                keywords,
+            )
         }
         Commands::Learn { dir, name } => {
             let dir = dir
@@ -1215,9 +1242,25 @@ fn main() -> Result<()> {
                 } else {
                     cfg.extraction.extract_every
                 };
-                cmd_hook_post(&store, extract_every, cfg.extraction.store_raw)
+                #[cfg(feature = "embeddings")]
+                let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
+                #[cfg(not(feature = "embeddings"))]
+                let emb_ref: Option<&dyn icm_core::Embedder> = None;
+                cmd_hook_post(
+                    &store,
+                    emb_ref,
+                    &cfg.memory,
+                    extract_every,
+                    cfg.extraction.store_raw,
+                )
             }
-            HookCommands::Compact => cmd_hook_compact(&store),
+            HookCommands::Compact => {
+                #[cfg(feature = "embeddings")]
+                let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
+                #[cfg(not(feature = "embeddings"))]
+                let emb_ref: Option<&dyn icm_core::Embedder> = None;
+                cmd_hook_compact(&store, emb_ref, &cfg.memory)
+            }
             HookCommands::Prompt => cmd_hook_prompt(&store),
             HookCommands::Start { max_tokens } => {
                 let tokens = if max_tokens > 0 {
@@ -1227,7 +1270,13 @@ fn main() -> Result<()> {
                 };
                 cmd_hook_start(&store, tokens)
             }
-            HookCommands::End => cmd_hook_end(&store),
+            HookCommands::End => {
+                #[cfg(feature = "embeddings")]
+                let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
+                #[cfg(not(feature = "embeddings"))]
+                let emb_ref: Option<&dyn icm_core::Embedder> = None;
+                cmd_hook_end(&store, emb_ref, &cfg.memory)
+            }
         },
         #[cfg(feature = "tui")]
         Commands::Dashboard => {
@@ -1246,9 +1295,39 @@ fn main() -> Result<()> {
 // Memory commands
 // ---------------------------------------------------------------------------
 
+/// If `auto_consolidate_enabled` is set, fire the rollup for the given topic.
+///
+/// Audit finding M2/AC1: only the MCP `tool_store` path used to trigger
+/// consolidation. The CLI `icm store` and the PostToolUse / PreCompact /
+/// SessionEnd hook extractions all bypassed the threshold check, so a
+/// user with `auto_consolidate_enabled = true` would never see a rollup
+/// unless they wrote via MCP. This helper centralises the trigger so
+/// every write path stays consistent. Errors are logged and swallowed
+/// — consolidation is a maintenance op, not on the critical path.
+fn maybe_auto_consolidate(
+    store: &SqliteStore,
+    embedder: Option<&dyn icm_core::Embedder>,
+    topic: &str,
+    cfg: &crate::config::MemoryConfig,
+) {
+    if !cfg.auto_consolidate_enabled {
+        return;
+    }
+    match store.auto_consolidate_with_embedder(topic, cfg.auto_consolidate_threshold, embedder) {
+        Ok(true) => eprintln!(
+            "[icm] auto-consolidated topic '{topic}' (exceeded {} entries)",
+            cfg.auto_consolidate_threshold
+        ),
+        Ok(false) => {} // below threshold — no-op
+        Err(e) => tracing::warn!("auto-consolidate failed for topic '{topic}': {e}"),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn cmd_store(
     store: &SqliteStore,
     embedder: Option<&dyn icm_core::Embedder>,
+    memory_cfg: &crate::config::MemoryConfig,
     topic: String,
     content: String,
     importance: Importance,
@@ -1299,6 +1378,10 @@ fn cmd_store(
             if linked_ids.len() == 1 { "" } else { "s" }
         );
     }
+
+    // Auto-consolidate the topic if config says so. Closes audit M2/AC1.
+    maybe_auto_consolidate(store, embedder, &topic, memory_cfg);
+
     Ok(())
 }
 
@@ -1563,6 +1646,34 @@ fn cmd_feedback_search(
     let results = store.search_feedback(query, topic, limit)?;
     if results.is_empty() {
         println!("No feedback found.");
+        return Ok(());
+    }
+
+    for fb in &results {
+        println!("--- {} [{}] ---", fb.id, fb.topic);
+        println!("  context:   {}", fb.context);
+        println!("  predicted: {}", fb.predicted);
+        println!("  corrected: {}", fb.corrected);
+        if let Some(ref reason) = fb.reason {
+            println!("  reason:    {reason}");
+        }
+        if !fb.source.is_empty() {
+            println!("  source:    {}", fb.source);
+        }
+        if fb.applied_count > 0 {
+            println!("  applied:   {} times", fb.applied_count);
+        }
+    }
+    Ok(())
+}
+
+fn cmd_feedback_list(store: &SqliteStore, topic: Option<&str>, limit: usize) -> Result<()> {
+    let results = store.list_feedback(topic, limit)?;
+    if results.is_empty() {
+        match topic {
+            Some(t) => println!("No feedback found in topic '{t}'."),
+            None => println!("No feedback found."),
+        }
         return Ok(());
     }
 
@@ -1894,7 +2005,13 @@ fn is_icm_command(cmd: &str) -> bool {
 
 /// PostToolUse hook: auto-extract context every N tool calls.
 /// Reads JSON from stdin. Runs extraction asynchronously.
-fn cmd_hook_post(store: &SqliteStore, extract_every: usize, store_raw: bool) -> Result<()> {
+fn cmd_hook_post(
+    store: &SqliteStore,
+    embedder: Option<&dyn icm_core::Embedder>,
+    memory_cfg: &crate::config::MemoryConfig,
+    extract_every: usize,
+    store_raw: bool,
+) -> Result<()> {
     use std::io::Read;
     let mut input = String::new();
     std::io::stdin().read_to_string(&mut input)?;
@@ -1940,7 +2057,14 @@ fn cmd_hook_post(store: &SqliteStore, extract_every: usize, store_raw: bool) -> 
 
     // Extract facts and store (with raw text fallback if enabled)
     match extract::extract_and_store_with_opts(store, tool_output, &project, store_raw) {
-        Ok(n) if n > 0 => eprintln!("[icm] auto-extracted {n} facts from tool output"),
+        Ok(n) if n > 0 => {
+            eprintln!("[icm] auto-extracted {n} facts from tool output");
+            // Audit M3: extracted facts all land under context-{project}.
+            // If the user has auto-consolidate enabled, fire it now so the
+            // hook path stops bypassing the rollup.
+            let topic = format!("context-{project}");
+            maybe_auto_consolidate(store, embedder, &topic, memory_cfg);
+        }
         _ => {}
     }
 
@@ -1948,8 +2072,12 @@ fn cmd_hook_post(store: &SqliteStore, extract_every: usize, store_raw: bool) -> 
 }
 
 /// PreCompact hook (Layer 1): extract memories from transcript before context compression.
-fn cmd_hook_compact(store: &SqliteStore) -> Result<()> {
-    extract_from_hook_transcript(store, "pre-compact")
+fn cmd_hook_compact(
+    store: &SqliteStore,
+    embedder: Option<&dyn icm_core::Embedder>,
+    memory_cfg: &crate::config::MemoryConfig,
+) -> Result<()> {
+    extract_from_hook_transcript(store, embedder, memory_cfg, "pre-compact")
 }
 
 /// SessionEnd hook (Layer 1b): extract memories from transcript before the
@@ -1959,8 +2087,12 @@ fn cmd_hook_compact(store: &SqliteStore) -> Result<()> {
 /// Same transcript-parsing logic as PreCompact — the only difference is the
 /// log prefix. SqliteStore handles its own dedup so a session that triggers
 /// both PreCompact and SessionEnd back-to-back will not double-store facts.
-fn cmd_hook_end(store: &SqliteStore) -> Result<()> {
-    extract_from_hook_transcript(store, "session-end")
+fn cmd_hook_end(
+    store: &SqliteStore,
+    embedder: Option<&dyn icm_core::Embedder>,
+    memory_cfg: &crate::config::MemoryConfig,
+) -> Result<()> {
+    extract_from_hook_transcript(store, embedder, memory_cfg, "session-end")
 }
 
 /// Read JSON from stdin, locate the transcript file, parse the last 100
@@ -1969,7 +2101,12 @@ fn cmd_hook_end(store: &SqliteStore) -> Result<()> {
 ///
 /// Reads JSON from stdin with `transcript_path`, reads the JSONL transcript,
 /// and extracts facts from assistant messages.
-fn extract_from_hook_transcript(store: &SqliteStore, source: &str) -> Result<()> {
+fn extract_from_hook_transcript(
+    store: &SqliteStore,
+    embedder: Option<&dyn icm_core::Embedder>,
+    memory_cfg: &crate::config::MemoryConfig,
+    source: &str,
+) -> Result<()> {
     use std::io::Read;
     let mut input = String::new();
     std::io::stdin().read_to_string(&mut input)?;
@@ -2071,7 +2208,14 @@ fn extract_from_hook_transcript(store: &SqliteStore, source: &str) -> Result<()>
         .unwrap_or_else(|| "project".to_string());
 
     match extract::extract_and_store_with_opts(store, text, &project, true) {
-        Ok(n) if n > 0 => eprintln!("[icm] {source}: extracted {n} facts from transcript"),
+        Ok(n) if n > 0 => {
+            eprintln!("[icm] {source}: extracted {n} facts from transcript");
+            // Audit M3/AC1: fire auto-consolidate after the bulk extract
+            // so the PreCompact / SessionEnd path stops bypassing the
+            // rollup configured in `[memory] auto_consolidate_enabled`.
+            let topic = format!("context-{project}");
+            maybe_auto_consolidate(store, embedder, &topic, memory_cfg);
+        }
         _ => {}
     }
 
@@ -3943,6 +4087,7 @@ fn cmd_wake_up(
 fn cmd_save_project(
     store: &SqliteStore,
     embedder: Option<&dyn icm_core::Embedder>,
+    memory_cfg: &crate::config::MemoryConfig,
     content: &str,
     importance: Importance,
     keywords: Option<String>,
@@ -3955,6 +4100,7 @@ fn cmd_save_project(
     cmd_store(
         store,
         embedder,
+        memory_cfg,
         topic,
         content.to_string(),
         importance,

--- a/crates/icm-core/src/error.rs
+++ b/crates/icm-core/src/error.rs
@@ -16,6 +16,11 @@ pub enum IcmError {
 
     #[error("embedding error: {0}")]
     Embedding(String),
+
+    /// Caller-supplied input violates a domain invariant (e.g. would
+    /// introduce a cycle in the concept graph, empty topic, etc.).
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
 }
 
 pub type IcmResult<T> = Result<T, IcmError>;

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -37,8 +37,18 @@ fn parse_keywords(args: &Value) -> Vec<String> {
 
 /// Try to auto-consolidate a topic if it exceeds the threshold.
 /// Returns a human-readable message if consolidation happened, or empty string.
-fn try_auto_consolidate(store: &SqliteStore, topic: &str, threshold: usize) -> String {
-    match store.auto_consolidate(topic, threshold) {
+///
+/// Routes through `auto_consolidate_with_embedder` so the consolidated
+/// memory is embedded inline (closes audit M2/AC2: previously the
+/// rolled-up memory had `embedding = None` and was invisible to hybrid
+/// recall until a manual `icm embed` rebuilt it).
+fn try_auto_consolidate(
+    store: &SqliteStore,
+    embedder: Option<&dyn Embedder>,
+    topic: &str,
+    threshold: usize,
+) -> String {
+    match store.auto_consolidate_with_embedder(topic, threshold, embedder) {
         Ok(true) => format!("Auto-consolidated topic '{topic}' (exceeded {threshold} entries)."),
         Ok(false) => String::new(),
         Err(e) => {
@@ -1066,7 +1076,7 @@ fn tool_store(
             if compact {
                 // Try auto-consolidation even in compact mode
                 let consolidation_msg =
-                    try_auto_consolidate(store, topic, AUTO_CONSOLIDATE_THRESHOLD);
+                    try_auto_consolidate(store, embedder, topic, AUTO_CONSOLIDATE_THRESHOLD);
                 if consolidation_msg.is_empty() {
                     ToolResult::text(format!("ok:{id}{link_suffix}"))
                 } else {
@@ -1074,7 +1084,7 @@ fn tool_store(
                 }
             } else {
                 let consolidation_msg =
-                    try_auto_consolidate(store, topic, AUTO_CONSOLIDATE_THRESHOLD);
+                    try_auto_consolidate(store, embedder, topic, AUTO_CONSOLIDATE_THRESHOLD);
                 if consolidation_msg.is_empty() {
                     // Still show a nudge if approaching threshold
                     let hint = if let Ok(count) = store.count_by_topic(topic) {

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -7,9 +7,9 @@ use rusqlite::{ffi::sqlite3_auto_extension, params, Connection};
 use zerocopy::IntoBytes;
 
 use icm_core::{
-    Concept, ConceptLink, Feedback, FeedbackStats, FeedbackStore, IcmError, IcmResult, Importance,
-    Label, Memoir, MemoirStats, MemoirStore, Memory, MemorySource, MemoryStore, Message,
-    PatternCluster, Relation, Role, Session, StoreStats, TopicHealth, TranscriptHit,
+    Concept, ConceptLink, Embedder, Feedback, FeedbackStats, FeedbackStore, IcmError, IcmResult,
+    Importance, Label, Memoir, MemoirStats, MemoirStore, Memory, MemorySource, MemoryStore,
+    Message, PatternCluster, Relation, Role, Session, StoreStats, TopicHealth, TranscriptHit,
     TranscriptStats, TranscriptStore,
 };
 
@@ -1317,6 +1317,28 @@ impl MemoirStore for SqliteStore {
     // --- Graph ---
 
     fn add_link(&self, link: ConceptLink) -> IcmResult<String> {
+        // Reject self-links: A→A is meaningless and produces a 1-step
+        // cycle. Caller usually catches this earlier but the store is
+        // the authoritative invariant gate.
+        if link.source_id == link.target_id {
+            return Err(IcmError::InvalidInput(format!(
+                "self-link rejected: source and target are the same concept ({})",
+                link.source_id
+            )));
+        }
+        // Cycle detection: BFS from `target` following outgoing edges.
+        // If we can reach `source`, the new edge would close a cycle
+        // (source → target → ... → source). Reject before insert.
+        //
+        // The BFS is bounded by the number of links currently in the
+        // memoir, so worst-case it touches every link once. For typical
+        // memoirs (<10k links) this is sub-millisecond.
+        if self.would_create_cycle(&link.source_id, &link.target_id)? {
+            return Err(IcmError::InvalidInput(format!(
+                "concept link rejected: {} → {} would create a cycle in the graph",
+                link.source_id, link.target_id
+            )));
+        }
         self.conn
             .execute(
                 "INSERT INTO concept_links (id, source_id, target_id, relation, weight, created_at)
@@ -2220,12 +2242,75 @@ impl TranscriptStore for SqliteStore {
 // ---------------------------------------------------------------------------
 
 impl SqliteStore {
+    /// Would inserting an edge `source → target` close a cycle in the
+    /// concept graph? BFS from `target` along outgoing edges; if we
+    /// reach `source`, the new edge would form a cycle.
+    ///
+    /// Returns `Ok(false)` for the empty-graph case and bounds the
+    /// search to a depth-limit equal to twice the link count to avoid
+    /// pathological loops on already-corrupt graphs.
+    fn would_create_cycle(&self, source: &str, target: &str) -> IcmResult<bool> {
+        if source == target {
+            return Ok(true);
+        }
+        let mut visited: HashSet<String> = HashSet::new();
+        let mut queue: VecDeque<String> = VecDeque::new();
+        queue.push_back(target.to_string());
+        visited.insert(target.to_string());
+        // Soft cap on traversal — guards against malformed pre-existing
+        // cycles (which shouldn't exist, but the user could have edited
+        // the DB by hand).
+        let cap = 10_000;
+        let mut steps = 0;
+        while let Some(current) = queue.pop_front() {
+            steps += 1;
+            if steps > cap {
+                tracing::warn!(
+                    "would_create_cycle: BFS hit {cap}-step cap while checking {source} → {target}"
+                );
+                break;
+            }
+            for next_link in self.get_links_from(&current)? {
+                if next_link.target_id == source {
+                    return Ok(true);
+                }
+                if visited.insert(next_link.target_id.clone()) {
+                    queue.push_back(next_link.target_id);
+                }
+            }
+        }
+        Ok(false)
+    }
+
     /// Automatically consolidate a topic if it exceeds the threshold.
     ///
     /// Keeps the top 3 summaries (by weight), merges all unique keywords,
     /// and replaces all memories with a single consolidated memory.
     /// Returns `true` if consolidation was performed.
+    ///
+    /// Backwards-compatible no-embedder variant. Prefer
+    /// [`auto_consolidate_with_embedder`] for new code so the
+    /// consolidated memory keeps a fresh embedding instead of being
+    /// silently un-recallable via vector search.
     pub fn auto_consolidate(&self, topic: &str, threshold: usize) -> IcmResult<bool> {
+        self.auto_consolidate_with_embedder(topic, threshold, None)
+    }
+
+    /// Same as [`auto_consolidate`] but also embeds the consolidated
+    /// memory when an embedder is available.
+    ///
+    /// Audit finding M2/AC2: the no-embedder variant produced a
+    /// consolidated memory with `embedding = None`, leaving it
+    /// invisible to hybrid / vector search until a manual `icm embed`
+    /// rebuilt it. With this variant the embedder is invoked inline so
+    /// the consolidated memory is recall-ready as soon as the topic is
+    /// rolled up.
+    pub fn auto_consolidate_with_embedder(
+        &self,
+        topic: &str,
+        threshold: usize,
+        embedder: Option<&dyn Embedder>,
+    ) -> IcmResult<bool> {
         let count = self.count_by_topic(topic)?;
         if count < threshold {
             return Ok(false);
@@ -2271,6 +2356,22 @@ impl SqliteStore {
         consolidated.raw_excerpt =
             Some(format!("auto-consolidated from {original_count} memories"));
         consolidated.weight = 1.0;
+
+        // Embed the consolidated content if an embedder is available so
+        // hybrid recall picks it up immediately. Errors are logged and
+        // swallowed — a partial consolidation (no embedding) is still
+        // better than blocking the whole rollup on an embedder hiccup.
+        if let Some(emb) = embedder {
+            match emb.embed(&consolidated.embed_text()) {
+                Ok(vec) => consolidated.embedding = Some(vec),
+                Err(e) => {
+                    tracing::warn!(
+                        "auto-consolidate: embedding failed for topic '{topic}': {e}; \
+                         consolidated memory will lack vector representation"
+                    );
+                }
+            }
+        }
 
         // Replace all memories in the topic with the consolidated one
         self.consolidate_topic(topic, consolidated)?;
@@ -2956,6 +3057,59 @@ mod tests {
         let link = ConceptLink::new(c_id.clone(), c_id, Relation::RelatedTo);
         let result = store.add_link(link);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_transitive_cycle_rejected() {
+        // Audit M11/CYC1: A → B → C → A used to be silently accepted,
+        // corrupting BFS in `get_neighborhood`. Now the third edge
+        // (closing the cycle) is rejected with `InvalidInput`.
+        let store = test_store();
+        let m_id = store.create_memoir(make_memoir("proj")).unwrap();
+        let a = store.add_concept(make_concept(&m_id, "A", "a")).unwrap();
+        let b = store.add_concept(make_concept(&m_id, "B", "b")).unwrap();
+        let c = store.add_concept(make_concept(&m_id, "C", "c")).unwrap();
+
+        // A → B: ok
+        store
+            .add_link(ConceptLink::new(a.clone(), b.clone(), Relation::DependsOn))
+            .unwrap();
+        // B → C: ok
+        store
+            .add_link(ConceptLink::new(b.clone(), c.clone(), Relation::Refines))
+            .unwrap();
+        // C → A: would close the cycle — reject
+        let cycle_attempt = store.add_link(ConceptLink::new(c, a, Relation::RelatedTo));
+        assert!(
+            cycle_attempt.is_err(),
+            "C → A should be rejected as a cycle"
+        );
+        let err_msg = cycle_attempt.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("cycle"),
+            "error message should mention cycle: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_dag_links_still_allowed() {
+        // Sanity: rejecting cycles must not break legitimate DAG links.
+        let store = test_store();
+        let m_id = store.create_memoir(make_memoir("proj")).unwrap();
+        let a = store.add_concept(make_concept(&m_id, "A", "a")).unwrap();
+        let b = store.add_concept(make_concept(&m_id, "B", "b")).unwrap();
+        let c = store.add_concept(make_concept(&m_id, "C", "c")).unwrap();
+
+        // A → B, A → C, B → C — three edges in a DAG, all should pass.
+        store
+            .add_link(ConceptLink::new(a.clone(), b.clone(), Relation::DependsOn))
+            .unwrap();
+        store
+            .add_link(ConceptLink::new(a, c.clone(), Relation::DependsOn))
+            .unwrap();
+        store
+            .add_link(ConceptLink::new(b, c, Relation::Refines))
+            .unwrap();
     }
 
     #[test]
@@ -4278,6 +4432,46 @@ mod tests {
         let result = store.auto_consolidate("bulk", 10).unwrap();
         assert!(result);
         assert_eq!(store.count_by_topic("bulk").unwrap(), 1);
+    }
+
+    #[test]
+    fn test_auto_consolidate_with_embedder_attaches_embedding() {
+        // Audit M2/AC2: the embedder-aware variant must produce a
+        // consolidated memory that is recall-ready (embedding != None).
+        struct StubEmbedder;
+        impl icm_core::Embedder for StubEmbedder {
+            fn embed(&self, _text: &str) -> IcmResult<Vec<f32>> {
+                Ok(vec![0.42; icm_core::DEFAULT_EMBEDDING_DIMS])
+            }
+            fn embed_batch(&self, texts: &[&str]) -> IcmResult<Vec<Vec<f32>>> {
+                Ok(texts
+                    .iter()
+                    .map(|_| vec![0.42; icm_core::DEFAULT_EMBEDDING_DIMS])
+                    .collect())
+            }
+            fn dimensions(&self) -> usize {
+                icm_core::DEFAULT_EMBEDDING_DIMS
+            }
+        }
+        let store = test_store();
+        for i in 0..11 {
+            store
+                .store(make_memory("rolled", &format!("fact {i}")))
+                .unwrap();
+        }
+        let stub = StubEmbedder;
+        let did = store
+            .auto_consolidate_with_embedder("rolled", 10, Some(&stub))
+            .unwrap();
+        assert!(did);
+        let consolidated = store.get_by_topic("rolled").unwrap();
+        assert_eq!(consolidated.len(), 1);
+        let embedding = consolidated[0]
+            .embedding
+            .as_ref()
+            .expect("consolidated memory must have an embedding");
+        assert_eq!(embedding.len(), icm_core::DEFAULT_EMBEDDING_DIMS);
+        assert!((embedding[0] - 0.42).abs() < 1e-6);
     }
 
     #[test]


### PR DESCRIPTION
Bundle B8 from the 15-agent moyen-run validation. Closes audit findings AC1 (auto-consolidate only fired on MCP path), AC2 (consolidated memory had no embedding), CYC1 (concept link cycles silently accepted), and FB1 (feedback list subcommand mentioned in spec but missing). 324 tests passing. See commit message for the full per-fix narrative.