### PR TITLE
fix(docs,cli): audit batch 9 — extract_every help text + 12 README count drifts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.35"
+version = "0.10.36"
 dependencies = [
  "anyhow",
  "axum",

--- a/README_ar.md
+++ b/README_ar.md
@@ -201,7 +201,7 @@ icm memoir export -m "system-architecture" -f json     # JSON منظم مع جم
 icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
 ```
 
-## أدوات MCP (22 أداة)
+## أدوات MCP (31 أداة)
 
 ### أدوات الذاكرة
 

--- a/README_de.md
+++ b/README_de.md
@@ -201,7 +201,7 @@ icm memoir export -m "system-architecture" -f json     # Strukturiertes JSON mit
 icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
 ```
 
-## MCP-Tools (22)
+## MCP-Tools (31)
 
 ### Gedächtnis-Tools
 

--- a/README_es.md
+++ b/README_es.md
@@ -201,7 +201,7 @@ icm memoir export -m "system-architecture" -f json     # JSON estructurado con t
 icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
 ```
 
-## Herramientas MCP (22)
+## Herramientas MCP (31)
 
 ### Herramientas de Memory
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -201,7 +201,7 @@ icm memoir export -m "system-architecture" -f json     # JSON structuré avec to
 icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
 ```
 
-## Outils MCP (22)
+## Outils MCP (31)
 
 ### Outils Memory
 

--- a/README_it.md
+++ b/README_it.md
@@ -217,7 +217,7 @@ icm memoir export -m "system-architecture" -f json     # JSON strutturato con tu
 icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
 ```
 
-## Tool MCP (22)
+## Tool MCP (31)
 
 ### Tool per le memorie
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -201,7 +201,7 @@ icm memoir export -m "system-architecture" -f json     # 全メタデータ付�
 icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
 ```
 
-## MCPツール（22個）
+## MCPツール（31個）
 
 ### メモリツール
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -201,7 +201,7 @@ icm memoir export -m "system-architecture" -f json     # 모든 메타데이터 
 icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
 ```
 
-## MCP 도구 (22개)
+## MCP 도구 (31개)
 
 ### 메모리 도구
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -217,7 +217,7 @@ icm memoir export -m "systeem-architectuur" -f json     # Gestructureerde JSON m
 icm memoir export -m "systeem-architectuur" -f dot | dot -Tsvg > graph.svg
 ```
 
-## MCP-tools (22)
+## MCP-tools (31)
 
 ### Geheugentools
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -201,7 +201,7 @@ icm memoir export -m "architektura-systemu" -f json     # Strukturalny JSON ze w
 icm memoir export -m "architektura-systemu" -f dot | dot -Tsvg > graph.svg
 ```
 
-## Narzędzia MCP (22)
+## Narzędzia MCP (31)
 
 ### Narzędzia pamięci
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -217,7 +217,7 @@ icm memoir export -m "system-architecture" -f json     # JSON estruturado com to
 icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
 ```
 
-## Ferramentas MCP (22)
+## Ferramentas MCP (31)
 
 ### Ferramentas de memória
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -201,7 +201,7 @@ icm memoir export -m "system-architecture" -f json     # Структуриро�
 icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
 ```
 
-## MCP-инструменты (22)
+## MCP-инструменты (31)
 
 ### Инструменты памяти
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -201,7 +201,7 @@ icm memoir export -m "system-architecture" -f json     # 包含所有元数据�
 icm memoir export -m "system-architecture" -f dot | dot -Tsvg > graph.svg
 ```
 
-## MCP 工具（22 个）
+## MCP 工具（31 个）
 
 ### 记忆工具
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -44,6 +44,17 @@ min_score = 3.0
 # Maximum facts per extraction pass
 max_facts = 10
 
+# Extract every N PostToolUse hook fires (i.e. every N tool calls in a
+# Claude Code / Gemini / Codex / Copilot session). Lower = more
+# aggressive (more memories, more noise); higher = quieter. The
+# `--every` CLI flag on `icm hook post` overrides this.
+extract_every = 3
+
+# Store the raw tool output as a low-importance memory when the
+# rule-based extractor produces no facts. Useful as a coarse safety
+# net; set to `false` if you only want signal-rich extractions.
+store_raw = true
+
 [recall]
 # Layer 2: context injection before sessions
 enabled = true

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -434,9 +434,16 @@ enum HookCommands {
     Pre,
     /// PostToolUse hook: auto-extract context every N tool calls
     Post {
-        /// Extract every N tool calls (default from config, fallback: 10)
-        #[arg(long, default_value = "15")]
-        every: usize,
+        /// Override how often to extract (every N tool calls).
+        ///
+        /// When omitted, uses `[extraction] extract_every` from config
+        /// (built-in default: 3). Audit M3/M6 found that the previous
+        /// help text claimed "default 15, fallback 10" while the actual
+        /// config default was 3 — three different numbers across help,
+        /// config example, and code. Made it Option-typed to drop the
+        /// sentinel and document the real default.
+        #[arg(long)]
+        every: Option<usize>,
     },
     /// PreCompact hook: extract memories from transcript before context compression
     Compact,
@@ -1237,11 +1244,8 @@ fn main() -> Result<()> {
         Commands::Hook { command } => match command {
             HookCommands::Pre => cmd_hook_pre(),
             HookCommands::Post { every } => {
-                let extract_every = if every != 15 {
-                    every // CLI flag overrides config
-                } else {
-                    cfg.extraction.extract_every
-                };
+                // CLI flag wins over config; absent flag falls back to config.
+                let extract_every = every.unwrap_or(cfg.extraction.extract_every);
                 #[cfg(feature = "embeddings")]
                 let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
                 #[cfg(not(feature = "embeddings"))]


### PR DESCRIPTION
Quick wins from the audit punch-list. `--every` on `icm hook post` had three different numbers across help/config/code (M3/M6) — fixed. 12 translated READMEs all stuck at "MCP Tools (22)" while EN is at 31 (B4b mechanical part) — bumped. Out of scope: the 4 missing tool rows + Dashboard section in translations need native-speaker review. 324 tests passing. See commit message for details.