### PR TITLE
fix(deps): restore vendored-openssl feature for cross-build pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.37"
+version = "0.10.38"
 dependencies = [
  "anyhow",
  "axum",
@@ -1327,6 +1327,7 @@ dependencies = [
  "icm-store",
  "libc",
  "mime_guess",
+ "openssl",
  "ratatui",
  "rpassword",
  "rust-embed",
@@ -2121,6 +2122,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,6 +2138,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/icm-cli/Cargo.toml
+++ b/crates/icm-cli/Cargo.toml
@@ -17,6 +17,16 @@ default = ["embeddings", "tui"]
 embeddings = ["icm-core/embeddings", "icm-mcp/embeddings"]
 tui = ["dep:ratatui", "dep:crossterm"]
 web = ["dep:axum", "dep:tokio", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:getrandom"]
+# `openssl` is not used directly in our source code, but it gets pulled
+# transitively via reqwest / hyper-tls / etc. (depending on the active
+# feature set). On cross-builds (e.g. aarch64-unknown-linux-gnu) the
+# host-system OpenSSL doesn't match the target arch, so the release
+# pipeline passes `--features vendored-openssl` to tell openssl-sys to
+# build OpenSSL from source against the cross toolchain. Audit batch 10
+# (PR #154) accidentally removed this feature; restored here so the
+# release.yml cross-build matrix doesn't choke on
+# `the package 'icm-cli' does not contain this feature: vendored-openssl`.
+vendored-openssl = ["openssl/vendored"]
 
 [dependencies]
 icm-core = { path = "../icm-core" }
@@ -31,6 +41,10 @@ serde_json = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+# Optional, only enabled by the `vendored-openssl` feature (see
+# explanation in [features] above). Cross-builds need it; native
+# builds don't pull it in.
+openssl = { version = "0.10", optional = true }
 ureq = { workspace = true }
 rpassword = { workspace = true }
 sha2 = { workspace = true }


### PR DESCRIPTION
Hotfix for v0.10.38 — the release.yml aarch64-unknown-linux-gnu cross-build broke after PR #154 removed the `vendored-openssl` feature. The feature is needed even though we don't import `openssl::` directly: it propagates the `vendored` setting through the transitive dep tree so cross-builds use a vendored OpenSSL instead of the host's. Restored. tokio narrowing from PR #154 stays — that was the actually-impactful change. 324 tests passing.