### PR TITLE
fix(cicd): match stable icm-v tags by anchored regex

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,9 +37,13 @@ jobs:
       - name: Compute next version from conventional commits
         id: tag
         run: |
-          # Latest stable tag follows the release-please format: icm-v0.10.42
+          # Latest stable tag follows the release-please format: icm-v0.10.42.
+          # The `^icm-v…$` anchor filters out any pre-release suffix
+          # (e.g. icm-v0.10.42-rc.1) without filtering on a bare dash —
+          # the icm- prefix itself contains one, which broke the original
+          # `grep -v '-'` borrowed from rtk-ai/rtk where tags are bare `vX.Y.Z`.
           LATEST_TAG=$(git tag -l 'icm-v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname \
-            | grep -v '-' | head -1)
+            | grep -E '^icm-v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
           if [ -z "$LATEST_TAG" ]; then
             echo "::error::No stable icm-v* release tag found"
             exit 1


### PR DESCRIPTION
The pre-release path in \`cd.yml\` (introduced in #168) borrowed \`grep -v '-'\` from rtk-ai/rtk where stable tags are bare \`vX.Y.Z\`. ICM's stable tags are \`icm-v0.10.42\` — the \`icm-\` prefix already contains a dash, so the filter dropped *every* stable tag and the workflow exited with \`No stable icm-v* release tag found\` on the very first push to \`develop\` ([failed run](https://github.com/rtk-ai/icm/actions/runs/25213170602)).

## Fix

Replace the bare-dash filter with an anchored regex that matches a stable tag shape exactly:

\`\`\`bash
# before
| grep -v '-' | head -1
# after
| grep -E '^icm-v[0-9]+\.[0-9]+\.[0-9]+\$' | head -1
\`\`\`

This still excludes pre-release suffixes (e.g. \`icm-v0.10.42-rc.1\`) if anyone ever creates one, while accepting the dash in the \`icm-\` prefix.

## Validated locally

\`\`\`text
\$ git tag -l 'icm-v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | grep -E '^icm-v[0-9]+\.[0-9]+\.[0-9]+\$' | head -3
icm-v0.10.42
icm-v0.10.41
icm-v0.10.40
\`\`\`

## Test plan

- [x] \`actionlint\` clean
- [ ] After merge, the new push to \`develop\` runs CD successfully and produces \`icm-dev-v0.10.43-rc.{run}\` with built artifacts
- [ ] Once that's confirmed, #166 and #167 can be merged on \`develop\` without re-tripping the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)