### PR TITLE
fix(deps): bump rustls-webpki / tar / lru to clear RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,7 +1122,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1124,6 +1130,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1379,7 +1396,7 @@ version = "0.10.34"
 dependencies = [
  "chrono",
  "icm-core",
- "lru",
+ "lru 0.18.0",
  "rusqlite",
  "serde_json",
  "sqlite-vec",
@@ -1772,6 +1789,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -2395,7 +2421,7 @@ dependencies = [
  "indoc",
  "instability",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "paste",
  "strum",
  "unicode-segmentation",
@@ -2721,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3110,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,14 +44,14 @@ clap = { version = "4", features = ["derive"] }
 directories = "6"
 
 # Caching
-lru = "0.12"
+lru = "0.18"
 
 # HTTP (cloud sync)
 ureq = { version = "2", features = ["json"] }
 rpassword = "5"
 sha2 = "0.10"
 flate2 = "1"
-tar = "0.4"
+tar = "0.4.45"
 
 # Platform
 libc = "0.2"


### PR DESCRIPTION
Three quick-win security bumps grouped into one PR — found via \`cargo audit\` during the 0.10.43 post-release verification audit.

## Cleared CVEs / advisories

| Advisory | Crate | From → To | Severity | Source |
|---|---|---|---|---|
| RUSTSEC-2026-0049 | rustls-webpki | 0.103.9 → 0.103.13 | — | transitive via ureq |
| RUSTSEC-2026-0098 | rustls-webpki | 0.103.9 → 0.103.13 | — | transitive |
| RUSTSEC-2026-0099 | rustls-webpki | 0.103.9 → 0.103.13 | — | transitive |
| RUSTSEC-2026-0104 | rustls-webpki | 0.103.9 → 0.103.13 | — | transitive |
| **RUSTSEC-2026-0067** | tar | 0.4.44 → **0.4.45** | medium 5.1 | direct (icm-cli) |
| **RUSTSEC-2026-0068** | tar | 0.4.44 → **0.4.45** | medium 5.1 | direct (icm-cli) |
| **RUSTSEC-2026-0002** | lru | 0.12 → **0.18** | warning (unsound \`IterMut\`) | direct (icm-store, added in #167) |

## Notes on lru bump

- The advisory affects \`lru\` 0.12 through ~0.16. The first listed unaffected version is **0.18**, so we bump straight there.
- Our usage (\`get\` / \`put\` / \`pop\` / \`clear\` in \`crates/icm-store/src/store.rs\`) never touched the unsound \`IterMut\` path, so this is precautionary, not a fix for an exploitable bug. Still: clears the audit warning and removes the lint noise.
- \`lru 0.12.5\` remains in the lockfile via \`ratatui 0.29.0\` — bumping ratatui is a bigger refactor and is **out of scope** for this PR. Our code (icm-store) is on 0.18 now.

## Remaining warnings (out of scope)

\`paste 1.0.15\` (unmaintained, via fastembed/ratatui), \`core2 0.4.0\` (yanked, via flate2 chain), \`number_prefix\` (unmaintained, via indicatif). All transitive; addressing them requires upstream releases or upstream-dep version bumps that need their own PRs.

## Test plan

- [x] \`cargo audit\` — no longer flags any **direct** dep of this workspace; only transitive warnings remain
- [x] \`cargo build --workspace\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --release --workspace\` — full pass
- [ ] CI debug-build run on this PR (the local \`perf_fts_search_100\` is parallelism-sensitive on debug — passes in release; same flakiness existed before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)