### PR TITLE
fix(schema): drop premature summary_hash unique index from initial batch

### DIFF
--- a/crates/icm-store/src/schema.rs
+++ b/crates/icm-store/src/schema.rs
@@ -72,13 +72,12 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
         CREATE INDEX IF NOT EXISTS idx_memories_topic ON memories(topic);
         CREATE INDEX IF NOT EXISTS idx_memories_weight ON memories(weight);
         CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at);
-        -- Partial unique index: only enforce on rows that have a hash
-        -- (i.e. new rows). Pre-existing dupes with NULL hash are left
-        -- alone — a separate one-shot dedup tool can collapse them later.
-        -- Topic compared case-insensitively to match the in-Rust
-        -- normalization done in summary_hash().
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_topic_hash
-            ON memories(LOWER(topic), summary_hash) WHERE summary_hash IS NOT NULL;
+        -- The summary_hash partial unique index is created later, AFTER the
+        -- idempotent ALTER TABLE migration that adds the column on legacy
+        -- DBs (PRs #176 + this hotfix). Creating it here would crash with
+        -- `no such column: summary_hash` on any pre-0.10.43 DB because
+        -- `CREATE TABLE IF NOT EXISTS` is a no-op on existing tables — the
+        -- new column declaration above only takes effect on fresh DBs.
 
         -- Memoir tables
         CREATE TABLE IF NOT EXISTS memoirs (
@@ -452,6 +451,96 @@ mod tests {
         init_db(&conn).unwrap();
         // Second call should be idempotent
         init_db(&conn).unwrap();
+    }
+
+    /// Simulates upgrading a pre-0.10.43 database (no `summary_hash`
+    /// column on the `memories` table) with the new binary. The migration
+    /// must (a) succeed without error, (b) add the missing column, and
+    /// (c) leave the partial unique index in place. Regression test for
+    /// the V8 retest blocker where the index was created in the same
+    /// batch as `CREATE TABLE IF NOT EXISTS`, before the ALTER TABLE
+    /// migration could run, bricking every existing user DB on upgrade.
+    #[test]
+    fn test_migration_from_pre_0_10_43_schema() {
+        ensure_vec_init();
+        let conn = Connection::open_in_memory().unwrap();
+
+        // Build a legacy schema by hand: CREATE TABLE without summary_hash.
+        conn.execute_batch(
+            "CREATE TABLE memories (
+                id TEXT PRIMARY KEY,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL DEFAULT '',
+                last_accessed TEXT NOT NULL,
+                access_count INTEGER DEFAULT 0,
+                weight REAL DEFAULT 1.0,
+                topic TEXT NOT NULL,
+                summary TEXT NOT NULL,
+                raw_excerpt TEXT,
+                keywords TEXT,
+                importance TEXT NOT NULL,
+                source_type TEXT NOT NULL,
+                source_data TEXT,
+                related_ids TEXT
+            );",
+        )
+        .unwrap();
+
+        // Seed one row that pre-dates the migration — must survive intact.
+        conn.execute(
+            "INSERT INTO memories (id, created_at, last_accessed, topic, summary, importance, source_type)
+             VALUES ('legacy-1', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'legacy', 'old summary', 'medium', 'manual')",
+            [],
+        )
+        .unwrap();
+
+        // Now run the new init — this is what the V8 test reproduced as a
+        // bricking error. Must complete without panic.
+        init_db(&conn).expect("upgrade must succeed on a legacy schema");
+
+        // summary_hash column now exists.
+        let cols: Vec<String> = conn
+            .prepare("PRAGMA table_info(memories)")
+            .unwrap()
+            .query_map([], |r| r.get::<_, String>(1))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert!(
+            cols.iter().any(|c| c == "summary_hash"),
+            "summary_hash column must be added by the migration; saw {cols:?}"
+        );
+
+        // Partial unique index now exists.
+        let indices: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name = 'idx_memories_topic_hash'")
+            .unwrap()
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(
+            indices.len(),
+            1,
+            "idx_memories_topic_hash must exist after migration"
+        );
+
+        // Legacy row still readable, summary_hash is NULL on it.
+        let (legacy_summary, legacy_hash): (String, Option<String>) = conn
+            .query_row(
+                "SELECT summary, summary_hash FROM memories WHERE id = 'legacy-1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(legacy_summary, "old summary");
+        assert!(
+            legacy_hash.is_none(),
+            "legacy row must keep NULL summary_hash so it doesn't conflict with the partial unique index"
+        );
+
+        // Re-running the migration is idempotent.
+        init_db(&conn).expect("re-running migration must be a no-op");
     }
 
     #[test]


### PR DESCRIPTION
**P0 hotfix on top of #176.** The dedup migration shipped in #176 was broken on the upgrade path — any existing pre-0.10.43 DB would crash on every \`icm\` command with \`database error: no such column: summary_hash\`. Patrick's prod DB (382 memories) was bricked. Caught by QA retest agents V8 and V10.

## Root cause

Two-phase init in \`init_db_with_dims\`:
1. First \`execute_batch\` had \`CREATE TABLE IF NOT EXISTS memories (… summary_hash TEXT)\` AND \`CREATE UNIQUE INDEX … ON memories(LOWER(topic), summary_hash) WHERE summary_hash IS NOT NULL\`.
2. After it: the idempotent \`ALTER TABLE … ADD COLUMN summary_hash TEXT\`.

On a legacy DB, phase 1's \`CREATE TABLE IF NOT EXISTS\` is a no-op (table exists, new column declaration ignored). The index creation in the same batch then fails because the column truly doesn't exist. Phase 2 never runs.

## Fix

Remove the index creation from the first batch entirely. The duplicate creation that already runs AFTER the \`ALTER TABLE\` is the only one needed — it covers both fresh DBs (column declared in CREATE TABLE) and legacy DBs (column just added by ALTER).

## Regression test

New \`test_migration_from_pre_0_10_43_schema\` in \`schema.rs\`:

1. Builds a legacy \`memories\` table by hand (no \`summary_hash\` column)
2. Inserts a representative legacy row
3. Runs \`init_db\` and asserts the migration succeeds without panic
4. Asserts the \`summary_hash\` column is added
5. Asserts \`idx_memories_topic_hash\` exists exactly once
6. Asserts legacy row is intact with NULL \`summary_hash\`
7. Asserts re-running migration is idempotent

The existing \`test_init_db\` only covered the fresh-DB path; this fills the upgrade gap.

## End-to-end verification

- Copied prod DB (\`~/.local/share/icm/memories.db\`, 382 memories) to a sandbox path
- Pre-fix: \`icm --db <copy> stats\` crashes with \`no such column: summary_hash\`
- Post-fix: \`icm --db <copy> stats\` succeeds, prints \`Memories: 382\`
- \`PRAGMA table_info(memories)\` confirms \`summary_hash\` column added
- Re-running \`stats\` is idempotent (count unchanged at 382)

## Tests

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --release --workspace\` — **348 passed, 2 ignored** (+1 new: \`test_migration_from_pre_0_10_43_schema\`)
- [x] Hand-tested: prod DB copy upgrades cleanly, no data loss

## Severity

**P0 ship blocker** for any release that includes #176. Without this, every existing user's DB breaks on first run after the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)