### PR TITLE
fix(cli): contract violations on recall --format and decay --factor

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1570,7 +1570,20 @@ fn cmd_recall(
     final_results.retain(&filter);
 
     if final_results.is_empty() {
-        println!("{MSG_NO_MEMORIES}");
+        // Audit #185 H8: don't short-circuit with a human-readable
+        // message — that breaks the JSON / TOON contracts. Render
+        // empty results through the chosen formatter; each renderer
+        // already produces a clean empty representation:
+        //   - toon:   "memories[0]{...}:\n"
+        //   - detail: empty string (so we keep the human banner there)
+        //   - json:   "[]"
+        match format {
+            recall_format::RecallFormat::Detail => println!("{MSG_NO_MEMORIES}"),
+            _ => {
+                let rendered = recall_format::render(&final_results, format)?;
+                print!("{rendered}");
+            }
+        }
         return Ok(());
     }
 
@@ -2660,6 +2673,17 @@ fn cmd_stats(store: &SqliteStore) -> Result<()> {
 }
 
 fn cmd_decay(store: &SqliteStore, factor: f32) -> Result<()> {
+    // Audit #185 H9: `apply_decay` multiplies each memory's weight by
+    // `factor`, so values >= 1 *amplify* weight instead of decaying it
+    // — the opposite of the user's intent and an instant footgun.
+    // Reject at the CLI boundary with a clear message rather than
+    // silently corrupting the ranking.
+    if !(factor.is_finite() && (0.0..1.0).contains(&factor)) {
+        return Err(anyhow::anyhow!(
+            "decay factor must be in [0.0, 1.0); got {factor}. \
+             Values >= 1 amplify weights instead of decaying them."
+        ));
+    }
     let affected = store.apply_decay(factor)?;
     println!("Decay applied (factor={factor}) to {affected} memories.");
     Ok(())
@@ -6893,5 +6917,46 @@ mod is_icm_command_tests {
         // for a one-time permission on `icm recall '<>'`.
         assert!(!is_icm_command(r#"icm recall "<>""#));
         assert!(!is_icm_command(r#"icm recall 'a > b'"#));
+    }
+}
+
+#[cfg(test)]
+mod cli_contracts_tests {
+    use super::*;
+    use icm_store::SqliteStore;
+
+    /// Audit #185 H9: `apply_decay` multiplies weight by `factor`,
+    /// so values >= 1 amplify instead of decaying. Reject at the CLI
+    /// boundary so users can't shoot themselves in the foot.
+    #[test]
+    fn cmd_decay_rejects_factor_one_or_greater() {
+        let store = SqliteStore::in_memory().unwrap();
+        for &bad in &[1.0_f32, 1.5, 2.0, 100.0, f32::INFINITY] {
+            let err = cmd_decay(&store, bad).unwrap_err();
+            assert!(
+                err.to_string().contains("decay factor must be in"),
+                "factor={bad} should be rejected, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn cmd_decay_rejects_negative_or_nan_factor() {
+        let store = SqliteStore::in_memory().unwrap();
+        for &bad in &[-0.1_f32, -1.0, f32::NAN, f32::NEG_INFINITY] {
+            let err = cmd_decay(&store, bad).unwrap_err();
+            assert!(
+                err.to_string().contains("decay factor must be in"),
+                "factor={bad} should be rejected, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn cmd_decay_accepts_valid_factor() {
+        let store = SqliteStore::in_memory().unwrap();
+        for &good in &[0.0_f32, 0.5, 0.95, 0.999_999] {
+            cmd_decay(&store, good).unwrap_or_else(|e| panic!("factor={good} rejected: {e}"));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Two CLI footguns from #185, both small and self-contained.

| Bug | Pre-fix | Post-fix |
|---|---|---|
| H8 — `recall --format json` on empty result | `No memories found.\n` (text) | `[]` |
| H9 — `decay --factor 2.0` | Amplifies weights to 1.6+ | Error: \"decay factor must be in [0.0, 1.0)\" |

## H8

`cmd_recall` short-circuited on empty results with `println!(\"{MSG_NO_MEMORIES}\")` regardless of the requested format. The TOON / JSON renderers already produced clean empty representations (`memories[0]{...}:\n` and `[]`); the short-circuit just bypassed them.

Fix: route empty results through the renderer when format is non-Detail, keep the legacy human message for Detail.

## H9

`apply_decay(factor)` multiplies each weight by `factor`. With `factor >= 1.0` the multiplication amplifies instead of decaying — the opposite of user intent. Weights jump to 1.6+ on a single bad invocation, destroying the importance ranking.

Fix: validate at the CLI boundary (`cmd_decay`) — reject anything outside `[0.0, 1.0)` and non-finite values (NaN, ±∞) with a clear error message.

## Tests

134 passing (was 131, +3 new):

- `cmd_decay_rejects_factor_one_or_greater` covering `[1.0, 1.5, 2.0, 100.0, ∞]`
- `cmd_decay_rejects_negative_or_nan_factor` covering `[-0.1, -1.0, NaN, -∞]`
- `cmd_decay_accepts_valid_factor` covering `[0.0, 0.5, 0.95, 0.999_999]`

H8 is covered by the pre-existing `recall_format::tests::empty_list_renders_clean` which pins:
- `render_json(&[])` → `\"[]\"`
- `render_toon(&[])` → `\"memories[0]{...}:\\n\"`
- `render_detail(&[])` → empty string

`cargo clippy -p icm-cli --no-deps -- -D warnings` clean. `cargo fmt --all --check` clean.

## Test plan

- [x] `cargo test -p icm-cli` — 134 passing
- [x] `cargo clippy -p icm-cli --no-deps -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [ ] Watch develop CI green before merge

Closes #185 H8, H9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)