### PR TITLE
fix(cli): forget rejects id+topic combo and empty topic

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1631,13 +1631,29 @@ fn cmd_list(store: &SqliteStore, topic: Option<&str>, all: bool, sort: SortField
 
 fn cmd_forget(store: &SqliteStore, id: Option<&str>, topic: Option<&str>) -> Result<()> {
     match (id, topic) {
-        (_, Some(topic)) => {
-            let memories = store.get_by_topic(topic)?;
+        (Some(_), Some(_)) => {
+            // Audit #185 medium: previously the topic path silently
+            // won and the id was discarded. Reject the ambiguous combo
+            // so a careless user isn't surprised by a topic-wide
+            // delete when they expected a single-id forget.
+            anyhow::bail!("cannot pass both a memory ID and --topic; use one or the other");
+        }
+        (None, Some(topic)) => {
+            // Audit #185 low: `--topic ""` deletes every memory in
+            // the empty-topic bucket without confirmation. Empty
+            // topics shouldn't exist post-#187 (validation rejects
+            // them on store), but reject here too so old data with
+            // legacy empty topics can't be wiped by typo.
+            let trimmed = topic.trim();
+            if trimmed.is_empty() {
+                anyhow::bail!("--topic cannot be empty");
+            }
+            let memories = store.get_by_topic(trimmed)?;
             let count = memories.len();
             for m in &memories {
                 store.delete(&m.id)?;
             }
-            println!("Deleted {count} memories from topic: {topic}");
+            println!("Deleted {count} memories from topic: {trimmed}");
         }
         (Some(id), None) => {
             store.delete(id)?;
@@ -6917,6 +6933,70 @@ mod is_icm_command_tests {
         // for a one-time permission on `icm recall '<>'`.
         assert!(!is_icm_command(r#"icm recall "<>""#));
         assert!(!is_icm_command(r#"icm recall 'a > b'"#));
+    }
+}
+
+#[cfg(test)]
+mod cmd_forget_tests {
+    use super::*;
+    use icm_core::{Importance, Memory};
+    use icm_store::SqliteStore;
+
+    /// Audit #185 medium: `forget <ID> -t TOPIC` used to silently nuke
+    /// the whole topic and discard the id. Now we reject the
+    /// ambiguous combo.
+    #[test]
+    fn rejects_id_and_topic_together() {
+        let store = SqliteStore::in_memory().unwrap();
+        let id = store
+            .store(Memory::new(
+                "topic".into(),
+                "content here for storage".into(),
+                Importance::Medium,
+            ))
+            .unwrap();
+
+        let err = cmd_forget(&store, Some(&id), Some("topic")).unwrap_err();
+        assert!(
+            err.to_string().contains("cannot pass both"),
+            "expected ambiguous-combo rejection, got {err}"
+        );
+
+        // Both should still exist — neither path executed.
+        assert!(store.get(&id).unwrap().is_some());
+    }
+
+    /// Audit #185 low: `forget --topic ""` deleted every empty-topic
+    /// memory without confirmation. Reject explicitly so old data
+    /// with legacy empty topics can't be wiped by typo.
+    #[test]
+    fn rejects_empty_topic() {
+        let store = SqliteStore::in_memory().unwrap();
+        let err = cmd_forget(&store, None, Some("")).unwrap_err();
+        assert!(
+            err.to_string().contains("--topic cannot be empty"),
+            "expected empty-topic rejection, got {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_whitespace_only_topic() {
+        let store = SqliteStore::in_memory().unwrap();
+        let err = cmd_forget(&store, None, Some("   \t  ")).unwrap_err();
+        assert!(
+            err.to_string().contains("--topic cannot be empty"),
+            "expected whitespace-topic rejection, got {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_neither_id_nor_topic() {
+        let store = SqliteStore::in_memory().unwrap();
+        let err = cmd_forget(&store, None, None).unwrap_err();
+        assert!(
+            err.to_string().contains("required"),
+            "expected required rejection, got {err}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Two \`icm forget\` footguns from #185.

| Bug | Pre-fix | Post-fix |
|---|---|---|
| \`forget <ID> -t TOPIC\` | Silently nukes whole topic, discards id | Errors: \"cannot pass both a memory ID and --topic\" |
| \`forget --topic \"\"\` | Wipes every empty-topic memory | Errors: \"--topic cannot be empty\" |

## Why these matter

A user typing \`icm forget 01ABC123 -t prefs\` expecting to delete one memory used to wipe **all** their preferences instead, because the match arm \`(_, Some(topic))\` won regardless of the id. The fix rejects the ambiguous combo before either delete path runs.

\`forget --topic \"\"\` (or with whitespace-only value) was a wipe-all-empty-topic-memories vector. Empty topics shouldn't exist post-#187 (store validation rejects them on insert), but legacy data may still have them, and shell quoting accidents could trigger the wipe unintentionally.

## Tests

138 passing in \`icm-cli\` (was 134, +4 new in \`cmd_forget_tests\`):
- \`rejects_id_and_topic_together\` — pins the ambiguous-combo fix
- \`rejects_empty_topic\`
- \`rejects_whitespace_only_topic\`
- \`rejects_neither_id_nor_topic\` (sanity, pre-existing behaviour)

\`cargo clippy --no-deps -- -D warnings\` clean. \`cargo fmt\` clean.

## Test plan

- [x] \`cargo test -p icm-cli\` — 138 passing
- [x] \`cargo clippy -p icm-cli --no-deps -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [ ] Watch develop CI green before merge

Closes #185 medium-tier forget items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)