### PR TITLE
fix(display): respect TZ env on every CLI/MCP timestamp render

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -24,9 +24,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 use serde_json::Value;
 
 use icm_core::{
-    build_wake_up, is_preference_topic, keyword_matches, project_matches, topic_matches, Concept,
-    ConceptLink, Feedback, FeedbackStore, Importance, Label, Memoir, MemoirStore, Memory,
-    MemoryStore, Relation, WakeUpFormat, WakeUpOptions, MSG_NO_MEMORIES,
+    build_wake_up, format_local, is_preference_topic, keyword_matches, project_matches,
+    topic_matches, Concept, ConceptLink, Feedback, FeedbackStore, Importance, Label, Memoir,
+    MemoirStore, Memory, MemoryStore, Relation, WakeUpFormat, WakeUpOptions, MSG_NO_MEMORIES,
 };
 use icm_store::SqliteStore;
 
@@ -1950,7 +1950,10 @@ fn cmd_transcript_search(
             "  session:  {} ({}, project={}, agent={})",
             hit.session.id, hit.message.role, proj, hit.session.agent
         );
-        println!("  ts:       {}", hit.message.ts.format("%Y-%m-%d %H:%M:%S"));
+        println!(
+            "  ts:       {}",
+            format_local(&hit.message.ts, "%Y-%m-%d %H:%M:%S")
+        );
         println!("  score:    {:.3}", hit.score);
         if let Some(t) = &hit.message.tool_name {
             println!("  tool:     {t}");
@@ -1985,8 +1988,8 @@ fn cmd_transcript_list_sessions(
             short_id,
             truncate(&s.agent, 14),
             truncate(proj, 18),
-            s.started_at.format("%Y-%m-%d %H:%M:%S"),
-            s.updated_at.format("%Y-%m-%d %H:%M:%S"),
+            format_local(&s.started_at, "%Y-%m-%d %H:%M:%S"),
+            format_local(&s.updated_at, "%Y-%m-%d %H:%M:%S"),
         );
     }
     Ok(())
@@ -2007,14 +2010,14 @@ fn cmd_transcript_show(store: &SqliteStore, session: &str, limit: usize) -> Resu
         "agent={} project={} started={} updated={}",
         meta.agent,
         meta.project.as_deref().unwrap_or("-"),
-        meta.started_at.format("%Y-%m-%d %H:%M:%S"),
-        meta.updated_at.format("%Y-%m-%d %H:%M:%S"),
+        format_local(&meta.started_at, "%Y-%m-%d %H:%M:%S"),
+        format_local(&meta.updated_at, "%Y-%m-%d %H:%M:%S"),
     );
     println!();
 
     let messages = store.list_session_messages(session, limit, 0)?;
     for m in messages {
-        let ts = m.ts.format("%H:%M:%S");
+        let ts = format_local(&m.ts, "%H:%M:%S");
         let tool = m
             .tool_name
             .as_ref()
@@ -2043,8 +2046,8 @@ fn cmd_transcript_stats(store: &SqliteStore) -> Result<()> {
     if let (Some(o), Some(n)) = (&s.oldest, &s.newest) {
         println!(
             "Range:         {} -> {}",
-            o.format("%Y-%m-%d %H:%M"),
-            n.format("%Y-%m-%d %H:%M")
+            format_local(o, "%Y-%m-%d %H:%M"),
+            format_local(n, "%Y-%m-%d %H:%M")
         );
     }
     if !s.by_role.is_empty() {
@@ -2727,10 +2730,10 @@ fn cmd_stats(store: &SqliteStore) -> Result<()> {
     println!("Topics:    {}", stats.total_topics);
     println!("Avg weight: {:.3}", stats.avg_weight);
     if let Some(oldest) = stats.oldest_memory {
-        println!("Oldest:    {}", oldest.format("%Y-%m-%d %H:%M"));
+        println!("Oldest:    {}", format_local(&oldest, "%Y-%m-%d %H:%M"));
     }
     if let Some(newest) = stats.newest_memory {
-        println!("Newest:    {}", newest.format("%Y-%m-%d %H:%M"));
+        println!("Newest:    {}", format_local(&newest, "%Y-%m-%d %H:%M"));
     }
     Ok(())
 }
@@ -4647,10 +4650,13 @@ fn print_memory_detail(mem: &Memory, score: Option<f32>) {
     println!("  topic:      {}", mem.topic);
     println!("  importance: {}", mem.importance);
     println!("  weight:     {:.3}", mem.weight);
-    println!("  created:    {}", mem.created_at.format("%Y-%m-%d %H:%M"));
+    println!(
+        "  created:    {}",
+        format_local(&mem.created_at, "%Y-%m-%d %H:%M")
+    );
     println!(
         "  accessed:   {} (x{})",
-        mem.last_accessed.format("%Y-%m-%d %H:%M"),
+        format_local(&mem.last_accessed, "%Y-%m-%d %H:%M"),
         mem.access_count
     );
     println!("  summary:    {}", mem.summary);
@@ -5763,11 +5769,11 @@ fn cmd_memoir_show(store: &SqliteStore, name: &str) -> Result<()> {
     }
     println!(
         "  created:     {}",
-        memoir.created_at.format("%Y-%m-%d %H:%M")
+        format_local(&memoir.created_at, "%Y-%m-%d %H:%M")
     );
     println!(
         "  updated:     {}",
-        memoir.updated_at.format("%Y-%m-%d %H:%M")
+        format_local(&memoir.updated_at, "%Y-%m-%d %H:%M")
     );
     println!("  concepts:    {}", stats.total_concepts);
     println!("  links:       {}", stats.total_links);
@@ -6215,8 +6221,14 @@ fn print_concept(c: &Concept) {
         let labels_str = c.format_labels();
         println!("  labels:     {labels_str}");
     }
-    println!("  created:    {}", c.created_at.format("%Y-%m-%d %H:%M"));
-    println!("  updated:    {}", c.updated_at.format("%Y-%m-%d %H:%M"));
+    println!(
+        "  created:    {}",
+        format_local(&c.created_at, "%Y-%m-%d %H:%M")
+    );
+    println!(
+        "  updated:    {}",
+        format_local(&c.updated_at, "%Y-%m-%d %H:%M")
+    );
     if !c.source_memory_ids.is_empty() {
         println!("  sources:    {}", c.source_memory_ids.join(", "));
     }

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -39,6 +39,9 @@ pub use wake_up::{
 
 pub use learn::{learn_project, LearnResult};
 
+pub mod time_fmt;
+pub use time_fmt::format_local;
+
 /// Common message for empty search results.
 pub const MSG_NO_MEMORIES: &str = "No memories found.";
 

--- a/crates/icm-core/src/time_fmt.rs
+++ b/crates/icm-core/src/time_fmt.rs
@@ -1,0 +1,55 @@
+//! Display-side timestamp formatting that respects the user's timezone.
+//!
+//! Storage stays in UTC (`DateTime<Utc>`) — that's the right canonical form
+//! for ordering, cross-machine comparison, and durable serialization. But
+//! when timestamps are shown to the user (CLI tables, MCP `icm_stats` /
+//! `icm_recall` output, dashboards), they should appear in the local
+//! timezone the user actually lives in. Issue #119 reported that all
+//! timestamps were rendered in UTC even when `TZ=Asia/Bangkok` was set.
+//!
+//! `chrono::Local` honours the `TZ` environment variable on Unix (via libc)
+//! and the system locale on Windows, so converting once here at the display
+//! boundary is enough.
+
+use chrono::{DateTime, Local, Utc};
+
+/// Format a UTC timestamp in the user's local timezone.
+///
+/// Pass any `chrono::format::strftime` pattern, e.g. `"%Y-%m-%d %H:%M"`.
+/// The output reflects `TZ` (Unix) or the system locale (Windows). For
+/// machine-readable output (JSON APIs, RFC 3339 in stored fields), keep
+/// using `to_rfc3339` on the UTC value directly — that path is unaffected.
+pub fn format_local(dt: &DateTime<Utc>, fmt: &str) -> String {
+    dt.with_timezone(&Local).format(fmt).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    /// Sanity: format_local must produce a non-empty string for any input.
+    #[test]
+    fn format_local_returns_non_empty() {
+        let utc = Utc.with_ymd_and_hms(2026, 5, 10, 12, 0, 0).unwrap();
+        let s = format_local(&utc, "%Y-%m-%d %H:%M");
+        assert!(!s.is_empty());
+        // Must look like a date-time of the requested shape.
+        assert!(
+            s.len() >= "2026-05-10 12:00".len(),
+            "expected date-time-shaped string, got {s:?}"
+        );
+    }
+
+    /// Issue #119: when TZ shifts the local clock, the formatted string
+    /// must change. We can't force chrono::Local to a specific TZ from
+    /// safe Rust without setting env vars (which is process-global), so
+    /// instead we round-trip through the same conversion chrono::Local
+    /// uses internally and assert the helper agrees with it.
+    #[test]
+    fn format_local_agrees_with_with_timezone_local() {
+        let utc = Utc.with_ymd_and_hms(2026, 5, 10, 12, 34, 56).unwrap();
+        let direct = utc.with_timezone(&Local).format("%H:%M:%S").to_string();
+        assert_eq!(format_local(&utc, "%H:%M:%S"), direct);
+    }
+}

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -2,10 +2,10 @@ use chrono::Utc;
 use serde_json::{json, Value};
 
 use icm_core::{
-    add_backrefs, auto_link_memory, build_wake_up, is_preference_topic, keyword_matches,
-    project_matches, topic_matches, AutoLinkOptions, Concept, ConceptLink, Embedder, Feedback,
-    FeedbackStore, Label, Memoir, MemoirStore, Memory, MemoryStore, Relation, WakeUpFormat,
-    WakeUpOptions, MSG_NO_MEMORIES,
+    add_backrefs, auto_link_memory, build_wake_up, format_local, is_preference_topic,
+    keyword_matches, project_matches, topic_matches, AutoLinkOptions, Concept, ConceptLink,
+    Embedder, Feedback, FeedbackStore, Label, Memoir, MemoirStore, Memory, MemoryStore, Relation,
+    WakeUpFormat, WakeUpOptions, MSG_NO_MEMORIES,
 };
 use icm_store::SqliteStore;
 
@@ -1410,10 +1410,16 @@ fn tool_stats(store: &SqliteStore) -> ToolResult {
                 stats.total_memories, stats.total_topics, stats.avg_weight
             );
             if let Some(oldest) = stats.oldest_memory {
-                output.push_str(&format!("Oldest: {}\n", oldest.format("%Y-%m-%d %H:%M")));
+                output.push_str(&format!(
+                    "Oldest: {}\n",
+                    format_local(&oldest, "%Y-%m-%d %H:%M")
+                ));
             }
             if let Some(newest) = stats.newest_memory {
-                output.push_str(&format!("Newest: {}\n", newest.format("%Y-%m-%d %H:%M")));
+                output.push_str(&format!(
+                    "Newest: {}\n",
+                    format_local(&newest, "%Y-%m-%d %H:%M")
+                ));
             }
             ToolResult::text(output)
         }


### PR DESCRIPTION
## Summary
Closes #119.

Storage stays in UTC (\`DateTime<Utc>\`) — that's the right canonical form for ordering and serialization. But every **user-facing** timestamp was also printed in UTC, even with \`TZ=Asia/Bangkok\` set, because the display sites called \`dt.format(...)\` directly on the UTC value.

## Fix
- New helper \`icm_core::format_local(dt, fmt)\` — wraps \`dt.with_timezone(&Local).format(fmt).to_string()\`. \`chrono::Local\` honours the \`TZ\` env var on Unix (via libc) and the system locale on Windows.
- Threaded through every display-side formatter:
  - **CLI (\`icm-cli\`)**: \`stats\`, \`show\`, \`recall\` hit ts, \`memoir show\`, \`concept show\`, \`transcript list/show/stats\` (~10 sites).
  - **MCP (\`icm_stats\` tool)**: oldest / newest.
- **Unchanged** (machine-readable, intentional): \`cloud.rs\` and \`web.rs\` keep \`to_rfc3339\` (UTC). API consumers parse offsets correctly; humans read the CLI.

## Smoke test on the release binary
\`\`\`
$ TZ=UTC                  icm stats | grep Oldest   # 2026-05-10 08:12
$ TZ=Asia/Bangkok         icm stats | grep Oldest   # 2026-05-10 15:12  (+7)
$ TZ=America/Los_Angeles  icm stats | grep Oldest   # 2026-05-10 01:12  (-7)
\`\`\`

## Test plan
- [x] 2 unit tests on \`format_local\` (non-empty, agrees with explicit \`with_timezone(&Local)\`)
- [x] Binary smoke test across 3 timezones (above)
- [x] \`cargo test --workspace\` — 409 passed, 4 ignored
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean

The TZ-shift correctness is asserted via the binary smoke test rather than a unit test because \`chrono::Local\` reads the env var once and Rust tests run in parallel — mutating \`TZ\` from inside one test would be racy with siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)