### PR TITLE
fix(opencode): inject recalled context via system.transform hook

### DIFF
--- a/plugins/opencode-icm.ts
+++ b/plugins/opencode-icm.ts
@@ -1,9 +1,16 @@
-// ICM auto-extraction plugin for OpenCode
+// ICM auto-extraction + auto-recall plugin for OpenCode
 // Installed by `icm init --mode hook`
 //
-// Layer 0: tool.execute.after → extract facts from tool output
-// Layer 1: experimental.session.compacting → extract from conversation before compaction
-// Layer 2: session.created → inject recalled context
+// Layer 0: tool.execute.after                       -> extract facts from tool output
+// Layer 1: experimental.session.compacting          -> extract from conversation before compaction
+// Layer 2: session.created                          -> log on session start (no API to inject from here)
+// Layer 3: experimental.chat.system.transform       -> inject recalled context into the system prompt
+//
+// Issue #169: the previous plugin only logged on session.created and never
+// actually injected anything into the conversation. OpenCode's hook API
+// exposes `experimental.chat.system.transform`, which lets us push extra
+// system-prompt strings before each model call — that's the correct place
+// to deliver recalled context into the agent's context window.
 
 import type { Plugin } from "@opencode-ai/plugin"
 import { execFileSync } from "child_process"
@@ -24,6 +31,22 @@ function icmExtract(args: string[], input: string): void {
   }
 }
 
+/// Capture stdout of `icm <args>` synchronously. Returns the empty string on
+/// any failure so a missing/old binary or empty memory store can never break
+/// a chat turn.
+function icmCapture(args: string[]): string {
+  try {
+    const out = execFileSync("icm", args, {
+      encoding: "utf-8",
+      timeout: 10000,
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    return String(out).trim()
+  } catch {
+    return ""
+  }
+}
+
 export const IcmPlugin: Plugin = async ({ $, directory }) => {
   const project = directory?.split("/").pop() || "project"
 
@@ -37,6 +60,11 @@ export const IcmPlugin: Plugin = async ({ $, directory }) => {
     console.warn("[icm] icm binary not found in PATH — plugin disabled")
     return {}
   }
+
+  // De-duplicate per-session to avoid re-injecting the same wake-up pack
+  // on every model turn. The transform hook fires per chat call; we only
+  // want context once at the start of each session.
+  const injectedSessions = new Set<string>()
 
   return {
     // Layer 0: extract facts from tool output every N calls
@@ -88,16 +116,40 @@ export const IcmPlugin: Plugin = async ({ $, directory }) => {
       }
     },
 
-    // Layer 2: recall context at session start
+    // Layer 2: log on session creation. OpenCode's `session.created` hook
+    // is observational — there is no API to inject context from here.
+    // Real injection happens in `experimental.chat.system.transform` below.
     "session.created": async () => {
-      try {
-        const result = await $`icm recall-context ${project} --limit 5`.quiet().nothrow()
-        const ctx = String(result.stdout).trim()
-        if (ctx) {
-          console.error(`[icm] recalled ${ctx.split("\n").length} lines of context`)
-        }
-      } catch {
-        // silent
+      console.error(`[icm] session ready, will inject project context on first chat turn`)
+    },
+
+    // Layer 3: inject recalled context into the system prompt.
+    //
+    // Issue #169: this is the hook the previous plugin was missing. It
+    // fires before each model call; we append the project's wake-up pack
+    // and a project-scoped recall to `output.system`, which OpenCode
+    // concatenates into the LLM's system prompt.
+    //
+    // Run only once per session (keyed by sessionID) so we don't re-inject
+    // the same context on every turn.
+    "experimental.chat.system.transform": async (input: any, output: any) => {
+      const sessionID = input?.sessionID ?? "no-session"
+      if (injectedSessions.has(sessionID)) return
+      injectedSessions.add(sessionID)
+
+      // Wake-up pack: critical/high-importance facts + preferences.
+      const wakeUp = icmCapture(["wake-up", "--project", project])
+      if (wakeUp) {
+        output.system.push(wakeUp)
+      }
+
+      // Project-scoped recall: top-N relevant memories for this project.
+      const ctx = icmCapture(["recall-project", "--limit", "5"])
+      if (ctx) {
+        output.system.push(ctx)
+        console.error(
+          `[icm] injected ${ctx.split("\n").length} lines of project context into system prompt`,
+        )
       }
     },
   }


### PR DESCRIPTION
## Summary
Closes #169.

The previous \`session.created\` handler only logged a debug line — it never actually delivered recalled memories into the session. OpenCode's \`session.created\` is observational; the API for context injection is **\`experimental.chat.system.transform\`**, which fires before each model call and lets a plugin push extra system-prompt strings.

## Fix
New **Layer 3** handler in the plugin that:

- Runs **once per session** (de-dup by sessionID so the wake-up doesn't re-inject on every chat turn).
- Captures \`icm wake-up --project <p>\` (critical/high facts + preferences) → pushes to \`output.system\`.
- Captures \`icm recall-project --limit 5\` (top project memories) → pushes to \`output.system\`.

Both calls are best-effort — a missing binary or empty memory store returns \"\" and silently no-ops.

## Why \`experimental.chat.system.transform\`
Verified against \`@opencode-ai/plugin@1.14.46\`:

\`\`\`ts
\"experimental.chat.system.transform\"?: (input: { sessionID?, model }, output: { system: string[] }) => Promise<void>
\`\`\`

This is the only hook that lets a plugin add to the system prompt. \`chat.params\` only modifies model parameters (temperature etc.), \`chat.message\` mutates the user message itself.

## Test plan
- [x] Smoke-tested both CLI commands the plugin shells out to (\`icm wake-up --project icm\`, \`icm recall-project --limit 3\`) — both produce non-empty stdout
- [x] \`tsc --strict\` against \`@opencode-ai/plugin@1.14.46\` — clean
- [x] \`cargo test --workspace\` — 423 passed (no Rust changes; verified suite still green)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] Other layers preserved: tool.execute.after extraction, experimental.session.compacting extraction, session.created log

🤖 Generated with [Claude Code](https://claude.com/claude-code)