### PR TITLE
fix(init): turn 7 init unwrap panics into proper error returns

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -3767,7 +3767,7 @@ fn inject_settings_hook(
     if let Some(m) = matcher {
         entry
             .as_object_mut()
-            .unwrap()
+            .expect("inline json! literal above is always Object")
             .insert("matcher".into(), serde_json::json!(m));
     }
     event_arr.push(entry);
@@ -3847,7 +3847,7 @@ fn inject_codex_hook(
     if let Some(m) = matcher {
         entry
             .as_object_mut()
-            .unwrap()
+            .expect("inline json! literal above is always Object")
             .insert("matcher".into(), serde_json::json!(m));
     }
     event_arr.push(entry);
@@ -4104,7 +4104,12 @@ fn inject_mcp_server(
 
     mcp_servers
         .as_object_mut()
-        .unwrap()
+        .with_context(|| {
+            format!(
+                "`{servers_key}` in {} is not a JSON object",
+                config_path.display()
+            )
+        })?
         .insert(name.to_string(), entry.clone());
 
     let output = serde_json::to_string_pretty(&config)?;
@@ -4143,7 +4148,12 @@ fn inject_zed_mcp_server(config_path: &Path, name: &str, bin_path: &str) -> Resu
 
     servers
         .as_object_mut()
-        .unwrap()
+        .with_context(|| {
+            format!(
+                "`context_servers` in {} is not a JSON object",
+                config_path.display()
+            )
+        })?
         .insert(name.to_string(), zed_entry);
 
     let output = serde_json::to_string_pretty(&config)?;
@@ -4181,15 +4191,23 @@ fn inject_copilot_cli_mcp_server(
         }
     }
 
-    servers.as_object_mut().unwrap().insert(
-        name.to_string(),
-        serde_json::json!({
-            "type": "local",
-            "command": icm_bin,
-            "args": ["serve"],
-            "tools": ["*"]
-        }),
-    );
+    servers
+        .as_object_mut()
+        .with_context(|| {
+            format!(
+                "`mcpServers` in {} is not a JSON object",
+                config_path.display()
+            )
+        })?
+        .insert(
+            name.to_string(),
+            serde_json::json!({
+                "type": "local",
+                "command": icm_bin,
+                "args": ["serve"],
+                "tools": ["*"]
+            }),
+        );
 
     let output = serde_json::to_string_pretty(&config)?;
     std::fs::write(config_path, output)
@@ -4356,7 +4374,12 @@ fn inject_codex_mcp_server(config_path: &Path, name: &str, icm_bin: &str) -> Res
 
     mcp_servers
         .as_table_mut()
-        .unwrap()
+        .with_context(|| {
+            format!(
+                "`mcp_servers` in {} is not a TOML table",
+                config_path.display()
+            )
+        })?
         .insert(name.to_string(), toml::Value::Table(server));
 
     let output = toml::to_string_pretty(&config)?;
@@ -4391,14 +4414,16 @@ fn inject_opencode_mcp_server(config_path: &Path, name: &str, icm_bin: &str) -> 
         }
     }
 
-    mcp.as_object_mut().unwrap().insert(
-        name.to_string(),
-        serde_json::json!({
-            "type": "local",
-            "command": [icm_bin, "serve"],
-            "enabled": true
-        }),
-    );
+    mcp.as_object_mut()
+        .with_context(|| format!("`mcp` in {} is not a JSON object", config_path.display()))?
+        .insert(
+            name.to_string(),
+            serde_json::json!({
+                "type": "local",
+                "command": [icm_bin, "serve"],
+                "enabled": true
+            }),
+        );
 
     let output = serde_json::to_string_pretty(&config)?;
     std::fs::write(config_path, output)


### PR DESCRIPTION
## Summary
Audit follow-up to #212. Every MCP-server / hook injector ended its writer chain with \`.as_object_mut().unwrap()\` (or \`.as_table_mut().unwrap()\`).

**5 of those operate on values pulled out of the user's settings/config files** via \`entry().or_insert_with(json!({}))\`. The default only kicks in when the key is absent — if the user has \`\"mcpServers\": \"string\"\`, \`\"mcpServers\": [array]\`, or any non-object shape, \`entry()\` hands back the existing value, \`as_object_mut()\` returns \`None\`, and \`icm init\` panics with the bare Rust thread-panic message instead of a useful error.

## Fix
- 5 user-config sites get \`.with_context(|| format!(\"\\\`<key>\\\` in <path> is not a JSON object\"))?\`. Errors now point at the exact file and key the user needs to fix.
- 2 sites operate on inline \`serde_json::json!({...})\` literals (always \`Value::Object\` by construction) → switched to \`.expect(\"…\")\` with a one-line justification so clippy can't flag them as user-input panics.

| Site | Before | After |
|---|---|---|
| \`inject_codex_mcp_server\` (mcp_servers / TOML) | \`unwrap\` | error w/ path |
| \`inject_zed_mcp_server\` (context_servers) | \`unwrap\` | error w/ path |
| \`inject_copilot_cli_mcp_server\` (mcpServers) | \`unwrap\` | error w/ path |
| \`inject_opencode_mcp_server\` (mcp) | \`unwrap\` | error w/ path |
| Generic mcp_servers writer (lines ~4080) | \`unwrap\` | error w/ path |
| \`inject_settings_hook\` (entry literal) | \`unwrap\` | \`expect\` |
| \`inject_codex_hook\` (entry literal) | \`unwrap\` | \`expect\` |

## Test plan
- [x] \`cargo test --workspace\` — 430 passed, 4 ignored (no behavior change on healthy configs)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)