### PR TITLE
ci: add Next Release tracking PR + auto back-merge after release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -148,3 +148,52 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -fa latest -m "Latest stable release (${{ needs.release-please.outputs.tag_name }})"
           git push origin latest --force
+
+  # ═══════════════════════════════════════════════
+  # POST-RELEASE: back-merge release commits to develop
+  # ═══════════════════════════════════════════════
+  #
+  # release-please commits (version bumps + CHANGELOG) land only on main, so
+  # develop falls one commit behind on every release. Without this job the
+  # drift accumulates and the next develop -> main PR carries no-op churn.
+  back-merge-develop:
+    name: Back-merge main into develop
+    needs: [release-please, build-release]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Open back-merge PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="chore/back-merge-main-${TAG}"
+          git checkout -b "$BRANCH"
+
+          # Fast-forward when possible (release-please commits are linear on
+          # top of develop); fall back to a merge commit if develop diverged.
+          if ! git merge origin/main --ff-only 2>/dev/null; then
+            git merge origin/main --no-edit \
+              -m "chore: back-merge main into develop (${TAG})"
+          fi
+
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --base develop \
+            --head "$BRANCH" \
+            --title "chore: sync release ${TAG} into develop" \
+            --body "Automated back-merge of release-please commits from \`main\` into \`develop\` so the next \`develop -> main\` PR stays free of release-commit drift." \
+            --label "automated"

--- a/.github/workflows/next-release.yml
+++ b/.github/workflows/next-release.yml
@@ -1,0 +1,126 @@
+name: Update Next Release PR
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update-next-release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Next Release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REPO: ${{ github.repository }}
+          ALLOWED_REPOS: "rtk-ai/icm"
+        run: |
+          set -euo pipefail
+
+          URL_PATTERN=""
+          for repo in $ALLOWED_REPOS; do
+            URL_PATTERN="${URL_PATTERN}|https://github\\.com/${repo}/issues/[0-9]+"
+          done
+          URL_PATTERN="${URL_PATTERN#|}"
+
+          if printf '%s' "$PR_TITLE" | grep -qiE '^feat'; then
+            SECTION="Feats"
+          elif printf '%s' "$PR_TITLE" | grep -qiE '^fix'; then
+            SECTION="Fix"
+          else
+            SECTION="Other"
+          fi
+
+          ISSUE_REFS=""
+          if [ -n "$PR_BODY" ]; then
+            ISSUE_REFS=$(echo "$PR_BODY" \
+              | grep -oiE "(closes|fixes|resolves):?\s+#[0-9]+|${URL_PATTERN}" \
+              | grep -oE '#[0-9]+|issues/[0-9]+' \
+              | sed 's|issues/|#|' \
+              | sort -u \
+              || true)
+          fi
+
+          ENTRY="- ${PR_TITLE} [#${PR_NUMBER}](${PR_URL})"
+          if [ -n "$ISSUE_REFS" ]; then
+            CLOSES_PARTS=""
+            while IFS= read -r ref; do
+              [ -z "$ref" ] && continue
+              NUM="${ref#\#}"
+              ISSUE_URL="https://github.com/${REPO}/issues/${NUM}"
+              if [ -n "$CLOSES_PARTS" ]; then
+                CLOSES_PARTS="${CLOSES_PARTS}, [${ref}](${ISSUE_URL}) (to verify)"
+              else
+                CLOSES_PARTS="Closes [${ref}](${ISSUE_URL}) (to verify)"
+              fi
+            done <<< "$ISSUE_REFS"
+            ENTRY="${ENTRY} — ${CLOSES_PARTS}"
+          fi
+
+          NEXT_PR=$(gh pr list \
+            --repo "$REPO" \
+            --label next-release \
+            --base main \
+            --head develop \
+            --state open \
+            --json number,body \
+            --jq '.[0] // empty')
+
+          NEXT_PR_NUMBER=""
+          if [ -n "$NEXT_PR" ]; then
+            NEXT_PR_NUMBER=$(echo "$NEXT_PR" | jq -r '.number')
+          fi
+
+          if [ -z "$NEXT_PR_NUMBER" ]; then
+            TEMPLATE="### Feats
+
+          ### Fix
+
+          ### Other"
+
+            PR_CREATE_URL=$(gh pr create \
+              --repo "$REPO" \
+              --base main \
+              --head develop \
+              --title "Next Release" \
+              --label next-release \
+              --body "$TEMPLATE")
+
+            NEXT_PR_NUMBER=$(echo "$PR_CREATE_URL" | grep -oE '/pull/[0-9]+' | grep -oE '[0-9]+')
+            CURRENT_BODY="$TEMPLATE"
+          else
+            CURRENT_BODY=$(echo "$NEXT_PR" | jq -r '.body')
+          fi
+
+          SECTION_HEADER="### ${SECTION}"
+          export ENTRY
+          if echo "$CURRENT_BODY" | grep -qF "$SECTION_HEADER"; then
+            UPDATED_BODY=$(echo "$CURRENT_BODY" | awk -v section="$SECTION_HEADER" '
+              $0 == section {
+                print
+                print ENVIRON["ENTRY"]
+                next
+              }
+              { print }
+            ')
+          else
+            UPDATED_BODY="${CURRENT_BODY}
+
+          ${SECTION_HEADER}
+          ${ENTRY}"
+          fi
+
+          gh pr edit "$NEXT_PR_NUMBER" \
+            --repo "$REPO" \
+            --body "$UPDATED_BODY"
+
+          echo "Updated Next Release PR #${NEXT_PR_NUMBER} — added entry to ### ${SECTION}"


### PR DESCRIPTION
## Summary
Mirrors the rtk-ai/rtk CI/CD pattern with two additions to ours:

1. **`next-release.yml`** (copied from rtk-ai/rtk, adapted to `main`) — on every PR merged into `develop`, updates a persistent "Next Release" PR (label `next-release`, base `main`, head `develop`) with the merged PR sorted under **Feats / Fix / Other**. Gives a continuously up-to-date preview of what ships next.
2. **`back-merge-develop` job in `cd.yml`** — after every successful release-please release on `main`, opens a PR `chore/back-merge-main-<tag>` against `develop` so the release commits (CHANGELOG + version bump) flow back automatically. Without this, `develop` drifts behind on every release (it was 7 commits behind before this session's manual sync).

## Post-merge step
Create the label so `next-release.yml` doesn't fail on first run:
\`\`\`bash
gh label create next-release --color BFD4F2 \
  --description "Tracks PRs queued for the next stable release"
\`\`\`

## Test plan
- [ ] Merge into \`develop\`, verify the \`next-release\` workflow opens the persistent "Next Release" PR
- [ ] On the next release cycle, verify \`back-merge-develop\` opens a PR automatically after the release-please PR is merged