### PR TITLE
ci: mint a GitHub App token for PR-creating workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -165,15 +165,23 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # GITHUB_TOKEN is blocked by the rtk-ai enterprise policy from
+      # creating PRs, so mint a token from the rtk-ai-icm-ci GitHub App.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: develop
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Open back-merge PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/next-release.yml
+++ b/.github/workflows/next-release.yml
@@ -14,9 +14,17 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      # GITHUB_TOKEN is blocked by the rtk-ai enterprise policy from
+      # creating PRs, so mint a token from the rtk-ai-icm-ci GitHub App.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Update Next Release PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Follow-up to #225 — switch the PR-creating workflows to use a token minted via \`actions/create-github-app-token@v3\` instead of the default token, since the default lacks the required permission to create PRs in this org.