### PR TITLE
fix(ci): generalize comments in PR-creating workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -165,8 +165,8 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      # GITHUB_TOKEN is blocked by the rtk-ai enterprise policy from
-      # creating PRs, so mint a token from the rtk-ai-icm-ci GitHub App.
+      # The default workflow token cannot open PRs in this org; mint a
+      # short-lived token from the configured GitHub App instead.
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:

--- a/.github/workflows/next-release.yml
+++ b/.github/workflows/next-release.yml
@@ -14,8 +14,8 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      # GITHUB_TOKEN is blocked by the rtk-ai enterprise policy from
-      # creating PRs, so mint a token from the rtk-ai-icm-ci GitHub App.
+      # The default workflow token cannot open PRs in this org; mint a
+      # short-lived token from the configured GitHub App instead.
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:


### PR DESCRIPTION
Replace the inline comments added in the previous PRs with a more generic description, so the workflow source doesn't expose internals.