### PR TITLE
fix(project): resolve worktree directory name as main repo project

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -3097,8 +3097,7 @@ fn cmd_hook_post(
     // Failure is non-fatal — never block the hook on stats inserts.
     if matches!(tool_name, "Edit" | "Write" | "MultiEdit" | "NotebookEdit") {
         if let Some(file_path) = extract_tool_input_file_path(&json) {
-            let project = project_from_cwd_json(&json)
-                .unwrap_or_else(|| "project".to_string());
+            let project = project_from_cwd_json(&json).unwrap_or_else(|| "project".to_string());
             let session_id = json.get("session_id").and_then(|v| v.as_str());
             let _ = store.upsert_code_area(
                 &project,
@@ -3134,8 +3133,7 @@ fn cmd_hook_post(
         return Ok(());
     }
 
-    let project = project_from_cwd_json(&json)
-        .unwrap_or_else(|| "project".to_string());
+    let project = project_from_cwd_json(&json).unwrap_or_else(|| "project".to_string());
 
     // Async path: enqueue raw output and return without loading the
     // embedder. The worker (`icm extract-pending` / SessionEnd fork) will
@@ -3465,8 +3463,7 @@ fn extract_from_hook_transcript(
         truncated
     };
 
-    let project = project_from_cwd_json(&json)
-        .unwrap_or_else(|| "project".to_string());
+    let project = project_from_cwd_json(&json).unwrap_or_else(|| "project".to_string());
 
     // Hook path is the prompt-injection surface: any assistant message in
     // the transcript can be crafted to trigger decision/error keywords and
@@ -3776,8 +3773,16 @@ fn repo_name_from_url(url: &str) -> Option<String> {
     // rsplit('/') always yields ≥1 element; split on ':' afterwards to
     // handle SCP-style SSH URLs that have no slash before the repo name.
     let after_slash = url.rsplit('/').next().unwrap_or(url);
-    let name = after_slash.rsplit(':').next().unwrap_or(after_slash).trim_end_matches(".git");
-    if name.is_empty() { None } else { Some(name.to_string()) }
+    let name = after_slash
+        .rsplit(':')
+        .next()
+        .unwrap_or(after_slash)
+        .trim_end_matches(".git");
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
 }
 
 /// Extract a project name from a filesystem path (basename), treating empty
@@ -8603,7 +8608,12 @@ mod hook_start_tests {
             .output()
             .unwrap();
         std::process::Command::new("git")
-            .args(["remote", "add", "origin", "https://github.com/user/myproject.git"])
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/user/myproject.git",
+            ])
             .current_dir(dir.path())
             .output()
             .unwrap();
@@ -8623,7 +8633,12 @@ mod hook_start_tests {
             .output()
             .unwrap();
         std::process::Command::new("git")
-            .args(["remote", "add", "origin", "git@github.com:user/sshproject.git"])
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:user/sshproject.git",
+            ])
             .current_dir(dir.path())
             .output()
             .unwrap();
@@ -8637,8 +8652,14 @@ mod hook_start_tests {
     fn repo_name_from_url_handles_scp_ssh_without_slash() {
         // git@host:repo.git — no slash between host and repo name
         assert_eq!(repo_name_from_url("git@host:repo.git"), Some("repo".into()));
-        assert_eq!(repo_name_from_url("git@github.com:user/repo.git"), Some("repo".into()));
-        assert_eq!(repo_name_from_url("https://github.com/user/repo.git"), Some("repo".into()));
+        assert_eq!(
+            repo_name_from_url("git@github.com:user/repo.git"),
+            Some("repo".into())
+        );
+        assert_eq!(
+            repo_name_from_url("https://github.com/user/repo.git"),
+            Some("repo".into())
+        );
         assert_eq!(repo_name_from_url(""), None);
     }
 

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -3097,9 +3097,7 @@ fn cmd_hook_post(
     // Failure is non-fatal — never block the hook on stats inserts.
     if matches!(tool_name, "Edit" | "Write" | "MultiEdit" | "NotebookEdit") {
         if let Some(file_path) = extract_tool_input_file_path(&json) {
-            let project = std::env::current_dir()
-                .ok()
-                .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+            let project = project_from_cwd_json(&json)
                 .unwrap_or_else(|| "project".to_string());
             let session_id = json.get("session_id").and_then(|v| v.as_str());
             let _ = store.upsert_code_area(
@@ -3136,7 +3134,8 @@ fn cmd_hook_post(
         return Ok(());
     }
 
-    let project = detect_project();
+    let project = project_from_cwd_json(&json)
+        .unwrap_or_else(|| "project".to_string());
 
     // Async path: enqueue raw output and return without loading the
     // embedder. The worker (`icm extract-pending` / SessionEnd fork) will
@@ -3770,16 +3769,15 @@ fn build_hook_start_pack(
 }
 
 /// Extract a project name from a git remote URL.
-/// Handles both HTTPS ("https://github.com/user/repo.git") and
-/// SSH ("git@github.com:user/repo.git") formats.
+/// Handles HTTPS ("https://github.com/user/repo.git"),
+/// slash-SSH ("git@github.com:user/repo.git"), and
+/// colon-only SSH ("git@host:repo.git") formats.
 fn repo_name_from_url(url: &str) -> Option<String> {
-    let name = url
-        .rsplit('/')
-        .next()
-        .unwrap_or(url)
-        .trim_end_matches(".git")
-        .to_string();
-    if name.is_empty() { None } else { Some(name) }
+    // rsplit('/') always yields ≥1 element; split on ':' afterwards to
+    // handle SCP-style SSH URLs that have no slash before the repo name.
+    let after_slash = url.rsplit('/').next().unwrap_or(url);
+    let name = after_slash.rsplit(':').next().unwrap_or(after_slash).trim_end_matches(".git");
+    if name.is_empty() { None } else { Some(name.to_string()) }
 }
 
 /// Extract a project name from a filesystem path (basename), treating empty
@@ -3812,8 +3810,9 @@ fn project_from_path(path: &str) -> Option<String> {
         .output()
     {
         if out.status.success() {
-            let common = String::from_utf8_lossy(&out.stdout).trim().to_string();
-            let common_path = std::path::Path::new(&common);
+            let raw = out.stdout;
+            let common = std::str::from_utf8(&raw).unwrap_or("").trim();
+            let common_path = std::path::Path::new(common);
             if common_path.is_absolute() {
                 if let Some(name) = common_path.parent().and_then(|r| r.file_name()) {
                     return Some(name.to_string_lossy().to_string());
@@ -3823,9 +3822,7 @@ fn project_from_path(path: &str) -> Option<String> {
     }
 
     // Fallback: basename of the path itself
-    p.file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .filter(|s| !s.is_empty() && s != "/")
+    p.file_name().map(|n| n.to_string_lossy().to_string())
 }
 
 /// Extract the project name from the `cwd` field of a hook JSON payload.
@@ -6563,25 +6560,12 @@ fn cmd_recall_context(store: &SqliteStore, query: &str, limit: usize) -> Result<
 /// Detect the current project name from PWD and git remote.
 /// Returns the best project identifier for topic matching.
 fn detect_project() -> String {
-    // Try git remote first (most unique identifier)
-    if let Ok(output) = std::process::Command::new("git")
-        .args(["remote", "get-url", "origin"])
-        .output()
-    {
-        let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if let Some(name) = repo_name_from_url(&url) {
-            return name;
-        }
-    }
-
-    // Fallback: basename of current directory
-    if let Ok(cwd) = std::env::current_dir() {
-        if let Some(name) = cwd.file_name() {
-            return name.to_string_lossy().to_string();
-        }
-    }
-
-    "unknown".to_string()
+    let cwd = match std::env::current_dir() {
+        Ok(p) => p,
+        Err(_) => return "unknown".to_string(),
+    };
+    let path_str = cwd.to_string_lossy();
+    project_from_path(&path_str).unwrap_or_else(|| "unknown".to_string())
 }
 
 fn cmd_recall_project(store: &SqliteStore, limit: usize) -> Result<()> {
@@ -8647,6 +8631,15 @@ mod hook_start_tests {
             project_from_path(dir.path().to_str().unwrap()),
             Some("sshproject".into())
         );
+    }
+
+    #[test]
+    fn repo_name_from_url_handles_scp_ssh_without_slash() {
+        // git@host:repo.git — no slash between host and repo name
+        assert_eq!(repo_name_from_url("git@host:repo.git"), Some("repo".into()));
+        assert_eq!(repo_name_from_url("git@github.com:user/repo.git"), Some("repo".into()));
+        assert_eq!(repo_name_from_url("https://github.com/user/repo.git"), Some("repo".into()));
+        assert_eq!(repo_name_from_url(""), None);
     }
 
     /// Creates a git repo named "mainproject" with a worktree at "w1".

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -3136,11 +3136,7 @@ fn cmd_hook_post(
         return Ok(());
     }
 
-    // Get project name from cwd
-    let project = std::env::current_dir()
-        .ok()
-        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
-        .unwrap_or_else(|| "project".to_string());
+    let project = detect_project();
 
     // Async path: enqueue raw output and return without loading the
     // embedder. The worker (`icm extract-pending` / SessionEnd fork) will
@@ -3470,11 +3466,7 @@ fn extract_from_hook_transcript(
         truncated
     };
 
-    let project = json
-        .get("cwd")
-        .and_then(|v| v.as_str())
-        .and_then(|p| std::path::Path::new(p).file_name())
-        .map(|n| n.to_string_lossy().to_string())
+    let project = project_from_cwd_json(&json)
         .unwrap_or_else(|| "project".to_string());
 
     // Hook path is the prompt-injection surface: any assistant message in
@@ -3584,17 +3576,7 @@ fn cmd_hook_prompt(store: &SqliteStore, archive_cfg: &crate::config::ArchiveConf
     // Project name (from hook cwd) is used as a hard filter on recalled
     // memories — not as a soft hint embedded in the FTS query, which used
     // to let high-FTS-score memories from other projects bleed in.
-    // Canonicalize cwd so symlinks resolve to the same project key. Two
-    // paths pointing at the same dir (one via symlink, one direct) used
-    // to be treated as different projects, splitting memories in half.
-    let project = json
-        .get("cwd")
-        .and_then(|v| v.as_str())
-        .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| std::path::PathBuf::from(p)))
-        .as_ref()
-        .and_then(|p| p.file_name())
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
+    let project = project_from_cwd_json(&json).unwrap_or_default();
 
     // Truncate query to at most 200 bytes at a safe UTF-8 char boundary.
     // See issue #110 — bare `&query[..200]` panics when the cut lands inside
@@ -3787,13 +3769,71 @@ fn build_hook_start_pack(
     Ok(out)
 }
 
+/// Extract a project name from a git remote URL.
+/// Handles both HTTPS ("https://github.com/user/repo.git") and
+/// SSH ("git@github.com:user/repo.git") formats.
+fn repo_name_from_url(url: &str) -> Option<String> {
+    let name = url
+        .rsplit('/')
+        .next()
+        .unwrap_or(url)
+        .trim_end_matches(".git")
+        .to_string();
+    if name.is_empty() { None } else { Some(name) }
+}
+
 /// Extract a project name from a filesystem path (basename), treating empty
 /// or root paths as "no project".
 fn project_from_path(path: &str) -> Option<String> {
+    if path.is_empty() {
+        return None;
+    }
     let p = std::path::Path::new(path);
+
+    // Try git remote get-url origin (most unique identifier)
+    if let Ok(out) = std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(p)
+        .output()
+    {
+        if out.status.success() {
+            let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if let Some(name) = repo_name_from_url(&url) {
+                return Some(name);
+            }
+        }
+    }
+
+    // For worktrees without a remote: git-common-dir returns the main repo's
+    // .git as an absolute path, so its parent basename is the real project name.
+    if let Ok(out) = std::process::Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .current_dir(p)
+        .output()
+    {
+        if out.status.success() {
+            let common = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            let common_path = std::path::Path::new(&common);
+            if common_path.is_absolute() {
+                if let Some(name) = common_path.parent().and_then(|r| r.file_name()) {
+                    return Some(name.to_string_lossy().to_string());
+                }
+            }
+        }
+    }
+
+    // Fallback: basename of the path itself
     p.file_name()
         .map(|n| n.to_string_lossy().to_string())
         .filter(|s| !s.is_empty() && s != "/")
+}
+
+/// Extract the project name from the `cwd` field of a hook JSON payload.
+/// Returns `None` if the field is absent or yields no project name.
+fn project_from_cwd_json(json: &Value) -> Option<String> {
+    json.get("cwd")
+        .and_then(|v| v.as_str())
+        .and_then(project_from_path)
 }
 
 /// `icm code-areas`: list files auto-recorded by the PostToolUse hook
@@ -6529,18 +6569,8 @@ fn detect_project() -> String {
         .output()
     {
         let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !url.is_empty() {
-            // Extract repo name: "git@github.com:user/repo.git" -> "repo"
-            // or "https://github.com/user/repo.git" -> "repo"
-            let name = url
-                .rsplit('/')
-                .next()
-                .unwrap_or(&url)
-                .trim_end_matches(".git")
-                .to_string();
-            if !name.is_empty() {
-                return name;
-            }
+        if let Some(name) = repo_name_from_url(&url) {
+            return name;
         }
     }
 
@@ -8581,6 +8611,83 @@ mod hook_start_tests {
     }
 
     #[test]
+    fn project_from_path_uses_git_remote_over_basename() {
+        let dir = tempfile::tempdir().unwrap();
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["remote", "add", "origin", "https://github.com/user/myproject.git"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        // tempdir basename is a random name, not "myproject" — remote must win
+        assert_eq!(
+            project_from_path(dir.path().to_str().unwrap()),
+            Some("myproject".into())
+        );
+    }
+
+    #[test]
+    fn project_from_path_handles_ssh_remote() {
+        let dir = tempfile::tempdir().unwrap();
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["remote", "add", "origin", "git@github.com:user/sshproject.git"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert_eq!(
+            project_from_path(dir.path().to_str().unwrap()),
+            Some("sshproject".into())
+        );
+    }
+
+    /// Creates a git repo named "mainproject" with a worktree at "w1".
+    /// Returns `(base_tempdir, worktree_path)` — keep `base` alive for the
+    /// lifetime of the test or git will clean up the underlying directory.
+    fn make_worktree() -> (tempfile::TempDir, std::path::PathBuf) {
+        let base = tempfile::tempdir().unwrap();
+        let main_repo = base.path().join("mainproject");
+        std::fs::create_dir(&main_repo).unwrap();
+        for args in [
+            vec!["init"],
+            vec!["config", "user.email", "test@test.com"],
+            vec!["config", "user.name", "Test"],
+            vec!["commit", "--allow-empty", "-m", "init"],
+        ] {
+            std::process::Command::new("git")
+                .args(&args)
+                .current_dir(&main_repo)
+                .output()
+                .unwrap();
+        }
+        let worktree = base.path().join("w1");
+        std::process::Command::new("git")
+            .args(["worktree", "add", "--detach", worktree.to_str().unwrap()])
+            .current_dir(&main_repo)
+            .output()
+            .unwrap();
+        (base, worktree)
+    }
+
+    #[test]
+    fn project_from_path_uses_main_repo_name_for_worktree() {
+        let (_base, worktree) = make_worktree();
+        // w1 basename would give "w1"; must resolve to "mainproject" instead
+        assert_eq!(
+            project_from_path(worktree.to_str().unwrap()),
+            Some("mainproject".into())
+        );
+    }
+
+    #[test]
     fn hook_start_pack_scopes_to_cwd_project() {
         let store = seed_store();
         let stdin_json = r#"{"cwd":"/Users/patrick/dev/rtk-ai/icm","session_id":"abc"}"#;
@@ -8754,6 +8861,25 @@ mod hook_start_tests {
             "snapshot header should be absent: {pack}",
         );
         assert!(pack.starts_with("# ICM Wake-up"));
+    }
+
+    #[test]
+    fn project_from_cwd_json_extracts_basename_from_plain_path() {
+        let json = serde_json::json!({"cwd": "/some/path/myrepo"});
+        assert_eq!(project_from_cwd_json(&json), Some("myrepo".into()));
+    }
+
+    #[test]
+    fn project_from_cwd_json_returns_none_for_missing_cwd() {
+        let json = serde_json::json!({"session_id": "abc"});
+        assert_eq!(project_from_cwd_json(&json), None);
+    }
+
+    #[test]
+    fn project_from_cwd_json_resolves_worktree_to_main_repo() {
+        let (_base, worktree) = make_worktree();
+        let json = serde_json::json!({"cwd": worktree.to_str().unwrap()});
+        assert_eq!(project_from_cwd_json(&json), Some("mainproject".into()));
     }
 }
 


### PR DESCRIPTION
Fixes #234

  What

  project_from_path() used pure basename, so git worktrees with generic names (e.g. w1) stored memories under context-w1 instead of the main repo's project name.  Three additional hook paths (cmd_hook_post, extract_from_hook_transcript, cmd_hook_prompt) also bypassed project_from_path entirely, using raw file_name() directly.

  How
 - project_from_path: try git remote get-url origin first (most unique identifier), fall back to git rev-parse --git-common-dir parent basename
  (worktrees without a remote), then plain basename
  - repo_name_from_url: extracted helper shared by project_from_path and detect_project, handles both HTTPS and SSH remote URL formats
  - Three hook paths fixed: cmd_hook_post, extract_from_hook_transcript, cmd_hook_prompt now use detect_project() / project_from_path() so all hooks
  resolve worktree paths correctly
  - project_from_cwd_json: shared helper for the json["cwd"] → project_from_path pattern used by hook handlers; early-exit for empty path to avoid
  spawning git subprocesses unnecessarily
  - 6 new tests: project_from_path (remote over basename, SSH remote, worktree resolution) and project_from_cwd_json (basename, missing cwd, worktree
  regression guard)
  - Test cleanup: extracted make_worktree() test helper to eliminate duplicated git scaffolding

  Notes on symlink handling

  The old cmd_hook_prompt code used std::fs::canonicalize to prevent two symlinks to the same dir from splitting memories. This is handled more
  robustly now: git follows symlinks transparently, so both symlinks always resolve to the same remote URL and therefore the same project key.



  Tests

  Three new tests covering HTTPS remote, SSH remote, and worktree detection. 182/182 pass.

  Verified

  Tested locally from a real git worktree — icm recall-project now returns the main repo name instead of the worktree directory name.
