### PR TITLE
fix: sync icm-cli version in Cargo.lock (0.10.42 → 0.10.49)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.42"
+version = "0.10.49"
 dependencies = [
  "anyhow",
  "axum",


### PR DESCRIPTION
This keeps wanting to update every time `cargo` is ran.