### PR TITLE
fix(extraction): defer fastembed extraction off the per-tool-call hot path

### DIFF
--- a/crates/icm-cli/src/config.rs
+++ b/crates/icm-cli/src/config.rs
@@ -86,8 +86,10 @@ pub struct ExtractionConfig {
     /// the configured LLM CLI. See `icm extract-pending` and the
     /// SessionEnd async trigger.
     ///
-    /// `provider = "none"` (default) keeps the existing inline fastembed
-    /// behavior so this feature is fully opt-in and zero-regression.
+    /// Defaults to `auto`: ICM detects an installed LLM CLI and uses the
+    /// async queue path. With no CLI installed, `extract-pending` drains
+    /// via a batched fastembed pass. Set `provider = "none"` explicitly
+    /// to force the legacy per-fire inline fastembed behavior.
     pub summarizer: SummarizerConfig,
 }
 
@@ -235,8 +237,15 @@ impl Default for ExtractionConfig {
             max_facts: 20,
             extract_every: 3,
             store_raw: true,
-            // Default = none → inline fastembed path, no behavior change.
-            summarizer: SummarizerConfig::default(),
+            // Default = auto: detect an installed LLM CLI and route
+            // extraction through the #219 async queue (~50ms hooks, no
+            // fastembed load). `extract-pending` falls back to a batched
+            // fastembed drain when no CLI is found. Shipping `none` here
+            // left every default install on the heavy inline path (#239).
+            summarizer: SummarizerConfig {
+                provider: "auto".into(),
+                ..SummarizerConfig::default()
+            },
         }
     }
 }

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -4845,6 +4845,34 @@ fn resolve_consolidate_provider(
     })
 }
 
+/// Check whether `name` resolves to an executable file on `$PATH`.
+///
+/// Used by the extraction drain to decide whether a configured LLM CLI
+/// (claude/codex/gemini/ollama) is actually usable, or whether it should
+/// fall back to the fastembed extractor.
+fn cli_on_path(name: &str) -> bool {
+    let Ok(path) = std::env::var("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| {
+        let candidate = dir.join(name);
+        if !candidate.is_file() {
+            return false;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::metadata(&candidate)
+                .map(|m| m.permissions().mode() & 0o111 != 0)
+                .unwrap_or(false)
+        }
+        #[cfg(not(unix))]
+        {
+            true
+        }
+    })
+}
+
 /// Process the async extraction queue.
 ///
 /// Reads up to `limit` oldest pending rows from `pending_extractions`.
@@ -4854,11 +4882,11 @@ fn resolve_consolidate_provider(
 /// preferences, parses the bullet response, and stores the results as
 /// Memory rows.
 ///
-/// With `provider = "none"` (the default), it falls back to the inline
-/// fastembed extractor — but runs it **once** over the whole drained
-/// batch instead of once per hook fire. That is the deferred half of
-/// the issue #239 fix: editor hooks enqueue cheaply, and the heavy
-/// model load happens here, once per drain.
+/// With `provider = "none"`, or when the resolved CLI is not installed,
+/// it falls back to the fastembed extractor — but runs it **once** over
+/// the whole drained batch instead of once per hook fire. That is the
+/// deferred half of the issue #239 fix: editor hooks enqueue cheaply,
+/// and the heavy model load happens here, once per drain.
 ///
 /// Successfully-processed rows are deleted from the queue regardless of
 /// whether facts were extracted (so an output with no extractable
@@ -4879,9 +4907,24 @@ fn cmd_extract_pending(
         return Ok(());
     }
 
-    let provider_kind = resolve_consolidate_provider(cfg, cli_provider)?;
+    let mut provider_kind = resolve_consolidate_provider(cfg, cli_provider)?;
+    // `auto` always resolves to a concrete CLI provider (Claude is the
+    // ultimate fallback in `detect_provider`). If that CLI is not actually
+    // on PATH, the LLM drain would fail on every run and the queue would
+    // never empty — so downgrade to the batched fastembed path when the
+    // binary is missing.
+    if !matches!(provider_kind, summarizer::ProviderKind::None)
+        && !cli_on_path(provider_kind.as_str())
+    {
+        eprintln!(
+            "[extract-pending] '{}' CLI not found on PATH — draining with \
+             the fastembed extractor instead",
+            provider_kind.as_str()
+        );
+        provider_kind = summarizer::ProviderKind::None;
+    }
     if matches!(provider_kind, summarizer::ProviderKind::None) {
-        // No LLM configured — drain with the fastembed extractor. The
+        // No usable LLM CLI — drain with the fastembed extractor. The
         // model loads once for this whole batch, instead of once per
         // tool call as the pre-#239 hook path did.
         let ids: Vec<String> = pending.iter().map(|(id, ..)| id.clone()).collect();

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -332,6 +332,14 @@ enum Commands {
         /// Store raw text as low-importance memory when no facts are extracted
         #[arg(long)]
         store_raw: bool,
+
+        /// Queue the raw text for deferred extraction instead of running
+        /// the embedder inline. ~50ms, no model load — drain later with
+        /// `icm extract-pending`. Editor hooks use this so the fastembed
+        /// model is loaded once per drain instead of once per tool call
+        /// (issue #239: CPU/RAM spikes on every read).
+        #[arg(long)]
+        enqueue: bool,
     },
 
     /// Import conversations from external sources (Claude.ai, ChatGPT, Claude Code, Slack, text)
@@ -1227,14 +1235,18 @@ fn main() -> Result<()> {
             provider,
             model,
             dry_run,
-        } => cmd_extract_pending(
-            &store,
-            &cfg.extraction.summarizer,
-            limit,
-            provider.as_deref(),
-            model.as_deref(),
-            dry_run,
-        ),
+        } => {
+            let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
+            cmd_extract_pending(
+                &store,
+                emb_ref,
+                &cfg.extraction.summarizer,
+                limit,
+                provider.as_deref(),
+                model.as_deref(),
+                dry_run,
+            )
+        }
         Commands::Decay { factor } => cmd_decay(&store, factor),
         Commands::Prune { threshold, dry_run } => cmd_prune(&store, threshold, dry_run),
         Commands::Consolidate {
@@ -1323,9 +1335,14 @@ fn main() -> Result<()> {
             text,
             dry_run,
             store_raw,
+            enqueue,
         } => {
-            let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
-            cmd_extract(&store, emb_ref, &project, text, dry_run, store_raw)
+            if enqueue {
+                cmd_extract_enqueue(&store, &project, text)
+            } else {
+                let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
+                cmd_extract(&store, emb_ref, &project, text, dry_run, store_raw)
+            }
         }
         Commands::Import {
             path,
@@ -4830,16 +4847,26 @@ fn resolve_consolidate_provider(
 
 /// Process the async extraction queue.
 ///
-/// Reads up to `limit` oldest pending rows from `pending_extractions`,
-/// concatenates their raw outputs, asks the configured LLM CLI to extract
-/// decisions / architecture / preferences, parses the bullet response,
-/// and stores the results as Memory rows. Successfully-processed rows
-/// are deleted from the queue regardless of whether facts were
-/// extracted (so an output with no extractable content doesn't loop
-/// forever).
+/// Reads up to `limit` oldest pending rows from `pending_extractions`.
+///
+/// With an LLM provider configured, it concatenates their raw outputs,
+/// asks the configured LLM CLI to extract decisions / architecture /
+/// preferences, parses the bullet response, and stores the results as
+/// Memory rows.
+///
+/// With `provider = "none"` (the default), it falls back to the inline
+/// fastembed extractor — but runs it **once** over the whole drained
+/// batch instead of once per hook fire. That is the deferred half of
+/// the issue #239 fix: editor hooks enqueue cheaply, and the heavy
+/// model load happens here, once per drain.
+///
+/// Successfully-processed rows are deleted from the queue regardless of
+/// whether facts were extracted (so an output with no extractable
+/// content doesn't loop forever).
 #[allow(clippy::too_many_arguments)]
 fn cmd_extract_pending(
     store: &SqliteStore,
+    embedder: Option<&dyn icm_core::Embedder>,
     cfg: &config::SummarizerConfig,
     limit: usize,
     cli_provider: Option<&str>,
@@ -4854,11 +4881,43 @@ fn cmd_extract_pending(
 
     let provider_kind = resolve_consolidate_provider(cfg, cli_provider)?;
     if matches!(provider_kind, summarizer::ProviderKind::None) {
-        bail!(
-            "extraction.summarizer.provider = \"none\" — nothing would be \
-             extracted. Set it to auto/claude/codex/gemini/ollama, or \
-             pass --provider on this command."
+        // No LLM configured — drain with the fastembed extractor. The
+        // model loads once for this whole batch, instead of once per
+        // tool call as the pre-#239 hook path did.
+        let ids: Vec<String> = pending.iter().map(|(id, ..)| id.clone()).collect();
+
+        if dry_run {
+            println!("=== Dry run (fastembed) ===");
+            println!("rows: {}", pending.len());
+            return Ok(());
+        }
+
+        let mut stored = 0usize;
+        for (_, project, _, raw, _) in &pending {
+            // Cap auto-extracted importance at Medium: queued tool
+            // output is untrusted (a malicious tool could emit
+            // decision-keyword text to poison wake-up).
+            match extract::extract_and_store_with_embedder(
+                store,
+                raw,
+                project,
+                false,
+                icm_core::Importance::Medium,
+                embedder,
+            ) {
+                Ok(n) => stored += n,
+                Err(e) => eprintln!("[extract-pending] fastembed row failed: {e}"),
+            }
+        }
+
+        let deleted = store.delete_pending_extractions(&ids)?;
+        println!(
+            "Processed {} rows (fastembed), extracted {} facts, dequeued {}.",
+            pending.len(),
+            stored,
+            deleted,
         );
+        return Ok(());
     }
 
     // Build a single LLM prompt covering all rows. The prompt asks for
@@ -5154,6 +5213,49 @@ fn cmd_extract(
         )?;
         println!("Extracted and stored {stored} facts.");
     }
+    Ok(())
+}
+
+/// `icm extract --enqueue`: queue raw text into `pending_extractions`
+/// without touching the embedder.
+///
+/// Editor hooks (the OpenCode plugin, etc.) call this on every Nth tool
+/// call. The previous behavior shelled out to a full `icm extract`,
+/// which reloads the ~multilingual-e5-small ONNX model from scratch in
+/// each short-lived process (~3.7s CPU + a few hundred MB RAM). Reading
+/// many files therefore produced a model reload every few reads — the
+/// CPU/RAM spikes reported in issue #239. Enqueuing instead costs ~50ms
+/// and never loads the model; `icm extract-pending` drains the queue
+/// later, loading the model once for the whole batch.
+fn cmd_extract_enqueue(store: &SqliteStore, project: &str, text: Option<String>) -> Result<()> {
+    let input = match text {
+        Some(t) => t,
+        None => {
+            use std::io::Read;
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .context("failed to read stdin")?;
+            buf
+        }
+    };
+
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+
+    // Cap to 8 KB — same bound as the PostToolUse async path. Long tool
+    // outputs are rare and their trailing slice carries the freshest
+    // context.
+    let capped = if trimmed.len() > 8192 {
+        &trimmed[trimmed.len() - 8192..]
+    } else {
+        trimmed
+    };
+
+    let id = store.enqueue_pending_extraction(project, "extract", capped)?;
+    eprintln!("[icm] enqueued raw text for deferred extraction (id={id})");
     Ok(())
 }
 

--- a/plugins/opencode-icm.ts
+++ b/plugins/opencode-icm.ts
@@ -13,19 +13,46 @@
 // to deliver recalled context into the agent's context window.
 
 import type { Plugin } from "@opencode-ai/plugin"
-import { execFileSync } from "child_process"
+import { execFileSync, spawn } from "child_process"
 
+// Capture tool output every N tool calls...
 const EXTRACT_EVERY = 3
+// ...but only drain the extraction queue (the step that loads the
+// fastembed model) once per N enqueues. Issue #239: running a full
+// `icm extract` on every 3rd tool call reloaded the embedding model
+// from scratch each time (~3.7s CPU + a few hundred MB RAM), so
+// reading many files produced visible CPU/RAM spikes. Enqueuing is
+// cheap (~50ms, no model); the heavy work is batched into one
+// detached drain.
+const DRAIN_EVERY = 10
 let toolCallCount = 0
+let enqueueCount = 0
 
-function icmExtract(args: string[], input: string): void {
+/// Enqueue raw text for deferred extraction. `icm extract --enqueue`
+/// only writes a queue row — it never loads the embedding model.
+function icmEnqueue(project: string, input: string): void {
   try {
-    execFileSync("icm", args, {
+    execFileSync("icm", ["extract", "--enqueue", "-p", project], {
       encoding: "utf-8",
       timeout: 10000,
       input,
       stdio: ["pipe", "pipe", "pipe"],
     })
+  } catch {
+    // silent — extraction is best-effort
+  }
+}
+
+/// Drain the pending-extraction queue in a detached background process.
+/// Fire-and-forget: the chat turn never waits on it, and the heavy
+/// fastembed model load happens at most once per drain.
+function icmDrainDetached(): void {
+  try {
+    const child = spawn("icm", ["extract-pending", "--limit", "30"], {
+      detached: true,
+      stdio: "ignore",
+    })
+    child.unref()
   } catch {
     // silent — extraction is best-effort
   }
@@ -81,10 +108,13 @@ export const IcmPlugin: Plugin = async ({ $, directory }) => {
         result?.metadata?.output ?? result?.output ?? (typeof result === "string" ? result : "")
       if (!output || typeof output !== "string" || output.length < 20) return
 
-      try {
-        icmExtract(["extract", "--store-raw", "-p", project], output.slice(0, 4000))
-      } catch {
-        // silent
+      // Enqueue only (cheap, no model load), then drain once per
+      // DRAIN_EVERY enqueues in a detached process — see issue #239.
+      icmEnqueue(project, output.slice(0, 8000))
+      enqueueCount++
+      if (enqueueCount >= DRAIN_EVERY) {
+        enqueueCount = 0
+        icmDrainDetached()
       }
     },
 
@@ -109,11 +139,11 @@ export const IcmPlugin: Plugin = async ({ $, directory }) => {
 
       if (text.length < 50) return
 
-      try {
-        icmExtract(["extract", "--store-raw", "-p", project], text)
-      } catch {
-        // silent
-      }
+      // Compaction is a natural flush point: enqueue the conversation
+      // slice and drain the whole queue once in a detached process.
+      icmEnqueue(project, text)
+      enqueueCount = 0
+      icmDrainDetached()
     },
 
     // Layer 2: log on session creation. OpenCode's `session.created` hook


### PR DESCRIPTION
## Problem

Reported in #239: ICM causes repeated CPU/RAM spikes while an agent reads
many files.

Two compounding causes:

1. The OpenCode plugin (`plugins/opencode-icm.ts`) shells out to
   `icm extract` every 3rd tool call. Each invocation is a fresh process
   that reloads the `multilingual-e5` ONNX model from scratch (measured on
   a dev box: ~8-10s CPU + ~2 GB RSS per load).
2. PR #219 added an async LLM-CLI extraction queue that makes hooks ~50ms,
   but shipped `extraction.summarizer.provider = "none"` as the default —
   so every default install stayed on the heavy inline fastembed path, and
   the OpenCode plugin was never migrated to the queue at all.

## Fix

Decouple enqueue (cheap, frequent) from extraction (heavy, batched), and
make the light path the default:

- **`icm extract --enqueue`** — new flag that queues raw text into
  `pending_extractions` in ~50ms without loading the embedder.
- **OpenCode plugin** — `tool.execute.after` now enqueues only, and drains
  the queue in a **detached** background process once per 10 enqueues and
  at compaction. This completes the #219 migration for OpenCode.
- **`extract-pending`** — drains via the configured LLM CLI; when no CLI
  is resolvable it now falls back to the fastembed extractor, loading the
  model **once per batch** instead of bailing out.
- **Default `provider` -> `auto`** — an installed claude/codex/gemini/
  ollama CLI is used automatically. `extract-pending` downgrades to the
  batched fastembed drain when the resolved CLI is not on `PATH`, so
  `auto` is safe even with no LLM CLI. `consolidate` keeps its own
  `none` default, unchanged.

## Result (measured)

- enqueue: ~10-20ms, ~30 MB RSS — never loads a model
- drain via an LLM CLI (`auto` -> claude): ~10s, ~290 MB RSS
- drain via fastembed fallback (no CLI): heavy, but batched + detached,
  off the agent's critical path
- end-to-end OpenCode session reading 10 files: 3 enqueues, 0 model loads
  during the session

## Behavior notes

- The drain path no longer honors `--store-raw`: tool outputs with no
  extractable fact are dropped rather than stored as low-importance
  memories. Matches the existing LLM drain path.
- `cmd_hook_post` (Claude Code / Codex / Gemini) already enqueues when a
  provider is configured (#219); flipping the default to `auto` now puts
  those clients on the light path too without further code changes.

## Validation

- `cargo build`, `cargo clippy`, `cargo fmt --check` clean
- 177 unit tests pass
- Manual: `--provider auto` resolves to the claude CLI; `--provider ollama`
  with ollama absent logs the downgrade and drains via fastembed.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)