### PR TITLE
fix(codex): drop unsupported updatedInput + generalize instruction template

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2279,18 +2279,19 @@ fn cmd_hook_pre() -> Result<()> {
         return Ok(());
     }
 
-    // Auto-allow: output hook response JSON
-    let tool_input = json
-        .get("tool_input")
-        .cloned()
-        .unwrap_or_else(|| serde_json::json!({}));
-
+    // Auto-allow: output hook response JSON.
+    //
+    // `updatedInput` is intentionally omitted — we are not rewriting the
+    // tool input, only granting permission. Including it as a passthrough
+    // worked on early Claude Code builds but codex-cli 0.130.0 rejects
+    // the response with "PreToolUse hook returned unsupported
+    // updatedInput" (issue #237), and the Claude Code spec lists the
+    // field as optional. Omitting it is forward-compatible.
     let response = serde_json::json!({
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "allow",
-            "permissionDecisionReason": "ICM auto-allow",
-            "updatedInput": tool_input
+            "permissionDecisionReason": "ICM auto-allow"
         }
     });
 

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -3571,7 +3571,7 @@ You MUST call `icm store` when ANY of the following happens:\n\
 \n\
 Do this BEFORE responding to the user. Not after. Not later. Immediately.\n\
 \n\
-Do NOT store: trivial details, info already in CLAUDE.md, ephemeral state (build logs, git status).\n\
+Do NOT store: trivial details, info already in this file, ephemeral state (build logs, git status).\n\
 \n\
 ### Other commands\n\
 ```bash\n\


### PR DESCRIPTION
Two small Codex-compat fixes.

## #237 — PreToolUse hook fails on codex-cli 0.130.0

The auto-allow response included `updatedInput` as a passthrough echo
of `tool_input`. codex-cli 0.130.0 rejects it with
`PreToolUse hook returned unsupported updatedInput` and every auto-allow
fails. We never actually modified the input — only granted permission —
so dropping the field is functionally a no-op for clients that previously
accepted it, and unblocks Codex. The Claude Code hook spec lists
`updatedInput` as optional.

Closes #237

## #238 — Instruction block hard-codes `CLAUDE.md`

`icm init` injects the same `<!-- icm:start --> ... <!-- icm:end -->`
block into every supported instruction file (CLAUDE.md, AGENTS.md,
GEMINI.md, copilot-instructions.md, .windsurfrules, .aider.conventions.md).
One line read "info already in CLAUDE.md" — wrong for Codex's AGENTS.md
and every other target. Replaced with "info already in this file" so
the wording is correct wherever the block is injected.

Closes #238

## Validation

- `cargo build`, `cargo clippy`, `cargo fmt --check` clean
- 177 unit tests pass
- Manual: `echo '{"tool_name":"Bash","tool_input":{"command":"icm topics"}}' | icm hook pre` returns the auto-allow response with no `updatedInput` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)