### PR TITLE
feat(uninstall): first-class `icm uninstall` with backups, dry-run, audit, check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.42"
+version = "0.10.49"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,6 +1360,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ directories = "6"
 # Caching
 lru = "0.18"
 
+# Filesystem walking (used by `icm uninstall --scan-dir`)
+walkdir = "2"
+
 # HTTP (cloud sync)
 ureq = { version = "2", features = ["json"] }
 rpassword = "5"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@
 
 ---
 
+> ⚠️ **Project status: experimental**
+>
+> ICM is pre-1.0 and under active development. Breaking changes can land
+> in any minor release, and hooks/MCP configuration formats may shift.
+>
+> That said, I (the maintainer) use ICM every day as my primary AI
+> coding memory layer — it's experimental in API stability, not in
+> day-to-day usefulness.
+>
+> My focus is currently on [rtk](https://github.com/rtk-ai/rtk); ICM
+> updates are merged on a best-effort cadence. Issues and pull requests
+> are welcome but may take longer to review than usual.
+>
+> ICM is Apache-2.0 licensed and ships **as-is, without warranty of any
+> kind** (see [LICENSE](LICENSE)). Before any destructive operation, run
+> the read-only equivalent first (`icm uninstall --dry-run`,
+> `icm uninstall --check`).
+
+---
+
 ICM gives your AI agent a real memory — not a note-taking tool, not a context manager, a **memory**.
 
 ```
@@ -46,6 +66,34 @@ ICM gives your AI agent a real memory — not a note-taking tool, not a context 
 - **Memories** — store/recall with temporal decay by importance. Critical memories never fade, low-importance ones decay naturally. Filter by topic or keyword.
 - **Memoirs** — permanent knowledge graphs. Concepts linked by typed relations (`depends_on`, `contradicts`, `superseded_by`, ...). Filter by label.
 - **Feedback** — record corrections when AI predictions are wrong. Search past mistakes before making new predictions. Closed-loop learning.
+
+## One memory, every AI tool — no re-explaining
+
+The point of ICM: **you stop re-explaining context every time you switch
+AI tools**. Tell Claude Code about your project's auth strategy on
+Monday — Tuesday's Gemini session already knows it. Hit a Postgres
+indexing gotcha in a Codex run — next week's Cursor session finds the
+fix in `errors-resolved`.
+
+This works because every AI tool you configure with `icm init` reads
+and writes the **same SQLite database** at the OS-standard data
+location (e.g. `~/.local/share/icm/memories.db` on Linux,
+`~/Library/Application Support/icm/memories.db` on macOS,
+`%APPDATA%\icm\icm\data\memories.db` on Windows):
+
+- A `icm store -t decisions-myapp -c "..."` from Claude Code is
+  immediately visible to Codex, Gemini, Cursor, Roo, Amp, Aider, ...
+- `icm recall "query"` from any tool searches the same corpus.
+- Topics (`decisions-myapp`, `preferences`, `errors-resolved`, ...)
+  are global — there is no per-tool partition.
+
+The [multi-agent benchmark](#multi-agent-unified-memory) below confirms
+it end-to-end: facts seeded through ICM are recalled with 100% accuracy
+by Claude Code, Gemini CLI, Copilot CLI, Cursor Agent, and Aider —
+**98% cross-agent efficiency** on the standard test.
+
+If you want isolation (per-project, per-tool, etc.) pass `--db <path>`
+or set `ICM_DB_PATH`; each path is an independent corpus.
 
 ## Install
 

--- a/crates/icm-cli/Cargo.toml
+++ b/crates/icm-cli/Cargo.toml
@@ -59,6 +59,7 @@ rust-embed = { workspace = true, optional = true }
 mime_guess = { workspace = true, optional = true }
 getrandom = { workspace = true, optional = true }
 serde_json_lenient = { workspace = true }
+walkdir = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -12,6 +12,7 @@ mod recall_format;
 mod summarizer;
 #[cfg(feature = "tui")]
 mod tui;
+mod uninstall;
 mod upgrade;
 #[cfg(feature = "web")]
 mod web;
@@ -307,6 +308,15 @@ enum Commands {
 
     /// Diagnose ICM integration: check hook binary paths in Claude Code settings
     Doctor,
+
+    /// Reverse `icm init`: remove ICM config from every detected AI tool.
+    ///
+    /// Default behavior: timestamped backups under
+    /// `~/.icm-uninstall-backups/<ts>/`, preserves your SQLite memory DB.
+    /// Use `--purge-data` to delete the DB and fastembed cache too.
+    /// Use `--dry-run` or `--audit` for a preview; `--check` for an exit-code
+    /// signal (0 = clean). See issue #229.
+    Uninstall(uninstall::UninstallOpts),
 
     /// Run performance benchmark on in-memory store
     Bench {
@@ -1318,6 +1328,10 @@ fn main() -> Result<()> {
         },
         Commands::Init { mode, force } => cmd_init(mode, force),
         Commands::Doctor => cmd_doctor(),
+        Commands::Uninstall(opts) => {
+            let code = uninstall::run(opts)?;
+            std::process::exit(code);
+        }
         Commands::Extract {
             project,
             text,

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -3266,7 +3266,7 @@ fn portable_command_path(path: &Path) -> String {
 /// `C:/.../icm.exe hook pre` was missed by every detect site (init
 /// idempotency, doctor binary check, codex/copilot injectors), so init
 /// re-injected duplicates and doctor reported zero hooks.
-fn cmd_matches_icm_pattern(cmd: &str, pattern: &str) -> bool {
+pub(crate) fn cmd_matches_icm_pattern(cmd: &str, pattern: &str) -> bool {
     if cmd.contains(pattern) {
         return true;
     }
@@ -4293,7 +4293,7 @@ fn strip_jsonc_comments(content: &str) -> String {
 /// Parse a JSON config file with lenient parsing: accepts trailing commas
 /// and JSONC comments (// and /* */). This is the only place we use lenient
 /// parsing — all other JSON handling uses strict serde_json.
-fn parse_json_config(config_path: &std::path::Path) -> Result<Value> {
+pub(crate) fn parse_json_config(config_path: &std::path::Path) -> Result<Value> {
     let content = std::fs::read_to_string(config_path)
         .with_context(|| format!("cannot read {}", config_path.display()))?;
     let clean = strip_jsonc_comments(&content);

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -4346,7 +4346,7 @@ pub(crate) fn home_dir_str() -> Result<String> {
 /// Falls back to `$HOME/{default_subdir}` if the env var is unset or empty.
 /// Mirrors how each tool documents its own override (CLAUDE_CONFIG_DIR,
 /// GEMINI_CONFIG_DIR, CODEX_HOME, COPILOT_HOME).
-fn cli_config_dir(env_var: &str, default_subdir: &str, home: &str) -> PathBuf {
+pub(crate) fn cli_config_dir(env_var: &str, default_subdir: &str, home: &str) -> PathBuf {
     match std::env::var(env_var) {
         Ok(custom) if !custom.is_empty() => PathBuf::from(custom),
         _ => PathBuf::from(home).join(default_subdir),

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1095,9 +1095,21 @@ fn main() -> Result<()> {
     }
     let cli_db: Option<PathBuf> = cli.db.into_iter().next();
     let db_path = cli_db.clone().unwrap_or_else(default_db_path);
+
+    // `icm uninstall` must NOT open the SQLite store: a default
+    // `open_store` call would recreate the DB directory and WAL/SHM files
+    // immediately after `--purge-data` removed them, leaving the user's
+    // data dir non-empty even though the run reported success. Dispatch
+    // it before `open_store` runs.
+    let command = cli.command;
+    if let Commands::Uninstall(opts) = command {
+        let code = uninstall::run(opts)?;
+        std::process::exit(code);
+    }
+
     let store = open_store(cli_db, embedding_dims)?;
 
-    match cli.command {
+    match command {
         Commands::Store {
             topic,
             content,
@@ -1328,10 +1340,7 @@ fn main() -> Result<()> {
         },
         Commands::Init { mode, force } => cmd_init(mode, force),
         Commands::Doctor => cmd_doctor(),
-        Commands::Uninstall(opts) => {
-            let code = uninstall::run(opts)?;
-            std::process::exit(code);
-        }
+        Commands::Uninstall(_) => unreachable!("dispatched before open_store"),
         Commands::Extract {
             project,
             text,

--- a/crates/icm-cli/src/uninstall/backup.rs
+++ b/crates/icm-cli/src/uninstall/backup.rs
@@ -15,8 +15,6 @@
 //! `files/` mirrors the original absolute paths with the leading `/`
 //! stripped, so a recursive copy lands every config back where it was.
 
-#![allow(dead_code)] // wired up by the mutator immediately below
-
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 

--- a/crates/icm-cli/src/uninstall/backup.rs
+++ b/crates/icm-cli/src/uninstall/backup.rs
@@ -1,0 +1,329 @@
+//! Timestamped backup of every file uninstall mutates.
+//!
+//! Layout (Windows-safe ISO timestamp with `-` instead of `:`):
+//!
+//! ```text
+//! ~/.icm-uninstall-backups/2026-05-20T14-32-05/
+//!   files/
+//!     home/patrick/.claude/settings.json     (mirrors the original tree)
+//!     home/patrick/.codex/config.toml
+//!     ...
+//!   manifest.json                            (sha256 per staged file)
+//! ```
+//!
+//! Restore is `cp -a <backup>/files/. /` — the relative tree under
+//! `files/` mirrors the original absolute paths with the leading `/`
+//! stripped, so a recursive copy lands every config back where it was.
+
+#![allow(dead_code)] // wired up by the mutator immediately below
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// One backup session, scoped to a single `icm uninstall` run. The
+/// session is created lazily — if the run turns out to have zero hits we
+/// never touch disk.
+pub(crate) struct BackupSession {
+    /// Root of this session: `~/.icm-uninstall-backups/<ts>/`.
+    root: PathBuf,
+    /// Subdirectory under the root that mirrors the original tree.
+    files_root: PathBuf,
+    /// Recorded entries — keyed by the original absolute path.
+    entries: BTreeMap<PathBuf, BackupEntry>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct BackupEntry {
+    original_path: PathBuf,
+    backup_path: PathBuf,
+    sha256: String,
+    bytes: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Manifest {
+    /// ISO timestamp string this session was created at.
+    timestamp: String,
+    /// Total number of files staged.
+    files: usize,
+    /// One entry per staged file.
+    entries: Vec<BackupEntry>,
+}
+
+impl BackupSession {
+    /// Build a session rooted at `<base>/<ISO-ts>/`. When `override_root`
+    /// is `None`, `<base>` defaults to `~/.icm-uninstall-backups/`.
+    pub(crate) fn new(override_root: Option<&Path>, home: &Path) -> Result<Self> {
+        let base = match override_root {
+            Some(p) => p.to_path_buf(),
+            None => home.join(".icm-uninstall-backups"),
+        };
+        let ts = iso_timestamp_no_colons();
+        let root = base.join(&ts);
+        let files_root = root.join("files");
+        std::fs::create_dir_all(&files_root)
+            .with_context(|| format!("cannot create backup root at {}", root.display()))?;
+        Ok(Self {
+            root,
+            files_root,
+            entries: BTreeMap::new(),
+        })
+    }
+
+    /// The absolute path to the session root (used in the final report).
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Stage one file. Idempotent: a second call for the same path is a
+    /// no-op (the first stage already captured the pre-mutation state).
+    /// Silently skips paths that don't exist on disk (they had nothing to
+    /// back up — the mutator catches the discrepancy via the hit list).
+    pub(crate) fn stage(&mut self, original: &Path) -> Result<()> {
+        let canonical = original.to_path_buf();
+        if self.entries.contains_key(&canonical) {
+            return Ok(());
+        }
+        if !canonical.exists() {
+            return Ok(());
+        }
+        // Avoid following symlinks during the stat — preserves the
+        // user's intent if `~/.claude` is symlinked into a dotfiles repo.
+        let meta = std::fs::symlink_metadata(&canonical)
+            .with_context(|| format!("cannot stat {}", canonical.display()))?;
+        if meta.file_type().is_symlink() {
+            // Don't dereference; record but don't copy contents. The
+            // mutator will leave such paths alone.
+            return Ok(());
+        }
+        if !meta.is_file() {
+            return Ok(()); // dirs handled by stage_dir
+        }
+        let backup_path = self.backup_path_for(&canonical);
+        if let Some(parent) = backup_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("cannot create backup parent {}", parent.display()))?;
+        }
+        std::fs::copy(&canonical, &backup_path).with_context(|| {
+            format!(
+                "cannot copy {} -> {}",
+                canonical.display(),
+                backup_path.display()
+            )
+        })?;
+        let bytes = meta.len();
+        let sha = sha256_of(&canonical)?;
+        self.entries.insert(
+            canonical.clone(),
+            BackupEntry {
+                original_path: canonical,
+                backup_path,
+                sha256: sha,
+                bytes,
+            },
+        );
+        Ok(())
+    }
+
+    /// Stage every regular file under `dir` recursively. Used for data
+    /// directories before `--purge-data` deletion.
+    pub(crate) fn stage_dir(&mut self, dir: &Path) -> Result<()> {
+        if !dir.exists() {
+            return Ok(());
+        }
+        let meta = std::fs::symlink_metadata(dir)?;
+        if meta.file_type().is_symlink() {
+            return Ok(());
+        }
+        if meta.is_file() {
+            return self.stage(dir);
+        }
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let p = entry.path();
+            let m = std::fs::symlink_metadata(&p)?;
+            if m.file_type().is_symlink() {
+                continue;
+            }
+            if m.is_file() {
+                self.stage(&p)?;
+            } else if m.is_dir() {
+                self.stage_dir(&p)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Write the manifest. Should be called once at the end of a run,
+    /// after every stage() / mutation pair completed. Cheap even with
+    /// zero staged files — produces a valid empty manifest.
+    pub(crate) fn commit_manifest(&self) -> Result<()> {
+        let manifest = Manifest {
+            timestamp: self
+                .root
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default(),
+            files: self.entries.len(),
+            entries: self.entries.values().cloned().collect(),
+        };
+        let path = self.root.join("manifest.json");
+        let json = serde_json::to_string_pretty(&manifest)?;
+        std::fs::write(&path, json)
+            .with_context(|| format!("cannot write manifest {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Map an absolute path to its location under `<root>/files/`. On
+    /// Windows the drive letter prefix is preserved as a path segment so
+    /// `C:\Users\x\.claude.json` lands under `files/C/Users/x/...`.
+    fn backup_path_for(&self, original: &Path) -> PathBuf {
+        let mut rel = PathBuf::new();
+        for c in original.components() {
+            match c {
+                std::path::Component::Prefix(p) => {
+                    let s = p.as_os_str().to_string_lossy();
+                    // Strip the trailing `:` from a Windows drive prefix.
+                    let cleaned: String = s.chars().filter(|c| *c != ':').collect();
+                    if !cleaned.is_empty() {
+                        rel.push(cleaned);
+                    }
+                }
+                std::path::Component::RootDir => {
+                    // Skip — `files/` is already the root anchor.
+                }
+                std::path::Component::CurDir | std::path::Component::ParentDir => {
+                    // Should not appear in a canonical path; ignore.
+                }
+                std::path::Component::Normal(s) => {
+                    rel.push(s);
+                }
+            }
+        }
+        self.files_root.join(rel)
+    }
+}
+
+/// `YYYY-MM-DDTHH-MM-SS` in UTC — colons replaced with dashes for
+/// Windows-safe directory names. Date is computed manually so we avoid
+/// pulling `chrono` into a hot path that already costs nothing.
+fn iso_timestamp_no_colons() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let (y, mo, d, h, mi, s) = epoch_to_ymdhms(secs);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}-{mi:02}-{s:02}")
+}
+
+/// Civil-from-days, adapted from Howard Hinnant's algorithm. Produces a
+/// UTC timestamp with no DST/locale dependency.
+fn epoch_to_ymdhms(secs: u64) -> (i32, u32, u32, u32, u32, u32) {
+    let days = (secs / 86_400) as i64;
+    let sec_of_day = secs % 86_400;
+    let h = (sec_of_day / 3600) as u32;
+    let mi = ((sec_of_day % 3600) / 60) as u32;
+    let s = (sec_of_day % 60) as u32;
+
+    let z = days + 719_468; // shift epoch to 0000-03-01
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64; // [0, 146097]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let mo = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32; // [1, 12]
+    let y = if mo <= 2 { y + 1 } else { y };
+    (y as i32, mo, d, h, mi, s)
+}
+
+fn sha256_of(path: &Path) -> Result<String> {
+    use sha2::{Digest, Sha256};
+    let mut f = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut f, &mut hasher)?;
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backup_preserves_directory_layout_under_files_subdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
+        let original = home.join(".claude/settings.json");
+        std::fs::create_dir_all(original.parent().unwrap()).unwrap();
+        std::fs::write(&original, "{\"hooks\": {}}").unwrap();
+
+        let backup_base = tmp.path().join(".icm-uninstall-backups");
+        let mut session = BackupSession::new(Some(&backup_base), &home).unwrap();
+        session.stage(&original).unwrap();
+        session.commit_manifest().unwrap();
+
+        // The staged file's relative path under files/ should mirror the
+        // original absolute path (leading slash stripped).
+        let canonical_rel = original
+            .strip_prefix("/")
+            .unwrap_or_else(|_| original.as_path());
+        let expected = session.files_root.join(canonical_rel);
+        assert!(
+            expected.exists(),
+            "expected staged copy at {}",
+            expected.display()
+        );
+
+        // Manifest must list this entry.
+        let mf_path = session.root().join("manifest.json");
+        assert!(mf_path.exists(), "manifest.json was not written");
+        let mf: Manifest =
+            serde_json::from_str(&std::fs::read_to_string(mf_path).unwrap()).unwrap();
+        assert_eq!(mf.files, 1);
+        assert_eq!(mf.entries[0].original_path, original);
+        assert!(!mf.entries[0].sha256.is_empty());
+    }
+
+    #[test]
+    fn backup_stage_is_idempotent_for_same_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
+        let original = home.join("a.json");
+        std::fs::write(&original, "v1").unwrap();
+        let mut session = BackupSession::new(Some(&home.join("bk")), &home).unwrap();
+        session.stage(&original).unwrap();
+        // Mutate the source so a naïve second copy would overwrite v1.
+        std::fs::write(&original, "v2").unwrap();
+        session.stage(&original).unwrap(); // no-op
+        let staged = session.backup_path_for(&original);
+        assert_eq!(std::fs::read_to_string(staged).unwrap(), "v1");
+    }
+
+    #[test]
+    fn backup_skips_nonexistent_paths_silently() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
+        let mut session = BackupSession::new(Some(&home.join("bk")), &home).unwrap();
+        session.stage(&home.join("does/not/exist.json")).unwrap();
+        assert_eq!(session.entries.len(), 0);
+    }
+
+    #[test]
+    fn iso_timestamp_is_windows_safe() {
+        let ts = iso_timestamp_no_colons();
+        assert!(!ts.contains(':'), "timestamp must not contain colons: {ts}");
+        assert_eq!(ts.len(), "YYYY-MM-DDTHH-MM-SS".len());
+    }
+
+    #[test]
+    fn epoch_to_ymdhms_known_reference_point() {
+        // 1700000000 = 2023-11-14T22:13:20 UTC
+        let (y, mo, d, h, mi, s) = epoch_to_ymdhms(1_700_000_000);
+        assert_eq!((y, mo, d, h, mi, s), (2023, 11, 14, 22, 13, 20));
+    }
+}

--- a/crates/icm-cli/src/uninstall/backup.rs
+++ b/crates/icm-cli/src/uninstall/backup.rs
@@ -254,9 +254,7 @@ mod tests {
 
         // The staged file's relative path under files/ should mirror the
         // original absolute path (leading slash stripped).
-        let canonical_rel = original
-            .strip_prefix("/")
-            .unwrap_or_else(|_| original.as_path());
+        let canonical_rel = original.strip_prefix("/").unwrap_or(original.as_path());
         let expected = session.files_root.join(canonical_rel);
         assert!(
             expected.exists(),

--- a/crates/icm-cli/src/uninstall/backup.rs
+++ b/crates/icm-cli/src/uninstall/backup.rs
@@ -3,7 +3,7 @@
 //! Layout (Windows-safe ISO timestamp with `-` instead of `:`):
 //!
 //! ```text
-//! ~/.icm-uninstall-backups/2026-05-20T14-32-05/
+//! <icm-data-dir>/uninstall-backups/2026-05-20T14-32-05/
 //!   files/
 //!     home/patrick/.claude/settings.json     (mirrors the original tree)
 //!     home/patrick/.codex/config.toml
@@ -11,9 +11,19 @@
 //!   manifest.json                            (sha256 per staged file)
 //! ```
 //!
-//! Restore is `cp -a <backup>/files/. /` — the relative tree under
-//! `files/` mirrors the original absolute paths with the leading `/`
-//! stripped, so a recursive copy lands every config back where it was.
+//! On Linux `<icm-data-dir>` resolves to `~/.local/share/icm/`, on macOS
+//! to `~/Library/Application Support/icm/`. Override the root with
+//! `--backup-dir <PATH>`. Restore is `cp -a <backup>/files/. /` — the
+//! relative tree under `files/` mirrors the original absolute paths with
+//! the leading `/` stripped, so a recursive copy lands every config back
+//! where it was.
+//!
+//! Note: `uninstall --purge-data` removes the data dir entirely, which
+//! includes this backup root. The orchestrator persists the manifest
+//! *before* the purge runs so the backup is at least complete on disk
+//! for the brief window between mutation and purge — but if you ran
+//! `--purge-data` you explicitly asked to lose this state. Do
+//! `uninstall -y` first if you want the safety net to survive.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -52,12 +62,18 @@ struct Manifest {
 }
 
 impl BackupSession {
-    /// Build a session rooted at `<base>/<ISO-ts>/`. When `override_root`
-    /// is `None`, `<base>` defaults to `~/.icm-uninstall-backups/`.
-    pub(crate) fn new(override_root: Option<&Path>, home: &Path) -> Result<Self> {
+    /// Build a session rooted at `<base>/<ISO-ts>/`.
+    ///
+    /// `override_root` wins when set (the `--backup-dir <PATH>` flag).
+    /// Otherwise the default is `<default_base>` — typically
+    /// `<icm-data-dir>/uninstall-backups/`, with `<icm-data-dir>` itself
+    /// resolved by `directories::ProjectDirs` so the path follows each
+    /// OS's convention (XDG on Linux/WSL, Application Support on macOS,
+    /// AppData/Roaming on Windows).
+    pub(crate) fn new(override_root: Option<&Path>, default_base: &Path) -> Result<Self> {
         let base = match override_root {
             Some(p) => p.to_path_buf(),
-            None => home.join(".icm-uninstall-backups"),
+            None => default_base.to_path_buf(),
         };
         let ts = iso_timestamp_no_colons();
         let root = base.join(&ts);
@@ -123,35 +139,6 @@ impl BackupSession {
                 bytes,
             },
         );
-        Ok(())
-    }
-
-    /// Stage every regular file under `dir` recursively. Used for data
-    /// directories before `--purge-data` deletion.
-    pub(crate) fn stage_dir(&mut self, dir: &Path) -> Result<()> {
-        if !dir.exists() {
-            return Ok(());
-        }
-        let meta = std::fs::symlink_metadata(dir)?;
-        if meta.file_type().is_symlink() {
-            return Ok(());
-        }
-        if meta.is_file() {
-            return self.stage(dir);
-        }
-        for entry in std::fs::read_dir(dir)? {
-            let entry = entry?;
-            let p = entry.path();
-            let m = std::fs::symlink_metadata(&p)?;
-            if m.file_type().is_symlink() {
-                continue;
-            }
-            if m.is_file() {
-                self.stage(&p)?;
-            } else if m.is_dir() {
-                self.stage_dir(&p)?;
-            }
-        }
         Ok(())
     }
 

--- a/crates/icm-cli/src/uninstall/discover.rs
+++ b/crates/icm-cli/src/uninstall/discover.rs
@@ -7,8 +7,6 @@
 //! enough detail (which key? which line? how many bytes?) for the audit
 //! / dry-run output to be actionable.
 
-#![allow(dead_code)] // consumed by report + mutate in the next two commits
-
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;

--- a/crates/icm-cli/src/uninstall/discover.rs
+++ b/crates/icm-cli/src/uninstall/discover.rs
@@ -1,0 +1,561 @@
+//! Read-only scanner that walks the [`super::locations`] catalog and
+//! reports every place ICM residue is detected. Mutation lives in
+//! `super::formats` (next commit).
+//!
+//! Discovery is JSON/TOML/YAML/Markdown-aware: it does not just
+//! grep the file. We parse where parsing is cheap so a hit comes with
+//! enough detail (which key? which line? how many bytes?) for the audit
+//! / dry-run output to be actionable.
+
+#![allow(dead_code)] // consumed by report + mutate in the next two commits
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde_json::Value;
+
+use super::locations::{HookCommandField, LocationKind, LocationSpec};
+
+/// Per-hit detail. Drives the report formatter and, later, the mutator.
+#[derive(Clone, Debug)]
+pub(crate) enum HitDetail {
+    /// JSON: `<servers_key>.icm` was found.
+    JsonServer { pointer: String },
+    /// JSON: at least one hook command matches `icm hook`.
+    JsonHook { event: String, command: String },
+    /// TOML: `<table>.<entry>` table was found.
+    TomlTable { table: String },
+    /// YAML: a candidate `- name: icm` block was found.
+    YamlBlock { start_line: usize, lines: usize },
+    /// Markdown: `<!-- icm:start -->` block was found.
+    MarkdownBlock {
+        start_line: usize,
+        end_line: usize,
+        file_will_be_empty: bool,
+    },
+    /// Owned file present on disk.
+    OwnedFile { bytes: u64 },
+    /// Data directory present on disk; reports approximate size.
+    DataDir { bytes_total: u64, files: usize },
+}
+
+/// One hit. A single `LocationSpec` can yield multiple hits (e.g. a hooks
+/// settings file has one entry per event).
+#[derive(Clone, Debug)]
+pub(crate) struct LocationHit {
+    pub spec_label: &'static str,
+    pub path: PathBuf,
+    pub detail: HitDetail,
+}
+
+/// Aggregate result of a discovery pass.
+#[derive(Default, Debug)]
+pub(crate) struct RemovalPlan {
+    pub hits: Vec<LocationHit>,
+    /// Reserved for the scan-dir walker (a later commit on this PR).
+    pub scan_dir_hits: Vec<LocationHit>,
+    /// Reserved for the `icm serve` process detector (a later commit).
+    pub processes: Vec<RunningProcess>,
+}
+
+impl RemovalPlan {
+    pub fn is_empty(&self) -> bool {
+        self.hits.is_empty() && self.scan_dir_hits.is_empty()
+    }
+
+    /// Number of hits across both the catalog and the project tree scan.
+    pub fn total_hits(&self) -> usize {
+        self.hits.len() + self.scan_dir_hits.len()
+    }
+}
+
+/// Placeholder until the process detector lands. Carries enough info to
+/// print a warning in the report.
+#[derive(Clone, Debug)]
+pub(crate) struct RunningProcess {
+    pub pid: u32,
+    pub cmdline: String,
+}
+
+/// Walk every spec and return the hits. `include_data` controls whether
+/// `DataDir` entries are inspected (only `--purge-data` opts in).
+pub(crate) fn scan(specs: &[LocationSpec], include_data: bool) -> Result<RemovalPlan> {
+    let mut plan = RemovalPlan::default();
+    for spec in specs {
+        if spec.purge_data_only && !include_data {
+            continue;
+        }
+        match scan_spec(spec) {
+            Ok(mut hits) => plan.hits.append(&mut hits),
+            Err(_e) => {
+                // Read or parse errors are non-fatal for discovery; we
+                // simply skip the spec. A later commit will surface
+                // these as warnings.
+            }
+        }
+    }
+    Ok(plan)
+}
+
+/// Dispatch on the spec's kind. Returns zero or more hits.
+fn scan_spec(spec: &LocationSpec) -> Result<Vec<LocationHit>> {
+    if !spec.path.exists() {
+        return Ok(Vec::new());
+    }
+    match &spec.kind {
+        LocationKind::JsonConfig {
+            servers_key,
+            has_hooks,
+            hooks_field,
+        } => scan_json(spec, servers_key.as_deref(), *has_hooks, *hooks_field),
+        LocationKind::TomlMcp { table, entry } => scan_toml(spec, table, entry),
+        LocationKind::YamlContinue => scan_yaml_continue(spec),
+        LocationKind::MarkdownBlock => scan_markdown(spec),
+        LocationKind::OwnedFile => Ok(vec![LocationHit {
+            spec_label: spec.label,
+            path: spec.path.clone(),
+            detail: HitDetail::OwnedFile {
+                bytes: std::fs::metadata(&spec.path).map(|m| m.len()).unwrap_or(0),
+            },
+        }]),
+        LocationKind::DataDir => scan_data_dir(spec),
+    }
+}
+
+fn scan_json(
+    spec: &LocationSpec,
+    servers_key: Option<&str>,
+    has_hooks: bool,
+    hooks_field: HookCommandField,
+) -> Result<Vec<LocationHit>> {
+    let value = crate::parse_json_config(&spec.path)?;
+    let mut hits = Vec::new();
+
+    if let Some(key) = servers_key {
+        if let Some(servers) = lookup_dotted(&value, key) {
+            if servers.get("icm").is_some() {
+                hits.push(LocationHit {
+                    spec_label: spec.label,
+                    path: spec.path.clone(),
+                    detail: HitDetail::JsonServer {
+                        pointer: format!("/{}/icm", key.replace('.', "/")),
+                    },
+                });
+            }
+        }
+    }
+
+    if has_hooks {
+        if let Some(hooks_obj) = value.get("hooks").and_then(|h| h.as_object()) {
+            for (event, arr) in hooks_obj {
+                let Some(arr) = arr.as_array() else { continue };
+                for entry in arr {
+                    match hooks_field {
+                        HookCommandField::Command => {
+                            let Some(inner) = entry.get("hooks").and_then(|h| h.as_array()) else {
+                                continue;
+                            };
+                            for h in inner {
+                                if let Some(cmd) = h.get("command").and_then(|c| c.as_str()) {
+                                    if crate::cmd_matches_icm_pattern(cmd, "icm hook") {
+                                        hits.push(LocationHit {
+                                            spec_label: spec.label,
+                                            path: spec.path.clone(),
+                                            detail: HitDetail::JsonHook {
+                                                event: event.clone(),
+                                                command: cmd.to_string(),
+                                            },
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                        HookCommandField::BashTopLevel => {
+                            if let Some(cmd) = entry.get("bash").and_then(|b| b.as_str()) {
+                                if crate::cmd_matches_icm_pattern(cmd, "icm hook") {
+                                    hits.push(LocationHit {
+                                        spec_label: spec.label,
+                                        path: spec.path.clone(),
+                                        detail: HitDetail::JsonHook {
+                                            event: event.clone(),
+                                            command: cmd.to_string(),
+                                        },
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(hits)
+}
+
+/// Walk a dotted key like `"amp.mcpServers"` through nested JSON objects.
+fn lookup_dotted<'a>(value: &'a Value, dotted: &str) -> Option<&'a Value> {
+    let mut cur = value;
+    for segment in dotted.split('.') {
+        cur = cur.get(segment)?;
+    }
+    Some(cur)
+}
+
+fn scan_toml(spec: &LocationSpec, table: &str, entry: &str) -> Result<Vec<LocationHit>> {
+    let content = std::fs::read_to_string(&spec.path)?;
+    let parsed: toml::Value = content.parse()?;
+    let mut hits = Vec::new();
+    if let Some(t) = parsed.get(table).and_then(|v| v.as_table()) {
+        if t.contains_key(entry) {
+            hits.push(LocationHit {
+                spec_label: spec.label,
+                path: spec.path.clone(),
+                detail: HitDetail::TomlTable {
+                    table: format!("[{table}.{entry}]"),
+                },
+            });
+        }
+    }
+    Ok(hits)
+}
+
+/// Continue.dev YAML detection: look for a top-level `- name: icm` entry.
+///
+/// We intentionally do not parse the YAML. The mutator (next commit)
+/// applies a regex strip with strict structural validation; we report a
+/// hit here as soon as the canonical opening line is present so the user
+/// sees it in the audit.
+fn scan_yaml_continue(spec: &LocationSpec) -> Result<Vec<LocationHit>> {
+    let content = std::fs::read_to_string(&spec.path)?;
+    let mut hits = Vec::new();
+    for (idx, line) in content.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("- name: icm") || trimmed.starts_with("- name: \"icm\"") {
+            let block_lines = count_yaml_block_lines(&content, idx);
+            hits.push(LocationHit {
+                spec_label: spec.label,
+                path: spec.path.clone(),
+                detail: HitDetail::YamlBlock {
+                    start_line: idx + 1, // 1-based for human reports
+                    lines: block_lines,
+                },
+            });
+            // Only the first hit; multiple `- name: icm` in one file is
+            // pathological and the mutator handles it line-by-line.
+            break;
+        }
+    }
+    Ok(hits)
+}
+
+/// Estimate the block length: the starting `- name: icm` line plus each
+/// continuation line indented further than the `- ` marker. Approximation
+/// only; the mutator does the precise strip.
+fn count_yaml_block_lines(content: &str, start: usize) -> usize {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut n = 1;
+    let start_indent = lines[start].len() - lines[start].trim_start().len();
+    for line in &lines[start + 1..] {
+        let indent = line.len() - line.trim_start().len();
+        if line.trim().is_empty() || indent > start_indent {
+            n += 1;
+        } else {
+            break;
+        }
+    }
+    n
+}
+
+fn scan_markdown(spec: &LocationSpec) -> Result<Vec<LocationHit>> {
+    let content = std::fs::read_to_string(&spec.path)?;
+    let Some(start_off) = content.find("<!-- icm:start -->") else {
+        return Ok(Vec::new());
+    };
+    let end_off = content
+        .find("<!-- icm:end -->")
+        .map(|o| o + "<!-- icm:end -->".len())
+        .unwrap_or(content.len());
+
+    let before = &content[..start_off];
+    let after = if end_off <= content.len() {
+        &content[end_off..]
+    } else {
+        ""
+    };
+    let file_will_be_empty = before.trim().is_empty() && after.trim().is_empty();
+
+    let start_line = byte_offset_to_line(&content, start_off);
+    let end_line = byte_offset_to_line(&content, end_off.min(content.len()));
+
+    Ok(vec![LocationHit {
+        spec_label: spec.label,
+        path: spec.path.clone(),
+        detail: HitDetail::MarkdownBlock {
+            start_line,
+            end_line,
+            file_will_be_empty,
+        },
+    }])
+}
+
+fn byte_offset_to_line(s: &str, offset: usize) -> usize {
+    let clamped = offset.min(s.len());
+    s[..clamped].bytes().filter(|&b| b == b'\n').count() + 1
+}
+
+fn scan_data_dir(spec: &LocationSpec) -> Result<Vec<LocationHit>> {
+    let mut bytes_total = 0u64;
+    let mut files = 0usize;
+    walk_size(&spec.path, &mut bytes_total, &mut files)?;
+    if files == 0 && bytes_total == 0 {
+        // Directory exists but is empty — still report it so the user
+        // sees the path that would be cleaned up.
+    }
+    Ok(vec![LocationHit {
+        spec_label: spec.label,
+        path: spec.path.clone(),
+        detail: HitDetail::DataDir { bytes_total, files },
+    }])
+}
+
+fn walk_size(path: &Path, bytes: &mut u64, files: &mut usize) -> Result<()> {
+    let meta = std::fs::metadata(path)?;
+    if meta.is_file() {
+        *bytes += meta.len();
+        *files += 1;
+        return Ok(());
+    }
+    if !meta.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(path)? {
+        let entry = entry?;
+        let p = entry.path();
+        // Resist symlink traversal — `read_dir` itself doesn't follow,
+        // but the child metadata call might if we use `metadata`. Use
+        // `symlink_metadata` to be explicit.
+        let m = std::fs::symlink_metadata(&p)?;
+        if m.file_type().is_symlink() {
+            continue;
+        }
+        if m.is_file() {
+            *bytes += m.len();
+            *files += 1;
+        } else if m.is_dir() {
+            walk_size(&p, bytes, files)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::uninstall::locations::{build_locations, dir_context_under};
+    use std::fs;
+    use std::io::Write;
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = fs::File::create(path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn scan_empty_fake_home_yields_zero_hits() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dir_context_under(tmp.path());
+        let specs = build_locations(&dirs);
+        let plan = scan(&specs, false).unwrap();
+        // ProjectDirs may resolve outside the tempdir; only assert that
+        // every hit lives under tempdir or is a data dir.
+        for h in &plan.hits {
+            let p = h.path.to_string_lossy();
+            let ok = p.starts_with(&*tmp.path().to_string_lossy())
+                || matches!(h.detail, HitDetail::DataDir { .. });
+            assert!(ok, "stray hit outside tempdir: {}", h.path.display());
+        }
+    }
+
+    #[test]
+    fn scan_detects_mcp_server_in_synthetic_claude_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dir_context_under(tmp.path());
+        let claude = dirs.claude_legacy_json();
+        write(
+            &claude,
+            r#"{
+  "mcpServers": {
+    "icm": { "command": "/x/icm", "args": ["serve"] },
+    "other": { "command": "/x/other" }
+  }
+}"#,
+        );
+        let specs = build_locations(&dirs);
+        let plan = scan(&specs, false).unwrap();
+        let mcp_hits: Vec<_> = plan
+            .hits
+            .iter()
+            .filter(|h| matches!(h.detail, HitDetail::JsonServer { .. }))
+            .collect();
+        assert_eq!(mcp_hits.len(), 1, "expected one MCP hit: {plan:#?}");
+        assert_eq!(mcp_hits[0].spec_label, "Claude Code MCP");
+    }
+
+    #[test]
+    fn scan_detects_hook_in_synthetic_claude_settings() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dir_context_under(tmp.path());
+        let settings = dirs.claude_dir.join("settings.json");
+        write(
+            &settings,
+            r#"{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [{"type":"command","command":"/x/icm hook pre"}] }
+    ],
+    "Unrelated": [
+      { "hooks": [{"type":"command","command":"/x/other --do"}] }
+    ]
+  }
+}"#,
+        );
+        let specs = build_locations(&dirs);
+        let plan = scan(&specs, false).unwrap();
+        let hook_hits: Vec<_> = plan
+            .hits
+            .iter()
+            .filter(|h| matches!(h.detail, HitDetail::JsonHook { .. }))
+            .collect();
+        assert_eq!(hook_hits.len(), 1, "{plan:#?}");
+        match &hook_hits[0].detail {
+            HitDetail::JsonHook { event, command } => {
+                assert_eq!(event, "PreToolUse");
+                assert!(command.contains("icm hook"));
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn scan_detects_copilot_bash_top_level_hook() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dir_context_under(tmp.path());
+        let settings = dirs.copilot_dir.join("settings.json");
+        write(
+            &settings,
+            r#"{
+  "hooks": {
+    "sessionStart": [
+      { "type": "command", "bash": "/x/icm hook start", "timeoutSec": 10 }
+    ]
+  }
+}"#,
+        );
+        let specs = build_locations(&dirs);
+        let plan = scan(&specs, false).unwrap();
+        let hits: Vec<_> = plan
+            .hits
+            .iter()
+            .filter(|h| matches!(h.detail, HitDetail::JsonHook { .. }))
+            .collect();
+        assert_eq!(hits.len(), 1, "{plan:#?}");
+        assert_eq!(hits[0].spec_label, "Copilot CLI hooks");
+    }
+
+    #[test]
+    fn scan_detects_codex_toml_table() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dir_context_under(tmp.path());
+        let toml_path = dirs.codex_dir.join("config.toml");
+        write(
+            &toml_path,
+            r#"
+[some.other.section]
+hello = "world"
+
+[mcp_servers.icm]
+command = "/x/icm"
+args = ["serve"]
+"#,
+        );
+        let specs = build_locations(&dirs);
+        let plan = scan(&specs, false).unwrap();
+        let hits: Vec<_> = plan
+            .hits
+            .iter()
+            .filter(|h| matches!(h.detail, HitDetail::TomlTable { .. }))
+            .collect();
+        assert_eq!(hits.len(), 1, "{plan:#?}");
+        match &hits[0].detail {
+            HitDetail::TomlTable { table } => assert_eq!(table, "[mcp_servers.icm]"),
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn scan_detects_markdown_block_with_correct_line_range() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dir_context_under(tmp.path());
+        let claude_md = dirs.cwd.join("CLAUDE.md");
+        let body = "intro\n\n<!-- icm:start -->\nblock\nlines\n<!-- icm:end -->\n\noutro\n";
+        write(&claude_md, body);
+        let specs = build_locations(&dirs);
+        let plan = scan(&specs, false).unwrap();
+        let hits: Vec<_> = plan
+            .hits
+            .iter()
+            .filter(|h| matches!(h.detail, HitDetail::MarkdownBlock { .. }))
+            .collect();
+        assert_eq!(hits.len(), 1, "{plan:#?}");
+        match &hits[0].detail {
+            HitDetail::MarkdownBlock {
+                start_line,
+                end_line,
+                file_will_be_empty,
+            } => {
+                assert_eq!(*start_line, 3);
+                assert!(*end_line >= 6);
+                assert!(!file_will_be_empty);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn scan_owned_file_reports_size() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dir_context_under(tmp.path());
+        let recall = dirs.claude_dir.join("commands/recall.md");
+        write(&recall, "Search ICM memory for: $ARGUMENTS");
+        let specs = build_locations(&dirs);
+        let plan = scan(&specs, false).unwrap();
+        let hits: Vec<_> = plan
+            .hits
+            .iter()
+            .filter(|h| matches!(h.detail, HitDetail::OwnedFile { .. }))
+            .collect();
+        assert!(
+            hits.iter().any(|h| h.spec_label == "Claude Code /recall"),
+            "missing /recall hit: {plan:#?}"
+        );
+    }
+
+    #[test]
+    fn scan_skips_data_dirs_unless_purge_data_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dir_context_under(tmp.path());
+        let specs = build_locations(&dirs);
+        let plan_default = scan(&specs, false).unwrap();
+        assert!(
+            !plan_default
+                .hits
+                .iter()
+                .any(|h| matches!(h.detail, HitDetail::DataDir { .. })),
+            "data dir reported without --purge-data"
+        );
+    }
+}

--- a/crates/icm-cli/src/uninstall/formats.rs
+++ b/crates/icm-cli/src/uninstall/formats.rs
@@ -7,8 +7,6 @@
 //! return type is a `StripResult` so callers can distinguish "nothing to
 //! do", "removed N entries", and "ambiguous — manual review needed".
 
-#![allow(dead_code)] // exposed to the mutator immediately below
-
 use anyhow::{Context, Result};
 use serde_json::Value;
 

--- a/crates/icm-cli/src/uninstall/formats.rs
+++ b/crates/icm-cli/src/uninstall/formats.rs
@@ -1,0 +1,690 @@
+//! Pure string/value strippers — every function takes content in,
+//! returns content out, never touches the filesystem. The mutator
+//! (`super::mutate`) wraps these to stage backups and write the result.
+//!
+//! Symmetric design with the `inject_*` helpers in `main.rs`: each
+//! stripper undoes exactly what its counterpart wrote, and the public
+//! return type is a `StripResult` so callers can distinguish "nothing to
+//! do", "removed N entries", and "ambiguous — manual review needed".
+
+#![allow(dead_code)] // exposed to the mutator immediately below
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use super::locations::HookCommandField;
+
+/// Outcome of a stripper run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum StripResult {
+    /// File was already clean — no change required, no rewrite needed.
+    NoOp,
+    /// `removed` entries were stripped. Caller should persist `new_content`.
+    Removed { removed: usize },
+    /// The whole file should be deleted (e.g. markdown block was the only
+    /// content). Caller deletes the file rather than writing back.
+    DeleteFile,
+    /// Structurally ambiguous; caller logs a warning and skips. Contributes
+    /// to exit code 3 in the orchestrator.
+    Ambiguous { reason: String },
+}
+
+// =========================================================================
+// JSON: mcpServers / servers / mcp / context_servers
+// =========================================================================
+
+/// Remove the `icm` entry from a dotted `servers_key` path (e.g.
+/// `"mcpServers"`, `"amp.mcpServers"`). Empty parent objects are cleaned
+/// up cascading upward.
+pub(crate) fn strip_json_mcp_server(value: &mut Value, dotted_key: &str) -> StripResult {
+    let segments: Vec<&str> = dotted_key.split('.').collect();
+    if segments.is_empty() {
+        return StripResult::NoOp;
+    }
+    let removed = remove_path_then_clean(value, &segments, "icm");
+    if removed {
+        StripResult::Removed { removed: 1 }
+    } else {
+        StripResult::NoOp
+    }
+}
+
+/// Walks `value` through `segments`, removes `leaf_key` at the deepest
+/// object, then cleans up emptied parent objects on the way back. Returns
+/// whether anything was removed.
+fn remove_path_then_clean(value: &mut Value, segments: &[&str], leaf_key: &str) -> bool {
+    if segments.is_empty() {
+        if let Some(obj) = value.as_object_mut() {
+            return obj.remove(leaf_key).is_some();
+        }
+        return false;
+    }
+    let head = segments[0];
+    let tail = &segments[1..];
+    let Some(obj) = value.as_object_mut() else {
+        return false;
+    };
+    let Some(child) = obj.get_mut(head) else {
+        return false;
+    };
+    let removed = remove_path_then_clean(child, tail, leaf_key);
+    // After recursion, drop the parent if its object became empty.
+    if removed {
+        let drop_parent = obj
+            .get(head)
+            .and_then(|v| v.as_object())
+            .map(|o| o.is_empty())
+            .unwrap_or(false);
+        if drop_parent {
+            obj.remove(head);
+        }
+    }
+    removed
+}
+
+// =========================================================================
+// JSON: hook arrays (Claude/Gemini/Codex shape and Copilot top-level shape)
+// =========================================================================
+
+/// Strip every ICM-bearing hook entry from `value["hooks"]`, cascading the
+/// clean-up: empty `hooks[]` arrays drop their wrapper entry, empty event
+/// arrays drop the event key, and an empty `hooks` object drops the top-
+/// level key. The root JSON object is never deleted.
+pub(crate) fn strip_json_hooks(value: &mut Value, field: HookCommandField) -> StripResult {
+    let Some(root) = value.as_object_mut() else {
+        return StripResult::NoOp;
+    };
+    let Some(hooks_value) = root.get_mut("hooks") else {
+        return StripResult::NoOp;
+    };
+    let Some(hooks_obj) = hooks_value.as_object_mut() else {
+        return StripResult::NoOp;
+    };
+
+    let mut removed = 0usize;
+    let event_names: Vec<String> = hooks_obj.keys().cloned().collect();
+
+    for event in event_names {
+        let Some(event_arr) = hooks_obj.get_mut(&event).and_then(|v| v.as_array_mut()) else {
+            continue;
+        };
+
+        match field {
+            HookCommandField::Command => {
+                // Mutate each entry's `hooks[]` in place; collect indices
+                // to drop after the inner pass.
+                let mut entry_drop = Vec::new();
+                for (i, entry) in event_arr.iter_mut().enumerate() {
+                    let Some(inner) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) else {
+                        continue;
+                    };
+                    let before = inner.len();
+                    inner.retain(|h| {
+                        h.get("command")
+                            .and_then(|c| c.as_str())
+                            .map(|s| !crate::cmd_matches_icm_pattern(s, "icm hook"))
+                            .unwrap_or(true)
+                    });
+                    removed += before - inner.len();
+                    if inner.is_empty() {
+                        entry_drop.push(i);
+                    }
+                }
+                // Drop entries whose `hooks[]` became empty. Reverse-iter
+                // so indices stay valid.
+                for i in entry_drop.into_iter().rev() {
+                    event_arr.remove(i);
+                }
+            }
+            HookCommandField::BashTopLevel => {
+                let before = event_arr.len();
+                event_arr.retain(|entry| {
+                    entry
+                        .get("bash")
+                        .and_then(|b| b.as_str())
+                        .map(|s| !crate::cmd_matches_icm_pattern(s, "icm hook"))
+                        .unwrap_or(true)
+                });
+                removed += before - event_arr.len();
+            }
+        }
+    }
+
+    // Cascade clean: drop now-empty event arrays.
+    let empty_events: Vec<String> = hooks_obj
+        .iter()
+        .filter_map(|(k, v)| v.as_array().filter(|a| a.is_empty()).map(|_| k.clone()))
+        .collect();
+    for k in empty_events {
+        hooks_obj.remove(&k);
+    }
+    if hooks_obj.is_empty() {
+        root.remove("hooks");
+    }
+
+    if removed == 0 {
+        StripResult::NoOp
+    } else {
+        StripResult::Removed { removed }
+    }
+}
+
+// =========================================================================
+// TOML: [<table>.<entry>]
+// =========================================================================
+
+/// Remove `[<table>.<entry>]` from a TOML document. Cleans up an empty
+/// parent table. Note: this round-trips through `toml`, which loses
+/// comments — symmetric with `inject_codex_mcp_server` in `main.rs`.
+pub(crate) fn strip_toml_table(value: &mut toml::Value, table: &str, entry: &str) -> StripResult {
+    let Some(root) = value.as_table_mut() else {
+        return StripResult::NoOp;
+    };
+    let Some(parent) = root.get_mut(table).and_then(|v| v.as_table_mut()) else {
+        return StripResult::NoOp;
+    };
+    if parent.remove(entry).is_some() {
+        if parent.is_empty() {
+            root.remove(table);
+        }
+        StripResult::Removed { removed: 1 }
+    } else {
+        StripResult::NoOp
+    }
+}
+
+// =========================================================================
+// YAML: Continue.dev `- name: icm` block
+// =========================================================================
+
+/// Strip a single `- name: icm` block from a YAML document, with strict
+/// structural validation. Returns `Ambiguous` if the block doesn't carry
+/// both a `command:` and an `args:` continuation line — in that case the
+/// user has hand-edited the layout and we refuse to guess.
+pub(crate) fn strip_yaml_continue(content: &str) -> StripResult {
+    let lines: Vec<&str> = content.lines().collect();
+    let Some(start) = lines.iter().position(|l| {
+        let t = l.trim_start();
+        t.starts_with("- name: icm") || t.starts_with("- name: \"icm\"")
+    }) else {
+        return StripResult::NoOp;
+    };
+    let start_indent = lines[start].len() - lines[start].trim_start().len();
+
+    // The block is the starting `- ` line plus every continuation line
+    // indented strictly more than `start_indent`. A blank line inside the
+    // block counts as a continuation only if the next non-blank line is
+    // still more-indented than `start_indent`.
+    let mut end = start + 1;
+    while end < lines.len() {
+        let line = lines[end];
+        if line.trim().is_empty() {
+            // Peek ahead: blanks belong to the block only if continuation
+            // follows.
+            let mut peek = end + 1;
+            while peek < lines.len() && lines[peek].trim().is_empty() {
+                peek += 1;
+            }
+            if peek < lines.len() {
+                let indent = lines[peek].len() - lines[peek].trim_start().len();
+                if indent > start_indent {
+                    end = peek + 1;
+                    continue;
+                }
+            }
+            break;
+        }
+        let indent = line.len() - line.trim_start().len();
+        if indent > start_indent {
+            end += 1;
+        } else {
+            break;
+        }
+    }
+
+    // Structural check: the block must contain both `command:` and `args:`
+    // (Continue.dev's canonical shape, which is what init writes).
+    let block = &lines[start..end];
+    let mut has_command = false;
+    let mut has_args = false;
+    for line in block {
+        let t = line.trim_start();
+        if t.starts_with("command:") {
+            has_command = true;
+        } else if t.starts_with("args:") {
+            has_args = true;
+        }
+    }
+    if !(has_command && has_args) {
+        return StripResult::Ambiguous {
+            reason: format!(
+                "YAML block at line {} for `- name: icm` is missing the canonical `command:`/`args:` lines — refusing to guess; review the file by hand.",
+                start + 1
+            ),
+        };
+    }
+
+    let kept: Vec<&str> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(i, l)| {
+            if i >= start && i < end {
+                None
+            } else {
+                Some(*l)
+            }
+        })
+        .collect();
+    let new_content = if content.ends_with('\n') {
+        format!("{}\n", kept.join("\n"))
+    } else {
+        kept.join("\n")
+    };
+    if new_content == content {
+        StripResult::NoOp
+    } else {
+        // Caller persists `new_content` via `apply_yaml_continue`.
+        // We can't bundle the string in `StripResult::Removed` without
+        // bloating the enum, so the apply function recomputes once. Keep
+        // both call sites in sync via the helper below.
+        StripResult::Removed { removed: 1 }
+    }
+}
+
+/// Same logic as [`strip_yaml_continue`] but returns the rewritten
+/// content. Used by the mutator after `strip_yaml_continue` reports a
+/// removal. Returning two values from the same scan would simplify the
+/// API; that refactor can wait.
+pub(crate) fn apply_yaml_continue(content: &str) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+    let Some(start) = lines.iter().position(|l| {
+        let t = l.trim_start();
+        t.starts_with("- name: icm") || t.starts_with("- name: \"icm\"")
+    }) else {
+        return content.to_string();
+    };
+    let start_indent = lines[start].len() - lines[start].trim_start().len();
+    let mut end = start + 1;
+    while end < lines.len() {
+        let line = lines[end];
+        if line.trim().is_empty() {
+            let mut peek = end + 1;
+            while peek < lines.len() && lines[peek].trim().is_empty() {
+                peek += 1;
+            }
+            if peek < lines.len() {
+                let indent = lines[peek].len() - lines[peek].trim_start().len();
+                if indent > start_indent {
+                    end = peek + 1;
+                    continue;
+                }
+            }
+            break;
+        }
+        let indent = line.len() - line.trim_start().len();
+        if indent > start_indent {
+            end += 1;
+        } else {
+            break;
+        }
+    }
+    let kept: Vec<&str> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(i, l)| {
+            if i >= start && i < end {
+                None
+            } else {
+                Some(*l)
+            }
+        })
+        .collect();
+    if content.ends_with('\n') {
+        format!("{}\n", kept.join("\n"))
+    } else {
+        kept.join("\n")
+    }
+}
+
+// =========================================================================
+// Markdown: <!-- icm:start --> ... <!-- icm:end -->
+// =========================================================================
+
+/// Result of `strip_markdown_block`: either a rewritten string, the
+/// signal to delete the file (block was the only content), or a no-op.
+pub(crate) enum MarkdownOutcome {
+    NoOp,
+    Rewrite(String),
+    DeleteFile,
+}
+
+pub(crate) fn strip_markdown_block(content: &str) -> MarkdownOutcome {
+    const START: &str = "<!-- icm:start -->";
+    const END: &str = "<!-- icm:end -->";
+    let Some(start) = content.find(START) else {
+        return MarkdownOutcome::NoOp;
+    };
+    let end = content
+        .find(END)
+        .map(|o| o + END.len())
+        .unwrap_or(content.len());
+    let before = &content[..start];
+    let after = if end <= content.len() {
+        &content[end..]
+    } else {
+        ""
+    };
+    if before.trim().is_empty() && after.trim().is_empty() {
+        return MarkdownOutcome::DeleteFile;
+    }
+    // Collapse the blank line that often separates the block from its
+    // surroundings: trim trailing whitespace from `before` and leading
+    // whitespace from `after`, then rejoin with one newline.
+    let trimmed_before = before.trim_end();
+    let trimmed_after = after.trim_start();
+    let mut out = String::with_capacity(trimmed_before.len() + trimmed_after.len() + 2);
+    out.push_str(trimmed_before);
+    if !trimmed_before.is_empty() && !trimmed_after.is_empty() {
+        out.push_str("\n\n");
+    }
+    out.push_str(trimmed_after);
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    MarkdownOutcome::Rewrite(out)
+}
+
+// =========================================================================
+// Public file-level helpers used by the mutator
+// =========================================================================
+
+/// Read JSON, mutate, write back. Returns the strip outcome. The caller
+/// is responsible for backing up `path` before invoking this.
+pub(crate) fn rewrite_json_mcp(path: &std::path::Path, dotted_key: &str) -> Result<StripResult> {
+    let mut value = crate::parse_json_config(path)?;
+    let result = strip_json_mcp_server(&mut value, dotted_key);
+    if matches!(result, StripResult::Removed { .. }) {
+        let out = serde_json::to_string_pretty(&value)?;
+        std::fs::write(path, out).with_context(|| format!("cannot write {}", path.display()))?;
+    }
+    Ok(result)
+}
+
+pub(crate) fn rewrite_json_hooks(
+    path: &std::path::Path,
+    field: HookCommandField,
+) -> Result<StripResult> {
+    let mut value = crate::parse_json_config(path)?;
+    let result = strip_json_hooks(&mut value, field);
+    if matches!(result, StripResult::Removed { .. }) {
+        let out = serde_json::to_string_pretty(&value)?;
+        std::fs::write(path, out).with_context(|| format!("cannot write {}", path.display()))?;
+    }
+    Ok(result)
+}
+
+pub(crate) fn rewrite_toml(
+    path: &std::path::Path,
+    table: &str,
+    entry: &str,
+) -> Result<StripResult> {
+    let content =
+        std::fs::read_to_string(path).with_context(|| format!("cannot read {}", path.display()))?;
+    let mut value: toml::Value = content.parse()?;
+    let result = strip_toml_table(&mut value, table, entry);
+    if matches!(result, StripResult::Removed { .. }) {
+        let out = toml::to_string(&value)?;
+        std::fs::write(path, out).with_context(|| format!("cannot write {}", path.display()))?;
+    }
+    Ok(result)
+}
+
+pub(crate) fn rewrite_yaml_continue(path: &std::path::Path) -> Result<StripResult> {
+    let content =
+        std::fs::read_to_string(path).with_context(|| format!("cannot read {}", path.display()))?;
+    let result = strip_yaml_continue(&content);
+    if matches!(result, StripResult::Removed { .. }) {
+        let new_content = apply_yaml_continue(&content);
+        std::fs::write(path, new_content)
+            .with_context(|| format!("cannot write {}", path.display()))?;
+    }
+    Ok(result)
+}
+
+pub(crate) fn rewrite_markdown(path: &std::path::Path) -> Result<StripResult> {
+    let content =
+        std::fs::read_to_string(path).with_context(|| format!("cannot read {}", path.display()))?;
+    match strip_markdown_block(&content) {
+        MarkdownOutcome::NoOp => Ok(StripResult::NoOp),
+        MarkdownOutcome::Rewrite(new) => {
+            std::fs::write(path, new)
+                .with_context(|| format!("cannot write {}", path.display()))?;
+            Ok(StripResult::Removed { removed: 1 })
+        }
+        MarkdownOutcome::DeleteFile => {
+            std::fs::remove_file(path)
+                .with_context(|| format!("cannot delete {}", path.display()))?;
+            Ok(StripResult::DeleteFile)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn strip_mcp_server_removes_icm_and_keeps_siblings() {
+        let mut v = json!({
+            "mcpServers": {
+                "icm": {"command": "/x/icm"},
+                "other": {"command": "/x/o"}
+            }
+        });
+        let r = strip_json_mcp_server(&mut v, "mcpServers");
+        assert_eq!(r, StripResult::Removed { removed: 1 });
+        assert!(v["mcpServers"].get("icm").is_none());
+        assert!(v["mcpServers"].get("other").is_some());
+    }
+
+    #[test]
+    fn strip_mcp_server_drops_emptied_parent() {
+        let mut v = json!({ "mcpServers": { "icm": {} } });
+        let r = strip_json_mcp_server(&mut v, "mcpServers");
+        assert_eq!(r, StripResult::Removed { removed: 1 });
+        // Parent dropped because it became empty.
+        assert!(v.get("mcpServers").is_none());
+    }
+
+    #[test]
+    fn strip_mcp_server_dotted_path() {
+        let mut v = json!({ "amp": { "mcpServers": { "icm": {}, "k": {} } } });
+        let r = strip_json_mcp_server(&mut v, "amp.mcpServers");
+        assert_eq!(r, StripResult::Removed { removed: 1 });
+        assert!(v["amp"]["mcpServers"].get("icm").is_none());
+        assert!(v["amp"]["mcpServers"].get("k").is_some());
+    }
+
+    #[test]
+    fn strip_mcp_server_noop_when_absent() {
+        let mut v = json!({ "mcpServers": { "other": {} } });
+        let r = strip_json_mcp_server(&mut v, "mcpServers");
+        assert_eq!(r, StripResult::NoOp);
+    }
+
+    #[test]
+    fn strip_hooks_command_field_removes_icm_keeps_siblings_and_cascades() {
+        let mut v = json!({
+            "hooks": {
+                "PreToolUse": [
+                    {"matcher":"Bash","hooks":[
+                        {"type":"command","command":"/x/icm hook pre"},
+                        {"type":"command","command":"/x/other"}
+                    ]}
+                ],
+                "PostToolUse": [
+                    {"hooks":[{"type":"command","command":"/x/icm hook post"}]}
+                ]
+            }
+        });
+        let r = strip_json_hooks(&mut v, HookCommandField::Command);
+        assert_eq!(r, StripResult::Removed { removed: 2 });
+        // Sibling hook preserved.
+        let pre_entry = &v["hooks"]["PreToolUse"][0];
+        assert_eq!(pre_entry["hooks"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            pre_entry["hooks"][0]["command"].as_str().unwrap(),
+            "/x/other"
+        );
+        // PostToolUse became empty -> event key dropped.
+        assert!(v["hooks"].get("PostToolUse").is_none());
+    }
+
+    #[test]
+    fn strip_hooks_drops_hooks_object_when_completely_empty() {
+        let mut v = json!({
+            "permissions": ["read"],
+            "hooks": {
+                "PreToolUse": [
+                    {"hooks":[{"type":"command","command":"/x/icm hook pre"}]}
+                ]
+            }
+        });
+        let r = strip_json_hooks(&mut v, HookCommandField::Command);
+        assert_eq!(r, StripResult::Removed { removed: 1 });
+        // hooks object dropped entirely; permissions untouched.
+        assert!(v.get("hooks").is_none());
+        assert_eq!(v["permissions"][0].as_str().unwrap(), "read");
+    }
+
+    #[test]
+    fn strip_hooks_bash_top_level_for_copilot() {
+        let mut v = json!({
+            "hooks": {
+                "sessionStart": [
+                    {"type":"command","bash":"/x/icm hook start","timeoutSec":10},
+                    {"type":"command","bash":"/x/other","timeoutSec":5}
+                ]
+            }
+        });
+        let r = strip_json_hooks(&mut v, HookCommandField::BashTopLevel);
+        assert_eq!(r, StripResult::Removed { removed: 1 });
+        let arr = v["hooks"]["sessionStart"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["bash"].as_str().unwrap(), "/x/other");
+    }
+
+    #[test]
+    fn strip_toml_table_removes_and_cascades() {
+        let src = r#"
+[some.other]
+hello = "world"
+
+[mcp_servers.icm]
+command = "/x/icm"
+args = ["serve"]
+"#;
+        let mut v: toml::Value = src.parse().unwrap();
+        let r = strip_toml_table(&mut v, "mcp_servers", "icm");
+        assert_eq!(r, StripResult::Removed { removed: 1 });
+        // mcp_servers parent had only icm -> dropped.
+        assert!(v.get("mcp_servers").is_none());
+        // Sibling table preserved.
+        assert!(v["some"]["other"]["hello"].is_str());
+    }
+
+    #[test]
+    fn strip_toml_table_keeps_parent_with_siblings() {
+        let src = r#"
+[mcp_servers.icm]
+command = "/x/icm"
+
+[mcp_servers.other]
+command = "/x/o"
+"#;
+        let mut v: toml::Value = src.parse().unwrap();
+        let r = strip_toml_table(&mut v, "mcp_servers", "icm");
+        assert_eq!(r, StripResult::Removed { removed: 1 });
+        assert!(v["mcp_servers"].get("other").is_some());
+        assert!(v["mcp_servers"].get("icm").is_none());
+    }
+
+    #[test]
+    fn strip_yaml_continue_removes_canonical_block() {
+        let src = "\
+mcpServers:
+  - name: icm
+    command: /x/icm
+    args:
+      - serve
+  - name: other
+    command: /x/other
+    args:
+      - run
+";
+        let r = strip_yaml_continue(src);
+        assert_eq!(r, StripResult::Removed { removed: 1 });
+        let new = apply_yaml_continue(src);
+        assert!(!new.contains("- name: icm"));
+        assert!(new.contains("- name: other"));
+    }
+
+    #[test]
+    fn strip_yaml_continue_flags_ambiguous_block_missing_command_or_args() {
+        let src = "\
+mcpServers:
+  - name: icm
+    foo: bar
+";
+        let r = strip_yaml_continue(src);
+        assert!(
+            matches!(r, StripResult::Ambiguous { .. }),
+            "expected Ambiguous, got {r:?}"
+        );
+    }
+
+    #[test]
+    fn strip_yaml_continue_noop_when_absent() {
+        let src = "mcpServers:\n  - name: other\n    command: /x/o\n";
+        assert_eq!(strip_yaml_continue(src), StripResult::NoOp);
+    }
+
+    #[test]
+    fn strip_markdown_block_preserves_surrounding_content() {
+        let src = "intro\n\n<!-- icm:start -->\nblock\n<!-- icm:end -->\n\noutro\n";
+        match strip_markdown_block(src) {
+            MarkdownOutcome::Rewrite(new) => {
+                assert!(!new.contains("icm:start"));
+                assert!(new.contains("intro"));
+                assert!(new.contains("outro"));
+            }
+            other => panic!("expected Rewrite, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn strip_markdown_block_deletes_file_when_block_is_only_content() {
+        let src = "<!-- icm:start -->\nfoo\n<!-- icm:end -->\n";
+        assert!(matches!(
+            strip_markdown_block(src),
+            MarkdownOutcome::DeleteFile
+        ));
+    }
+
+    #[test]
+    fn strip_markdown_block_noop_when_no_block() {
+        let src = "# Title\n\nbody\n";
+        assert!(matches!(strip_markdown_block(src), MarkdownOutcome::NoOp));
+    }
+
+    impl std::fmt::Debug for MarkdownOutcome {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                MarkdownOutcome::NoOp => write!(f, "NoOp"),
+                MarkdownOutcome::Rewrite(_) => write!(f, "Rewrite(..)"),
+                MarkdownOutcome::DeleteFile => write!(f, "DeleteFile"),
+            }
+        }
+    }
+}

--- a/crates/icm-cli/src/uninstall/locations.rs
+++ b/crates/icm-cli/src/uninstall/locations.rs
@@ -9,10 +9,6 @@
 //! Path resolution honors the same environment overrides as `cmd_init`:
 //! `CLAUDE_CONFIG_DIR`, `GEMINI_CONFIG_DIR`, `CODEX_HOME`, `COPILOT_HOME`.
 
-// The catalog is consumed by `discover` in the next commit on this PR;
-// suppress dead-code warnings until that hooks up.
-#![allow(dead_code)]
-
 use std::path::PathBuf;
 
 use anyhow::Result;

--- a/crates/icm-cli/src/uninstall/locations.rs
+++ b/crates/icm-cli/src/uninstall/locations.rs
@@ -1,0 +1,595 @@
+//! Catalog of every file `icm init` may have touched.
+//!
+//! The list is built statically per the mirror of `cmd_init`
+//! (`crates/icm-cli/src/main.rs`). When `icm init` learns to write a new
+//! file, this catalog must be kept in sync. A future PR will replace this
+//! with an install manifest persisted at init time so uninstall doesn't
+//! have to re-derive the surface from a hard-coded list (issue #229).
+//!
+//! Path resolution honors the same environment overrides as `cmd_init`:
+//! `CLAUDE_CONFIG_DIR`, `GEMINI_CONFIG_DIR`, `CODEX_HOME`, `COPILOT_HOME`.
+
+// The catalog is consumed by `discover` in the next commit on this PR;
+// suppress dead-code warnings until that hooks up.
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+/// Shape of the command field inside a hook entry. Copilot uses a
+/// top-level `bash` field; every other CLI uses `hooks[].command`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum HookCommandField {
+    Command,
+    BashTopLevel,
+}
+
+/// One *category* of artifact init produces. Drives the matching strategy
+/// in `discover::scan` and the mutation strategy in `formats`.
+#[derive(Clone, Debug)]
+pub(crate) enum LocationKind {
+    /// JSON file (possibly JSONC). The icm entry lives at
+    /// `<servers_key>.icm` when `servers_key` is `Some`; the file may also
+    /// carry a `hooks.<Event>[].hooks[]` section that needs filtering.
+    /// `servers_key` accepts dotted paths (e.g. `"amp.mcpServers"`).
+    JsonConfig {
+        servers_key: Option<&'static str>,
+        has_hooks: bool,
+        hooks_field: HookCommandField,
+    },
+    /// TOML file with `[<table>.<entry>]` to remove, plus dotted child
+    /// keys like `<table>.<entry>.env`.
+    TomlMcp {
+        table: &'static str,
+        entry: &'static str,
+    },
+    /// Continue.dev YAML — regex-stripped block under `mcpServers:`.
+    YamlContinue,
+    /// Markdown file with an `<!-- icm:start --> ... <!-- icm:end -->`
+    /// block to remove. Whole file is deleted if the block was the only
+    /// content.
+    MarkdownBlock,
+    /// Whole-file artifact owned solely by `icm init` (skill prompts,
+    /// OpenCode plugin). Deleted outright.
+    OwnedFile,
+    /// Data directory. Touched only with `--purge-data`. The catalog
+    /// records the directory; discover enumerates the actual files inside.
+    DataDir,
+}
+
+/// One concrete file/directory ICM may have written to.
+#[derive(Clone, Debug)]
+pub(crate) struct LocationSpec {
+    pub label: &'static str,
+    pub path: PathBuf,
+    pub kind: LocationKind,
+    /// `true` for DataDir entries (memories.db, fastembed cache) that are
+    /// preserved unless the user passes `--purge-data`.
+    pub purge_data_only: bool,
+}
+
+/// Resolved per-tool directories, honoring env var overrides. Built once
+/// at the start of `uninstall::run` and passed into the catalog.
+#[derive(Clone, Debug)]
+pub(crate) struct DirContext {
+    pub home: PathBuf,
+    pub claude_dir: PathBuf,
+    pub gemini_dir: PathBuf,
+    pub codex_dir: PathBuf,
+    pub copilot_dir: PathBuf,
+    pub vscode_data: PathBuf,
+    pub zed_settings: PathBuf,
+    pub cwd: PathBuf,
+}
+
+impl DirContext {
+    /// Resolve every dir from the environment exactly the way `cmd_init`
+    /// does. Tests should construct `DirContext` manually with a tempdir.
+    pub(crate) fn from_env() -> Result<Self> {
+        let home_str = crate::home_dir_str()?;
+        let home = PathBuf::from(&home_str);
+        let claude_dir = crate::cli_config_dir("CLAUDE_CONFIG_DIR", ".claude", &home_str);
+        let gemini_dir = crate::cli_config_dir("GEMINI_CONFIG_DIR", ".gemini", &home_str);
+        let codex_dir = crate::cli_config_dir("CODEX_HOME", ".codex", &home_str);
+        let copilot_dir = crate::cli_config_dir("COPILOT_HOME", ".copilot", &home_str);
+        let vscode_data = if cfg!(target_os = "macos") {
+            home.join("Library/Application Support/Code/User")
+        } else {
+            home.join(".config/Code/User")
+        };
+        let zed_settings = if cfg!(target_os = "macos") {
+            home.join(".zed/settings.json")
+        } else {
+            home.join(".config/zed/settings.json")
+        };
+        let cwd = std::env::current_dir()?;
+        Ok(Self {
+            home,
+            claude_dir,
+            gemini_dir,
+            codex_dir,
+            copilot_dir,
+            vscode_data,
+            zed_settings,
+            cwd,
+        })
+    }
+
+    /// `~/.claude.json` lives at the home root, unless `CLAUDE_CONFIG_DIR`
+    /// is set — in which case `cmd_init` colocates it inside the override.
+    pub(crate) fn claude_legacy_json(&self) -> PathBuf {
+        if std::env::var("CLAUDE_CONFIG_DIR")
+            .map(|s| !s.is_empty())
+            .unwrap_or(false)
+        {
+            self.claude_dir.join(".claude.json")
+        } else {
+            self.home.join(".claude.json")
+        }
+    }
+
+    pub(crate) fn claude_desktop_json(&self) -> PathBuf {
+        self.home
+            .join("Library/Application Support/Claude/claude_desktop_config.json")
+    }
+}
+
+/// `ProjectDirs::from("dev","icm","icm")` data dir, mirroring
+/// `default_db_path` in `main.rs`. Returned even if the directory does
+/// not exist on disk so discover can decide whether it's a hit.
+pub(crate) fn icm_data_dir() -> Option<PathBuf> {
+    directories::ProjectDirs::from("dev", "icm", "icm").map(|d| d.data_dir().to_path_buf())
+}
+
+/// Same as [`icm_data_dir`] for the fastembed model cache.
+pub(crate) fn icm_cache_dir() -> Option<PathBuf> {
+    directories::ProjectDirs::from("dev", "icm", "icm").map(|d| d.cache_dir().to_path_buf())
+}
+
+/// Build the full catalog of locations to scan.
+///
+/// Order roughly groups locations by tool family so reports group nicely.
+/// Path existence is **not** checked here — discover does that.
+pub(crate) fn build_locations(d: &DirContext) -> Vec<LocationSpec> {
+    use HookCommandField as F;
+    use LocationKind as K;
+
+    let mut specs = Vec::with_capacity(40);
+
+    // --- Claude Code (mcpServers + hooks + skills + cwd CLAUDE.md) ---
+    specs.push(LocationSpec {
+        label: "Claude Code MCP",
+        path: d.claude_legacy_json(),
+        kind: K::JsonConfig {
+            servers_key: Some("mcpServers"),
+            has_hooks: false,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "Claude Code hooks",
+        path: d.claude_dir.join("settings.json"),
+        kind: K::JsonConfig {
+            servers_key: None,
+            has_hooks: true,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "Claude Code /recall",
+        path: d.claude_dir.join("commands/recall.md"),
+        kind: K::OwnedFile,
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "Claude Code /remember",
+        path: d.claude_dir.join("commands/remember.md"),
+        kind: K::OwnedFile,
+        purge_data_only: false,
+    });
+
+    // --- Claude Desktop (macOS) ---
+    specs.push(LocationSpec {
+        label: "Claude Desktop MCP",
+        path: d.claude_desktop_json(),
+        kind: K::JsonConfig {
+            servers_key: Some("mcpServers"),
+            has_hooks: false,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+
+    // --- Codex CLI (TOML MCP + JSON hooks) ---
+    specs.push(LocationSpec {
+        label: "Codex CLI MCP",
+        path: d.codex_dir.join("config.toml"),
+        kind: K::TomlMcp {
+            table: "mcp_servers",
+            entry: "icm",
+        },
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "Codex CLI hooks",
+        path: d.codex_dir.join("hooks.json"),
+        kind: K::JsonConfig {
+            servers_key: None,
+            has_hooks: true,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+
+    // --- Gemini CLI (MCP + hooks live in the same settings.json) ---
+    specs.push(LocationSpec {
+        label: "Gemini CLI",
+        path: d.gemini_dir.join("settings.json"),
+        kind: K::JsonConfig {
+            servers_key: Some("mcpServers"),
+            has_hooks: true,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "Gemini CLI GEMINI.md",
+        path: d.gemini_dir.join("GEMINI.md"),
+        kind: K::MarkdownBlock,
+        purge_data_only: false,
+    });
+
+    // --- Copilot CLI (separate mcp + settings files, bash top-level hooks) ---
+    specs.push(LocationSpec {
+        label: "Copilot CLI MCP",
+        path: d.copilot_dir.join("mcp-config.json"),
+        kind: K::JsonConfig {
+            servers_key: Some("mcpServers"),
+            has_hooks: false,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "Copilot CLI hooks",
+        path: d.copilot_dir.join("settings.json"),
+        kind: K::JsonConfig {
+            servers_key: None,
+            has_hooks: true,
+            hooks_field: F::BashTopLevel,
+        },
+        purge_data_only: false,
+    });
+
+    // --- Cursor ---
+    specs.push(LocationSpec {
+        label: "Cursor MCP",
+        path: d.home.join(".cursor/mcp.json"),
+        kind: K::JsonConfig {
+            servers_key: Some("mcpServers"),
+            has_hooks: false,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "Cursor rule",
+        path: d.home.join(".cursor/rules/icm.mdc"),
+        kind: K::OwnedFile,
+        purge_data_only: false,
+    });
+
+    // --- Roo Code (global rules) ---
+    specs.push(LocationSpec {
+        label: "Roo Code rule",
+        path: d.home.join(".roo/rules/icm.md"),
+        kind: K::OwnedFile,
+        purge_data_only: false,
+    });
+
+    // --- Windsurf ---
+    specs.push(LocationSpec {
+        label: "Windsurf MCP",
+        path: d.home.join(".codeium/windsurf/mcp_config.json"),
+        kind: K::JsonConfig {
+            servers_key: Some("mcpServers"),
+            has_hooks: false,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+
+    // --- VS Code (user mcp.json + 3 extensions in globalStorage) ---
+    specs.push(LocationSpec {
+        label: "VS Code MCP",
+        path: d.vscode_data.join("mcp.json"),
+        kind: K::JsonConfig {
+            servers_key: Some("servers"),
+            has_hooks: false,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "Cline (VS Code)",
+        path: d
+            .vscode_data
+            .join("globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json"),
+        kind: K::JsonConfig {
+            servers_key: Some("mcpServers"),
+            has_hooks: false,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "Roo (VS Code)",
+        path: d
+            .vscode_data
+            .join("globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json"),
+        kind: K::JsonConfig {
+            servers_key: Some("mcpServers"),
+            has_hooks: false,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "Kilo Code (VS Code)",
+        path: d
+            .vscode_data
+            .join("globalStorage/kilocode.kilo-code/settings/mcp_settings.json"),
+        kind: K::JsonConfig {
+            servers_key: Some("mcpServers"),
+            has_hooks: false,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+
+    // --- Zed ---
+    specs.push(LocationSpec {
+        label: "Zed MCP",
+        path: d.zed_settings.clone(),
+        kind: K::JsonConfig {
+            servers_key: Some("context_servers"),
+            has_hooks: false,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+
+    // --- OpenCode (different JSON shape under "mcp" + TS plugin) ---
+    specs.push(LocationSpec {
+        label: "OpenCode MCP",
+        path: d.home.join(".config/opencode/opencode.json"),
+        kind: K::JsonConfig {
+            servers_key: Some("mcp"),
+            has_hooks: false,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "OpenCode plugin",
+        path: d.home.join(".config/opencode/plugins/icm.ts"),
+        kind: K::OwnedFile,
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "OpenCode plugin (legacy .js)",
+        path: d.home.join(".config/opencode/plugins/icm.js"),
+        kind: K::OwnedFile,
+        purge_data_only: false,
+    });
+
+    // --- Amp (dotted servers key + skills) ---
+    specs.push(LocationSpec {
+        label: "Amp MCP",
+        path: d.home.join(".config/amp/settings.json"),
+        kind: K::JsonConfig {
+            servers_key: Some("amp.mcpServers"),
+            has_hooks: false,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "Amp /icm-recall",
+        path: d.home.join(".config/amp/skills/icm-recall.md"),
+        kind: K::OwnedFile,
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "Amp /icm-remember",
+        path: d.home.join(".config/amp/skills/icm-remember.md"),
+        kind: K::OwnedFile,
+        purge_data_only: false,
+    });
+
+    // --- Amazon Q ---
+    specs.push(LocationSpec {
+        label: "Amazon Q MCP",
+        path: d.home.join(".aws/amazonq/mcp.json"),
+        kind: K::JsonConfig {
+            servers_key: Some("mcpServers"),
+            has_hooks: false,
+            hooks_field: F::Command,
+        },
+        purge_data_only: false,
+    });
+
+    // --- Continue.dev (YAML config) ---
+    specs.push(LocationSpec {
+        label: "Continue.dev",
+        path: d.home.join(".continue/config.yaml"),
+        kind: K::YamlContinue,
+        purge_data_only: false,
+    });
+
+    // --- Cwd instruction files (written by `icm init` at the cwd it ran in) ---
+    let cwd_md_files: &[(&str, &str)] = &[
+        ("CLAUDE.md (cwd)", "CLAUDE.md"),
+        ("AGENTS.md (cwd)", "AGENTS.md"),
+        (
+            "Copilot instructions (cwd)",
+            ".github/copilot-instructions.md",
+        ),
+        ("Windsurf rules (cwd)", ".windsurfrules"),
+        ("Aider conventions (cwd)", ".aider.conventions.md"),
+    ];
+    for (label, rel) in cwd_md_files {
+        specs.push(LocationSpec {
+            label,
+            path: d.cwd.join(rel),
+            kind: K::MarkdownBlock,
+            purge_data_only: false,
+        });
+    }
+
+    // --- Data (--purge-data) ---
+    if let Some(data) = icm_data_dir() {
+        specs.push(LocationSpec {
+            label: "ICM database directory",
+            path: data,
+            kind: K::DataDir,
+            purge_data_only: true,
+        });
+    }
+    if let Some(cache) = icm_cache_dir() {
+        specs.push(LocationSpec {
+            label: "Fastembed model cache",
+            path: cache.join("models"),
+            kind: K::DataDir,
+            purge_data_only: true,
+        });
+    }
+
+    specs
+}
+
+/// Convenience for tests: build a `DirContext` rooted at `root`, so the
+/// real `$HOME` is not touched.
+#[cfg(test)]
+pub(crate) fn dir_context_under(root: &std::path::Path) -> DirContext {
+    let home = root.to_path_buf();
+    let vscode_data = if cfg!(target_os = "macos") {
+        home.join("Library/Application Support/Code/User")
+    } else {
+        home.join(".config/Code/User")
+    };
+    let zed_settings = if cfg!(target_os = "macos") {
+        home.join(".zed/settings.json")
+    } else {
+        home.join(".config/zed/settings.json")
+    };
+    DirContext {
+        home: home.clone(),
+        claude_dir: home.join(".claude"),
+        gemini_dir: home.join(".gemini"),
+        codex_dir: home.join(".codex"),
+        copilot_dir: home.join(".copilot"),
+        vscode_data,
+        zed_settings,
+        cwd: home.join("proj"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_locations_covers_every_tool_family_under_fake_home() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let d = dir_context_under(tmp.path());
+        let specs = build_locations(&d);
+
+        // Sanity: catalog should include all major surfaces. Tweak as
+        // `cmd_init` learns new files.
+        let labels: Vec<&str> = specs.iter().map(|s| s.label).collect();
+        for expected in [
+            "Claude Code MCP",
+            "Claude Code hooks",
+            "Claude Code /recall",
+            "Claude Code /remember",
+            "Claude Desktop MCP",
+            "Codex CLI MCP",
+            "Codex CLI hooks",
+            "Gemini CLI",
+            "Gemini CLI GEMINI.md",
+            "Copilot CLI MCP",
+            "Copilot CLI hooks",
+            "Cursor MCP",
+            "Cursor rule",
+            "Roo Code rule",
+            "Windsurf MCP",
+            "VS Code MCP",
+            "Cline (VS Code)",
+            "Roo (VS Code)",
+            "Kilo Code (VS Code)",
+            "Zed MCP",
+            "OpenCode MCP",
+            "OpenCode plugin",
+            "Amp MCP",
+            "Amp /icm-recall",
+            "Amp /icm-remember",
+            "Amazon Q MCP",
+            "Continue.dev",
+            "CLAUDE.md (cwd)",
+            "AGENTS.md (cwd)",
+        ] {
+            assert!(
+                labels.contains(&expected),
+                "catalog missing {expected}: {labels:?}"
+            );
+        }
+
+        // Every non-data spec must live under the fake home or the fake
+        // cwd; nothing should escape to the real filesystem.
+        for spec in &specs {
+            if spec.purge_data_only {
+                continue; // data dirs are platform-global; not under tempdir
+            }
+            let p = spec.path.to_string_lossy();
+            let under_home = p.starts_with(&*tmp.path().to_string_lossy());
+            assert!(
+                under_home,
+                "{} escaped tempdir: {}",
+                spec.label,
+                spec.path.display()
+            );
+        }
+
+        // At least 25 specs, per the original audit in issue #229.
+        assert!(
+            specs.len() >= 25,
+            "catalog has only {} entries; expected at least 25",
+            specs.len()
+        );
+    }
+
+    #[test]
+    fn data_dirs_are_marked_purge_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = dir_context_under(tmp.path());
+        let specs = build_locations(&d);
+        let purge: Vec<&str> = specs
+            .iter()
+            .filter(|s| s.purge_data_only)
+            .map(|s| s.label)
+            .collect();
+        // ProjectDirs is best-effort; on minimal sandboxes it can return
+        // None, in which case nothing is marked purge-only. Assert at
+        // most "if present, all data entries are flagged".
+        for label in &purge {
+            assert!(
+                label.contains("database") || label.contains("cache"),
+                "unexpected purge-only label: {label}"
+            );
+        }
+    }
+}

--- a/crates/icm-cli/src/uninstall/mod.rs
+++ b/crates/icm-cli/src/uninstall/mod.rs
@@ -1,0 +1,80 @@
+//! Reverse `icm init`: remove every configuration mutation across detected
+//! AI tools, with timestamped backups, dry-run preview, audit, and check.
+//!
+//! Issue #229: <https://github.com/rtk-ai/icm/issues/229>.
+//!
+//! See the crate-level docs at `crates/icm-cli/src/uninstall/locations.rs`
+//! for the catalog of paths mirrored from `cmd_init`. The high-level flow
+//! is `build_locations -> discover::scan -> report or mutate -> verify`.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Args;
+
+/// CLI surface for `icm uninstall`. Kept here so the rest of the crate only
+/// imports `UninstallOpts` from this module.
+#[derive(Args, Debug, Clone)]
+pub struct UninstallOpts {
+    /// Preview removals without modifying anything. Always exits 0.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Group output by file with full discovery detail. Read-only, exits 0.
+    #[arg(long)]
+    pub audit: bool,
+
+    /// Exit 0 iff no ICM residue is found. No mutation, no backup.
+    #[arg(long)]
+    pub check: bool,
+
+    /// Also delete the SQLite memory database and the fastembed model cache.
+    /// Off by default — your personal memories are preserved.
+    #[arg(long)]
+    pub purge_data: bool,
+
+    /// Additionally scan this project tree for free-form ICM references in
+    /// instruction files (CLAUDE.md, AGENTS.md, .windsurfrules, etc.).
+    #[arg(long, value_name = "PATH")]
+    pub scan_dir: Option<PathBuf>,
+
+    /// Skip the interactive confirmation prompt.
+    #[arg(short = 'y', long)]
+    pub yes: bool,
+
+    /// Override the backup root. Defaults to `~/.icm-uninstall-backups/<ts>`.
+    #[arg(long, value_name = "PATH")]
+    pub backup_dir: Option<PathBuf>,
+
+    /// Disable backups entirely. Not recommended.
+    #[arg(long)]
+    pub no_backup: bool,
+}
+
+/// Exit codes published in `--help`.
+///
+/// | code | meaning |
+/// |------|---------|
+/// | 0    | clean / dry-run / audit succeeded |
+/// | 1    | `--check` found residue |
+/// | 2    | user declined the confirmation prompt |
+/// | 3    | partial success — residue remains after mutation (e.g. ambiguous YAML) |
+/// | 4    | I/O or parse error during mutation |
+#[allow(dead_code)] // populated incrementally across follow-up commits in this PR
+pub mod exit_codes {
+    pub const CLEAN: i32 = 0;
+    pub const CHECK_RESIDUE: i32 = 1;
+    pub const USER_DECLINED: i32 = 2;
+    pub const PARTIAL: i32 = 3;
+    pub const MUTATION_ERROR: i32 = 4;
+}
+
+/// Entry point. Returns the process exit code; the caller is responsible
+/// for invoking `std::process::exit`.
+pub fn run(opts: UninstallOpts) -> Result<i32> {
+    // Scaffold stage — subsequent commits flesh out discover/mutate/report.
+    println!("icm uninstall (scaffold) — opts: {opts:#?}");
+    println!();
+    println!("This command is being implemented incrementally. See issue #229.");
+    Ok(exit_codes::CLEAN)
+}

--- a/crates/icm-cli/src/uninstall/mod.rs
+++ b/crates/icm-cli/src/uninstall/mod.rs
@@ -69,7 +69,6 @@ pub struct UninstallOpts {
 /// | 2    | user declined the confirmation prompt |
 /// | 3    | partial success — residue remains after mutation (e.g. ambiguous YAML) |
 /// | 4    | I/O or parse error during mutation |
-#[allow(dead_code)] // populated incrementally across follow-up commits in this PR
 pub mod exit_codes {
     pub const CLEAN: i32 = 0;
     pub const CHECK_RESIDUE: i32 = 1;
@@ -94,11 +93,11 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
         return Ok(report::print_check(&plan));
     }
     if opts.audit {
-        report::print_audit(&plan, "ICM uninstall audit");
+        report::print_audit(&plan, "ICM uninstall audit", opts.purge_data);
         return Ok(exit_codes::CLEAN);
     }
     if opts.dry_run {
-        report::print_audit(&plan, "ICM uninstall (dry run)");
+        report::print_audit(&plan, "ICM uninstall (dry run)", opts.purge_data);
         return Ok(exit_codes::CLEAN);
     }
 
@@ -107,7 +106,7 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
         println!("Nothing to uninstall — already clean.");
         return Ok(exit_codes::CLEAN);
     }
-    report::print_audit(&plan, "ICM uninstall plan");
+    report::print_audit(&plan, "ICM uninstall plan", opts.purge_data);
 
     if !opts.yes && !mutate::confirm("Proceed with removal?") {
         println!("Aborted (no changes made).");

--- a/crates/icm-cli/src/uninstall/mod.rs
+++ b/crates/icm-cli/src/uninstall/mod.rs
@@ -17,7 +17,9 @@ pub(crate) mod discover;
 pub(crate) mod formats;
 pub(crate) mod locations;
 pub(crate) mod mutate;
+pub(crate) mod process;
 pub(crate) mod report;
+pub(crate) mod scan_dir;
 
 /// CLI surface for `icm uninstall`. Kept here so the rest of the crate only
 /// imports `UninstallOpts` from this module.
@@ -81,7 +83,11 @@ pub mod exit_codes {
 pub fn run(opts: UninstallOpts) -> Result<i32> {
     let dirs = locations::DirContext::from_env()?;
     let specs = locations::build_locations(&dirs);
-    let plan = discover::scan(&specs, opts.purge_data)?;
+    let mut plan = discover::scan(&specs, opts.purge_data)?;
+    if let Some(dir) = opts.scan_dir.as_deref() {
+        plan.scan_dir_hits = scan_dir::scan_dir(dir)?;
+    }
+    plan.processes = process::detect_icm_serve();
 
     // --- Read-only modes ---
     if opts.check {
@@ -124,9 +130,33 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
     }
 
     if opts.purge_data {
-        let purge_outcomes = mutate::purge_data(&plan, &mut backup_session);
-        for o in &purge_outcomes {
-            summary.record(o);
+        // Refuse to purge while `icm serve` is running unless the user
+        // explicitly opted in via `-y`. Serve keeps the SQLite DB open
+        // via WAL; deleting underneath it can corrupt cross-session
+        // neighbour processes.
+        if !plan.processes.is_empty() && !opts.yes {
+            println!();
+            println!(
+                "Refusing to --purge-data: {} `icm serve` process(es) detected. \
+                Stop them with `pkill -f 'icm serve'` (or pass -y to override at your own risk).",
+                plan.processes.len()
+            );
+            for p in &plan.processes {
+                println!("  pid={:<6} {}", p.pid, p.cmdline);
+            }
+        } else {
+            if !plan.processes.is_empty() {
+                println!();
+                println!(
+                    "WARNING: {} `icm serve` process(es) still running — \
+                    purging the DB anyway because -y was passed.",
+                    plan.processes.len()
+                );
+            }
+            let purge_outcomes = mutate::purge_data(&plan, &mut backup_session);
+            for o in &purge_outcomes {
+                summary.record(o);
+            }
         }
     }
 

--- a/crates/icm-cli/src/uninstall/mod.rs
+++ b/crates/icm-cli/src/uninstall/mod.rs
@@ -12,6 +12,8 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::Args;
 
+pub(crate) mod locations;
+
 /// CLI surface for `icm uninstall`. Kept here so the rest of the crate only
 /// imports `UninstallOpts` from this module.
 #[derive(Args, Debug, Clone)]

--- a/crates/icm-cli/src/uninstall/mod.rs
+++ b/crates/icm-cli/src/uninstall/mod.rs
@@ -12,7 +12,9 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::Args;
 
+pub(crate) mod discover;
 pub(crate) mod locations;
+pub(crate) mod report;
 
 /// CLI surface for `icm uninstall`. Kept here so the rest of the crate only
 /// imports `UninstallOpts` from this module.
@@ -74,9 +76,30 @@ pub mod exit_codes {
 /// Entry point. Returns the process exit code; the caller is responsible
 /// for invoking `std::process::exit`.
 pub fn run(opts: UninstallOpts) -> Result<i32> {
-    // Scaffold stage — subsequent commits flesh out discover/mutate/report.
-    println!("icm uninstall (scaffold) — opts: {opts:#?}");
+    let dirs = locations::DirContext::from_env()?;
+    let specs = locations::build_locations(&dirs);
+    let plan = discover::scan(&specs, opts.purge_data)?;
+
+    // --- Read-only modes ---
+    if opts.check {
+        return Ok(report::print_check(&plan));
+    }
+    if opts.audit {
+        report::print_audit(&plan, "ICM uninstall audit");
+        return Ok(exit_codes::CLEAN);
+    }
+    if opts.dry_run {
+        report::print_audit(&plan, "ICM uninstall (dry run)");
+        return Ok(exit_codes::CLEAN);
+    }
+
+    // --- Mutating run: stubbed until C4 lands ---
+    report::print_audit(&plan, "ICM uninstall plan");
     println!();
-    println!("This command is being implemented incrementally. See issue #229.");
+    println!(
+        "Mutation phase is not yet implemented (issue #229 follow-up). \
+        Re-run with --dry-run, --audit, or --check, or wait for the \
+        backup + apply commits to land on this branch."
+    );
     Ok(exit_codes::CLEAN)
 }

--- a/crates/icm-cli/src/uninstall/mod.rs
+++ b/crates/icm-cli/src/uninstall/mod.rs
@@ -12,8 +12,11 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::Args;
 
+pub(crate) mod backup;
 pub(crate) mod discover;
+pub(crate) mod formats;
 pub(crate) mod locations;
+pub(crate) mod mutate;
 pub(crate) mod report;
 
 /// CLI surface for `icm uninstall`. Kept here so the rest of the crate only
@@ -93,13 +96,52 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
         return Ok(exit_codes::CLEAN);
     }
 
-    // --- Mutating run: stubbed until C4 lands ---
+    // --- Mutating run ---
+    if plan.is_empty() {
+        println!("Nothing to uninstall — already clean.");
+        return Ok(exit_codes::CLEAN);
+    }
     report::print_audit(&plan, "ICM uninstall plan");
-    println!();
-    println!(
-        "Mutation phase is not yet implemented (issue #229 follow-up). \
-        Re-run with --dry-run, --audit, or --check, or wait for the \
-        backup + apply commits to land on this branch."
+
+    if !opts.yes && !mutate::confirm("Proceed with removal?") {
+        println!("Aborted (no changes made).");
+        return Ok(exit_codes::USER_DECLINED);
+    }
+
+    let mut backup_session: Option<backup::BackupSession> = if opts.no_backup {
+        None
+    } else {
+        Some(backup::BackupSession::new(
+            opts.backup_dir.as_deref(),
+            &dirs.home,
+        )?)
+    };
+
+    let mut summary = mutate::ApplySummary::default();
+    let outcomes = mutate::apply(&plan, &specs, &mut backup_session);
+    for o in &outcomes {
+        summary.record(o);
+    }
+
+    if opts.purge_data {
+        let purge_outcomes = mutate::purge_data(&plan, &mut backup_session);
+        for o in &purge_outcomes {
+            summary.record(o);
+        }
+    }
+
+    if let Some(b) = &backup_session {
+        b.commit_manifest()?;
+    }
+
+    // Verify pass: rescan to detect any residue (ambiguous YAML, parse
+    // errors that skipped a file, etc.).
+    let after = discover::scan(&specs, opts.purge_data)?;
+    let exit = report::print_apply_summary(
+        &outcomes,
+        &summary,
+        backup_session.as_ref().map(|b| b.root()),
+        after.total_hits(),
     );
-    Ok(exit_codes::CLEAN)
+    Ok(exit)
 }

--- a/crates/icm-cli/src/uninstall/mod.rs
+++ b/crates/icm-cli/src/uninstall/mod.rs
@@ -51,7 +51,11 @@ pub struct UninstallOpts {
     #[arg(short = 'y', long)]
     pub yes: bool,
 
-    /// Override the backup root. Defaults to `~/.icm-uninstall-backups/<ts>`.
+    /// Override the backup root. Defaults to
+    /// `<icm-data-dir>/uninstall-backups/<ts>/` (resolved by
+    /// `directories::ProjectDirs` so the location follows each OS:
+    /// `~/.local/share/icm/` on Linux/WSL, `~/Library/Application Support/icm/`
+    /// on macOS, `%APPDATA%\icm\icm\data\` on Windows).
     #[arg(long, value_name = "PATH")]
     pub backup_dir: Option<PathBuf>,
 
@@ -86,7 +90,13 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
     if let Some(dir) = opts.scan_dir.as_deref() {
         plan.scan_dir_hits = scan_dir::scan_dir(dir)?;
     }
-    plan.processes = process::detect_icm_serve();
+    // Process detection only matters when --purge-data is about to
+    // delete the SQLite DB underneath a live `icm serve` (WAL
+    // corruption risk). Skip it otherwise — most users run in
+    // --mode standard which never spawns `icm serve`.
+    if opts.purge_data {
+        plan.processes = process::detect_icm_serve();
+    }
 
     // --- Read-only modes ---
     if opts.check {
@@ -113,12 +123,21 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
         return Ok(exit_codes::USER_DECLINED);
     }
 
+    // Resolve the default backup root via ProjectDirs so the layout
+    // follows each OS's convention (XDG on Linux/WSL, Application
+    // Support on macOS, AppData/Roaming on Windows). Falls back to a
+    // dotfile at $HOME when ProjectDirs is unavailable (stripped
+    // sandboxes without standard env vars).
+    let default_backup_base = locations::icm_data_dir()
+        .map(|d| d.join("uninstall-backups"))
+        .unwrap_or_else(|| dirs.home.join(".icm-uninstall-backups"));
+
     let mut backup_session: Option<backup::BackupSession> = if opts.no_backup {
         None
     } else {
         Some(backup::BackupSession::new(
             opts.backup_dir.as_deref(),
-            &dirs.home,
+            &default_backup_base,
         )?)
     };
 
@@ -126,6 +145,14 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
     let outcomes = mutate::apply(&plan, &specs, &mut backup_session);
     for o in &outcomes {
         summary.record(o);
+    }
+
+    // Persist the manifest **before** any --purge-data step: when the
+    // default backup root lives under the data dir we're about to delete,
+    // we want the manifest to have been written at least once before
+    // the recursive remove takes the whole tree.
+    if let Some(b) = &backup_session {
+        b.commit_manifest()?;
     }
 
     if opts.purge_data {
@@ -157,10 +184,6 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
                 summary.record(o);
             }
         }
-    }
-
-    if let Some(b) = &backup_session {
-        b.commit_manifest()?;
     }
 
     // Verify pass: rescan to detect any residue (ambiguous YAML, parse

--- a/crates/icm-cli/src/uninstall/mutate.rs
+++ b/crates/icm-cli/src/uninstall/mutate.rs
@@ -4,8 +4,6 @@
 //! Side effects are intentionally isolated here so the strippers in
 //! `formats.rs` stay pure (string in, string out).
 
-#![allow(dead_code)] // used by `run()` from this same commit
-
 use anyhow::Result;
 
 use super::backup::BackupSession;

--- a/crates/icm-cli/src/uninstall/mutate.rs
+++ b/crates/icm-cli/src/uninstall/mutate.rs
@@ -58,6 +58,20 @@ pub(crate) fn apply(
             .unwrap_or(LocationKind::MarkdownBlock);
 
         let result: Result<StripResult> = (|| {
+            // Refuse to mutate paths that are symlinks: the backup
+            // session deliberately doesn't dereference them, and writing
+            // through a symlink would silently mutate a shared target
+            // (e.g. a dotfiles repo) without any safety net.
+            if let Ok(m) = std::fs::symlink_metadata(&hit.path) {
+                if m.file_type().is_symlink() {
+                    return Ok(StripResult::Ambiguous {
+                        reason: format!(
+                            "{} is a symlink — refusing to mutate the target without an explicit backup; resolve manually.",
+                            hit.path.display()
+                        ),
+                    });
+                }
+            }
             if let Some(b) = backup.as_mut() {
                 b.stage(&hit.path)?;
             }

--- a/crates/icm-cli/src/uninstall/mutate.rs
+++ b/crates/icm-cli/src/uninstall/mutate.rs
@@ -146,9 +146,15 @@ fn apply_json(
 /// Delete the data directories listed in `plan.hits`. Caller has
 /// confirmed `--purge-data` and (separately) that no `icm serve` process
 /// holds the DB open.
+///
+/// Deliberately skips the backup for these dirs: the user explicitly
+/// requested `--purge-data` (= "lose this data"), so staging copies
+/// would defeat the purpose. It would also recurse pathologically when
+/// the default backup root lives inside the data dir we're about to
+/// delete (`<data_dir>/uninstall-backups/`).
 pub(crate) fn purge_data(
     plan: &RemovalPlan,
-    backup: &mut Option<BackupSession>,
+    _backup: &mut Option<BackupSession>,
 ) -> Vec<ApplyOutcome> {
     let mut outcomes = Vec::new();
     for hit in &plan.hits {
@@ -156,9 +162,6 @@ pub(crate) fn purge_data(
             continue;
         }
         let res: Result<StripResult> = (|| {
-            if let Some(b) = backup.as_mut() {
-                b.stage_dir(&hit.path)?;
-            }
             if hit.path.exists() {
                 std::fs::remove_dir_all(&hit.path)?;
             }

--- a/crates/icm-cli/src/uninstall/mutate.rs
+++ b/crates/icm-cli/src/uninstall/mutate.rs
@@ -1,0 +1,205 @@
+//! Apply phase: walks the discovered hits, stages each file in the backup
+//! session, and dispatches to the right `formats::rewrite_*` helper.
+//!
+//! Side effects are intentionally isolated here so the strippers in
+//! `formats.rs` stay pure (string in, string out).
+
+#![allow(dead_code)] // used by `run()` from this same commit
+
+use anyhow::Result;
+
+use super::backup::BackupSession;
+use super::discover::{HitDetail, LocationHit, RemovalPlan};
+use super::formats::{
+    rewrite_json_hooks, rewrite_json_mcp, rewrite_markdown, rewrite_toml, rewrite_yaml_continue,
+    StripResult,
+};
+use super::locations::{HookCommandField, LocationKind, LocationSpec};
+
+/// Per-file outcome surfaced to the report.
+#[derive(Debug)]
+pub(crate) struct ApplyOutcome {
+    pub path: std::path::PathBuf,
+    pub label: &'static str,
+    pub result: Result<StripResult>,
+}
+
+/// Apply every non-data hit in `plan`. Each touched path is staged in
+/// the backup session once (idempotent) before its mutator runs.
+pub(crate) fn apply(
+    plan: &RemovalPlan,
+    specs: &[LocationSpec],
+    backup: &mut Option<BackupSession>,
+) -> Vec<ApplyOutcome> {
+    // Group hits by path so a single multi-event hooks file is only
+    // staged + mutated once.
+    let mut paths: Vec<std::path::PathBuf> = Vec::new();
+    for h in plan.hits.iter().chain(plan.scan_dir_hits.iter()) {
+        if matches!(h.detail, HitDetail::DataDir { .. }) {
+            continue;
+        }
+        if !paths.contains(&h.path) {
+            paths.push(h.path.clone());
+        }
+    }
+
+    let mut outcomes = Vec::with_capacity(paths.len());
+    for path in paths {
+        let Some(hit) = plan
+            .hits
+            .iter()
+            .chain(plan.scan_dir_hits.iter())
+            .find(|h| h.path == path)
+        else {
+            continue;
+        };
+        let kind = specs
+            .iter()
+            .find(|s| s.path == hit.path)
+            .map(|s| s.kind.clone())
+            .unwrap_or(LocationKind::MarkdownBlock);
+
+        let result: Result<StripResult> = (|| {
+            if let Some(b) = backup.as_mut() {
+                b.stage(&hit.path)?;
+            }
+            match kind {
+                LocationKind::JsonConfig {
+                    servers_key,
+                    has_hooks,
+                    hooks_field,
+                } => apply_json(&hit.path, servers_key, has_hooks, hooks_field, hit),
+                LocationKind::TomlMcp { table, entry } => rewrite_toml(&hit.path, table, entry),
+                LocationKind::YamlContinue => rewrite_yaml_continue(&hit.path),
+                LocationKind::MarkdownBlock => rewrite_markdown(&hit.path),
+                LocationKind::OwnedFile => {
+                    std::fs::remove_file(&hit.path)?;
+                    Ok(StripResult::DeleteFile)
+                }
+                LocationKind::DataDir => Ok(StripResult::NoOp),
+            }
+        })();
+        outcomes.push(ApplyOutcome {
+            path: hit.path.clone(),
+            label: hit.spec_label,
+            result,
+        });
+    }
+    outcomes
+}
+
+/// JSON specs may carry both an mcp entry and hooks. Each pass is
+/// independent; report the union.
+fn apply_json(
+    path: &std::path::Path,
+    servers_key: Option<&str>,
+    has_hooks: bool,
+    hooks_field: HookCommandField,
+    hit: &LocationHit,
+) -> Result<StripResult> {
+    let mut total_removed = 0usize;
+    let mut deleted_file = false;
+
+    let try_mcp = matches!(hit.detail, HitDetail::JsonServer { .. }) || servers_key.is_some();
+    let try_hooks = matches!(hit.detail, HitDetail::JsonHook { .. }) || has_hooks;
+
+    if try_mcp {
+        if let Some(key) = servers_key {
+            match rewrite_json_mcp(path, key)? {
+                StripResult::Removed { removed } => total_removed += removed,
+                StripResult::DeleteFile => deleted_file = true,
+                _ => {}
+            }
+        }
+    }
+    if try_hooks && !deleted_file {
+        match rewrite_json_hooks(path, hooks_field)? {
+            StripResult::Removed { removed } => total_removed += removed,
+            StripResult::DeleteFile => deleted_file = true,
+            _ => {}
+        }
+    }
+
+    if deleted_file {
+        Ok(StripResult::DeleteFile)
+    } else if total_removed > 0 {
+        Ok(StripResult::Removed {
+            removed: total_removed,
+        })
+    } else {
+        Ok(StripResult::NoOp)
+    }
+}
+
+/// Delete the data directories listed in `plan.hits`. Caller has
+/// confirmed `--purge-data` and (separately) that no `icm serve` process
+/// holds the DB open.
+pub(crate) fn purge_data(
+    plan: &RemovalPlan,
+    backup: &mut Option<BackupSession>,
+) -> Vec<ApplyOutcome> {
+    let mut outcomes = Vec::new();
+    for hit in &plan.hits {
+        if !matches!(hit.detail, HitDetail::DataDir { .. }) {
+            continue;
+        }
+        let res: Result<StripResult> = (|| {
+            if let Some(b) = backup.as_mut() {
+                b.stage_dir(&hit.path)?;
+            }
+            if hit.path.exists() {
+                std::fs::remove_dir_all(&hit.path)?;
+            }
+            Ok(StripResult::DeleteFile)
+        })();
+        outcomes.push(ApplyOutcome {
+            path: hit.path.clone(),
+            label: hit.spec_label,
+            result: res,
+        });
+    }
+    outcomes
+}
+
+/// Tally for the final summary.
+#[derive(Default, Debug)]
+pub(crate) struct ApplySummary {
+    pub files_changed: usize,
+    pub files_deleted: usize,
+    pub entries_removed: usize,
+    pub errors: Vec<(std::path::PathBuf, String)>,
+    pub ambiguous: Vec<(std::path::PathBuf, String)>,
+}
+
+impl ApplySummary {
+    pub fn record(&mut self, outcome: &ApplyOutcome) {
+        match &outcome.result {
+            Ok(StripResult::NoOp) => {}
+            Ok(StripResult::Removed { removed }) => {
+                self.files_changed += 1;
+                self.entries_removed += removed;
+            }
+            Ok(StripResult::DeleteFile) => {
+                self.files_deleted += 1;
+            }
+            Ok(StripResult::Ambiguous { reason }) => {
+                self.ambiguous.push((outcome.path.clone(), reason.clone()));
+            }
+            Err(e) => {
+                self.errors.push((outcome.path.clone(), format!("{e:#}")));
+            }
+        }
+    }
+}
+
+/// Interactive `[y/N]` confirmation. Returns `true` for a y/Y answer.
+pub(crate) fn confirm(prompt: &str) -> bool {
+    use std::io::Write;
+    print!("{prompt} [y/N] ");
+    let _ = std::io::stdout().flush();
+    let mut buf = String::new();
+    if std::io::stdin().read_line(&mut buf).is_err() {
+        return false;
+    }
+    matches!(buf.trim().chars().next(), Some('y' | 'Y'))
+}

--- a/crates/icm-cli/src/uninstall/process.rs
+++ b/crates/icm-cli/src/uninstall/process.rs
@@ -12,8 +12,6 @@
 //!   `tasklist /v` or `sysinfo`; uninstall still works without it,
 //!   we just don't print a warning.
 
-#![allow(dead_code)] // wired into the orchestrator immediately after this commit
-
 use super::discover::RunningProcess;
 
 /// Return every process whose command line contains `"icm serve"`. The

--- a/crates/icm-cli/src/uninstall/process.rs
+++ b/crates/icm-cli/src/uninstall/process.rs
@@ -1,0 +1,117 @@
+//! Detect (but do **not** kill) running `icm serve` processes.
+//!
+//! Cross-platform safety: killing other processes from inside a CLI
+//! command is fraught. We list them and let the user decide. The
+//! orchestrator surfaces the list as a warning before `--purge-data`
+//! mutation since serve holds the SQLite DB open via WAL.
+//!
+//! Implementation:
+//! - Linux: walk `/proc/<pid>/cmdline` (NUL-separated argv).
+//! - macOS: spawn `ps -eo pid=,command=` and parse line-by-line.
+//! - Windows / other: stubbed `Ok(vec![])`. A future PR can use
+//!   `tasklist /v` or `sysinfo`; uninstall still works without it,
+//!   we just don't print a warning.
+
+#![allow(dead_code)] // wired into the orchestrator immediately after this commit
+
+use super::discover::RunningProcess;
+
+/// Return every process whose command line contains `"icm serve"`. The
+/// caller's own PID is filtered out so an `icm uninstall` invocation
+/// doesn't flag itself.
+pub(crate) fn detect_icm_serve() -> Vec<RunningProcess> {
+    detect_inner()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|p| p.pid != std::process::id())
+        .filter(|p| p.cmdline.contains("icm serve"))
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn detect_inner() -> Option<Vec<RunningProcess>> {
+    use std::fs;
+    let entries = fs::read_dir("/proc").ok()?;
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let Ok(pid) = name.parse::<u32>() else {
+            continue;
+        };
+        let cmd_path = entry.path().join("cmdline");
+        let Ok(raw) = fs::read(&cmd_path) else {
+            continue;
+        };
+        // cmdline arguments are NUL-separated; replace with spaces.
+        let cmdline: String = raw
+            .into_iter()
+            .map(|b| if b == 0 { b' ' } else { b })
+            .map(char::from)
+            .collect();
+        let trimmed = cmdline.trim().to_string();
+        if trimmed.is_empty() {
+            continue;
+        }
+        out.push(RunningProcess {
+            pid,
+            cmdline: trimmed,
+        });
+    }
+    Some(out)
+}
+
+#[cfg(target_os = "macos")]
+fn detect_inner() -> Option<Vec<RunningProcess>> {
+    use std::process::Command;
+    let output = Command::new("ps")
+        .args(["-eo", "pid=,command="])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut out = Vec::new();
+    for line in stdout.lines() {
+        let line = line.trim_start();
+        let (pid_str, rest) = match line.split_once(char::is_whitespace) {
+            Some(parts) => parts,
+            None => continue,
+        };
+        let Ok(pid) = pid_str.parse::<u32>() else {
+            continue;
+        };
+        out.push(RunningProcess {
+            pid,
+            cmdline: rest.trim().to_string(),
+        });
+    }
+    Some(out)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn detect_inner() -> Option<Vec<RunningProcess>> {
+    // Windows/BSD/other: no detection in this PR. Uninstall still works;
+    // the report just won't surface a warning. A follow-up can add
+    // `sysinfo` or `tasklist` integration.
+    Some(Vec::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_runs_without_panic_and_filters_self() {
+        // We can't assert on the *content* (the test runner's own pid
+        // would show up in /proc), but the function must succeed and the
+        // self-PID filter must hold.
+        let procs = detect_icm_serve();
+        for p in &procs {
+            assert_ne!(p.pid, std::process::id());
+            assert!(p.cmdline.contains("icm serve"));
+        }
+    }
+}

--- a/crates/icm-cli/src/uninstall/report.rs
+++ b/crates/icm-cli/src/uninstall/report.rs
@@ -1,14 +1,13 @@
 //! Stdout formatters for the read-only modes (`--check`, `--dry-run`,
-//! `--audit`). Mutation reports land in a later commit alongside the
-//! mutator itself.
-
-#![allow(dead_code)] // additional formatters land with the mutator
+//! `--audit`) and the post-mutation summary.
 
 use super::discover::{HitDetail, RemovalPlan};
 
 /// Print the audit / dry-run preview. Groups hits by file so users see
 /// each path once with all the things uninstall would touch under it.
-pub(crate) fn print_audit(plan: &RemovalPlan, header: &str) {
+/// `purge_data` toggles the wording for [`HitDetail::DataDir`] so the
+/// preview matches what the run is actually about to do.
+pub(crate) fn print_audit(plan: &RemovalPlan, header: &str, purge_data: bool) {
     println!("{header}");
     println!("{}", "=".repeat(header.len()));
 
@@ -17,9 +16,13 @@ pub(crate) fn print_audit(plan: &RemovalPlan, header: &str) {
         return;
     }
 
-    print_section("Configured locations", &plan.hits);
+    print_section("Configured locations", &plan.hits, purge_data);
     if !plan.scan_dir_hits.is_empty() {
-        print_section("Project tree references (--scan-dir)", &plan.scan_dir_hits);
+        print_section(
+            "Project tree references (--scan-dir)",
+            &plan.scan_dir_hits,
+            purge_data,
+        );
     }
 
     if !plan.processes.is_empty() {
@@ -34,7 +37,7 @@ pub(crate) fn print_audit(plan: &RemovalPlan, header: &str) {
     println!("Total: {} item(s).", plan.total_hits());
 }
 
-fn print_section(title: &str, hits: &[super::discover::LocationHit]) {
+fn print_section(title: &str, hits: &[super::discover::LocationHit], purge_data: bool) {
     if hits.is_empty() {
         return;
     }
@@ -85,10 +88,12 @@ fn print_section(title: &str, hits: &[super::discover::LocationHit]) {
                 println!("  Owned file ({} byte(s)) — will be deleted", bytes);
             }
             HitDetail::DataDir { bytes_total, files } => {
-                println!(
-                    "  Data directory: {files} file(s), {} byte(s) — kept unless --purge-data",
-                    bytes_total
-                );
+                let tag = if purge_data {
+                    "will be deleted (--purge-data)"
+                } else {
+                    "kept unless --purge-data"
+                };
+                println!("  Data directory: {files} file(s), {bytes_total} byte(s) — {tag}",);
             }
         }
     }

--- a/crates/icm-cli/src/uninstall/report.rs
+++ b/crates/icm-cli/src/uninstall/report.rs
@@ -104,3 +104,72 @@ pub(crate) fn print_check(plan: &RemovalPlan) -> i32 {
         super::exit_codes::CHECK_RESIDUE
     }
 }
+
+/// Per-outcome and aggregate summary after a mutation run.
+pub(crate) fn print_apply_summary(
+    outcomes: &[super::mutate::ApplyOutcome],
+    summary: &super::mutate::ApplySummary,
+    backup_root: Option<&std::path::Path>,
+    residue_after: usize,
+) -> i32 {
+    println!();
+    println!("Per-file results");
+    println!("----------------");
+    for o in outcomes {
+        let tag = match &o.result {
+            Ok(super::formats::StripResult::NoOp) => "no-op".to_string(),
+            Ok(super::formats::StripResult::Removed { removed }) => {
+                format!("removed {removed}")
+            }
+            Ok(super::formats::StripResult::DeleteFile) => "deleted".to_string(),
+            Ok(super::formats::StripResult::Ambiguous { reason: _ }) => "ambiguous".to_string(),
+            Err(e) => format!("ERROR: {e:#}"),
+        };
+        println!("  [{:<22}] {:<10} {}", o.label, tag, o.path.display());
+    }
+
+    println!();
+    println!("Summary");
+    println!("-------");
+    println!("  Files modified : {}", summary.files_changed);
+    println!("  Files deleted  : {}", summary.files_deleted);
+    println!("  Entries removed: {}", summary.entries_removed);
+
+    if !summary.ambiguous.is_empty() {
+        println!();
+        println!("Ambiguous (manual review needed):");
+        for (p, why) in &summary.ambiguous {
+            println!("  {}: {}", p.display(), why);
+        }
+    }
+    if !summary.errors.is_empty() {
+        println!();
+        println!("Errors:");
+        for (p, why) in &summary.errors {
+            println!("  {}: {}", p.display(), why);
+        }
+    }
+    if let Some(root) = backup_root {
+        println!();
+        println!(
+            "Backups written under {} (restore with `cp -a <ts>/files/. /`)",
+            root.display()
+        );
+    }
+
+    if residue_after > 0 {
+        println!();
+        println!(
+            "WARNING: {residue_after} item(s) remain after the run (see above). \
+            Re-run with --dry-run to inspect."
+        );
+    }
+
+    if !summary.errors.is_empty() {
+        super::exit_codes::MUTATION_ERROR
+    } else if !summary.ambiguous.is_empty() || residue_after > 0 {
+        super::exit_codes::PARTIAL
+    } else {
+        super::exit_codes::CLEAN
+    }
+}

--- a/crates/icm-cli/src/uninstall/report.rs
+++ b/crates/icm-cli/src/uninstall/report.rs
@@ -1,0 +1,106 @@
+//! Stdout formatters for the read-only modes (`--check`, `--dry-run`,
+//! `--audit`). Mutation reports land in a later commit alongside the
+//! mutator itself.
+
+#![allow(dead_code)] // additional formatters land with the mutator
+
+use super::discover::{HitDetail, RemovalPlan};
+
+/// Print the audit / dry-run preview. Groups hits by file so users see
+/// each path once with all the things uninstall would touch under it.
+pub(crate) fn print_audit(plan: &RemovalPlan, header: &str) {
+    println!("{header}");
+    println!("{}", "=".repeat(header.len()));
+
+    if plan.hits.is_empty() && plan.scan_dir_hits.is_empty() {
+        println!("No known ICM residue found.");
+        return;
+    }
+
+    print_section("Configured locations", &plan.hits);
+    if !plan.scan_dir_hits.is_empty() {
+        print_section("Project tree references (--scan-dir)", &plan.scan_dir_hits);
+    }
+
+    if !plan.processes.is_empty() {
+        println!();
+        println!("Running `icm serve` processes:");
+        for p in &plan.processes {
+            println!("  pid={:<6} {}", p.pid, p.cmdline);
+        }
+    }
+
+    println!();
+    println!("Total: {} item(s).", plan.total_hits());
+}
+
+fn print_section(title: &str, hits: &[super::discover::LocationHit]) {
+    if hits.is_empty() {
+        return;
+    }
+    println!();
+    println!("{title}");
+    println!("{}", "-".repeat(title.len()));
+
+    // Group by path so multiple hits in the same file collapse together.
+    let mut current: Option<&std::path::Path> = None;
+    for hit in hits {
+        if current != Some(hit.path.as_path()) {
+            println!();
+            println!(
+                "{:<28} {}",
+                format!("[{}]", hit.spec_label),
+                hit.path.display()
+            );
+            current = Some(hit.path.as_path());
+        }
+        match &hit.detail {
+            HitDetail::JsonServer { pointer } => {
+                println!("  MCP server entry at {pointer}");
+            }
+            HitDetail::JsonHook { event, command } => {
+                println!("  hook {event}: {command}");
+            }
+            HitDetail::TomlTable { table } => {
+                println!("  TOML table {table}");
+            }
+            HitDetail::YamlBlock { start_line, lines } => {
+                println!(
+                    "  YAML block at line {start_line} (~{lines} line(s)) — manual review may be needed"
+                );
+            }
+            HitDetail::MarkdownBlock {
+                start_line,
+                end_line,
+                file_will_be_empty,
+            } => {
+                let tag = if *file_will_be_empty {
+                    " (file will be deleted, no other content)"
+                } else {
+                    ""
+                };
+                println!("  Markdown block lines {start_line}-{end_line}{tag}");
+            }
+            HitDetail::OwnedFile { bytes } => {
+                println!("  Owned file ({} byte(s)) — will be deleted", bytes);
+            }
+            HitDetail::DataDir { bytes_total, files } => {
+                println!(
+                    "  Data directory: {files} file(s), {} byte(s) — kept unless --purge-data",
+                    bytes_total
+                );
+            }
+        }
+    }
+}
+
+/// Brief output for `--check`. Returns the exit code.
+pub(crate) fn print_check(plan: &RemovalPlan) -> i32 {
+    if plan.is_empty() {
+        println!("OK: no known ICM residue found");
+        super::exit_codes::CLEAN
+    } else {
+        println!("FOUND: {} known ICM residue item(s)", plan.total_hits());
+        super::exit_codes::CHECK_RESIDUE
+    }
+}

--- a/crates/icm-cli/src/uninstall/scan_dir.rs
+++ b/crates/icm-cli/src/uninstall/scan_dir.rs
@@ -6,8 +6,6 @@
 //! current cwd; if the user wants to clean up multiple project clones
 //! they point `--scan-dir <PATH>` at the root and we walk from there.
 
-#![allow(dead_code)] // consumed by `run()` once flagged in mod.rs
-
 use std::path::Path;
 
 use anyhow::Result;

--- a/crates/icm-cli/src/uninstall/scan_dir.rs
+++ b/crates/icm-cli/src/uninstall/scan_dir.rs
@@ -173,12 +173,20 @@ mod tests {
             "<!-- icm:start -->\nignored\n<!-- icm:end -->\n",
         );
         let hits = scan_dir(root).unwrap();
-        let paths: Vec<_> = hits.iter().map(|h| h.path.display().to_string()).collect();
-        assert_eq!(hits.len(), 2, "got: {paths:?}");
-        assert!(paths.iter().any(|p| p.ends_with("proj-a/CLAUDE.md")));
-        assert!(paths.iter().any(|p| p.ends_with("proj-b/sub/AGENTS.md")));
-        // Decoy must be ignored.
-        assert!(!paths.iter().any(|p| p.contains("node_modules")));
+        // Compare via `Path::ends_with` (component-aware) so the test
+        // works on both Unix and Windows path separators.
+        assert_eq!(hits.len(), 2, "got: {hits:?}");
+        assert!(hits
+            .iter()
+            .any(|h| h.path.ends_with(Path::new("proj-a").join("CLAUDE.md"))));
+        assert!(hits.iter().any(|h| {
+            h.path
+                .ends_with(Path::new("proj-b").join("sub").join("AGENTS.md"))
+        }));
+        // Decoy must be ignored. Use components, not raw string.
+        assert!(!hits
+            .iter()
+            .any(|h| h.path.components().any(|c| c.as_os_str() == "node_modules")));
     }
 
     #[test]

--- a/crates/icm-cli/src/uninstall/scan_dir.rs
+++ b/crates/icm-cli/src/uninstall/scan_dir.rs
@@ -1,0 +1,223 @@
+//! Recursive scan of a project tree for free-form ICM references.
+//!
+//! `icm init` writes the `<!-- icm:start --> ... <!-- icm:end -->` block
+//! into instruction files at the cwd it ran in (CLAUDE.md, AGENTS.md,
+//! .windsurfrules, etc.). The main location catalog only covers the
+//! current cwd; if the user wants to clean up multiple project clones
+//! they point `--scan-dir <PATH>` at the root and we walk from there.
+
+#![allow(dead_code)] // consumed by `run()` once flagged in mod.rs
+
+use std::path::Path;
+
+use anyhow::Result;
+use walkdir::{DirEntry, WalkDir};
+
+use super::discover::{HitDetail, LocationHit};
+
+const MAX_DEPTH: usize = 8;
+const SKIP_DIRS: &[&str] = &[
+    ".git",
+    "node_modules",
+    "target",
+    ".venv",
+    "venv",
+    ".tox",
+    "__pycache__",
+    "dist",
+    "build",
+    ".next",
+];
+
+/// Filenames (without dir) that init creates verbatim. Anything in this
+/// list is opened regardless of extension.
+const INSTRUCTION_FILENAMES: &[&str] = &[
+    "CLAUDE.md",
+    "AGENTS.md",
+    ".windsurfrules",
+    ".aider.conventions.md",
+    ".cursorrules",
+    "GEMINI.md",
+];
+
+/// Extensions worth opening to look for the markdown delimiter.
+const INSTRUCTION_EXTS: &[&str] = &["md", "mdc", "markdown"];
+
+const START_MARKER: &str = "<!-- icm:start -->";
+const END_MARKER: &str = "<!-- icm:end -->";
+
+/// Walk `root` (depth-limited, skipping noisy directories) and return one
+/// `LocationHit` per file that contains the ICM markdown block.
+pub(crate) fn scan_dir(root: &Path) -> Result<Vec<LocationHit>> {
+    let mut hits = Vec::new();
+    if !root.exists() {
+        return Ok(hits);
+    }
+    let walker = WalkDir::new(root)
+        .follow_links(false)
+        .max_depth(MAX_DEPTH)
+        .into_iter()
+        .filter_entry(|e| !is_skipped(e));
+
+    for entry in walker {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue, // unreadable subtree — skip silently
+        };
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if !is_candidate(&entry) {
+            continue;
+        }
+        // Only read the file if its size is reasonable. Skip giant
+        // blobs (>4 MiB) — they're never instruction files.
+        if entry
+            .metadata()
+            .map(|m| m.len() > 4 * 1024 * 1024)
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        let Some(start) = content.find(START_MARKER) else {
+            continue;
+        };
+        let end_off = content
+            .find(END_MARKER)
+            .map(|o| o + END_MARKER.len())
+            .unwrap_or(content.len());
+        let before = &content[..start];
+        let after = if end_off <= content.len() {
+            &content[end_off..]
+        } else {
+            ""
+        };
+        let file_will_be_empty = before.trim().is_empty() && after.trim().is_empty();
+        let start_line = content[..start].bytes().filter(|&b| b == b'\n').count() + 1;
+        let end_line = content[..end_off.min(content.len())]
+            .bytes()
+            .filter(|&b| b == b'\n')
+            .count()
+            + 1;
+
+        hits.push(LocationHit {
+            spec_label: "Project tree (--scan-dir)",
+            path: entry.path().to_path_buf(),
+            detail: HitDetail::MarkdownBlock {
+                start_line,
+                end_line,
+                file_will_be_empty,
+            },
+        });
+    }
+    Ok(hits)
+}
+
+fn is_skipped(entry: &DirEntry) -> bool {
+    if !entry.file_type().is_dir() {
+        return false;
+    }
+    entry
+        .file_name()
+        .to_str()
+        .map(|n| SKIP_DIRS.contains(&n))
+        .unwrap_or(false)
+}
+
+fn is_candidate(entry: &DirEntry) -> bool {
+    let name = entry.file_name().to_string_lossy();
+    if INSTRUCTION_FILENAMES.contains(&name.as_ref()) {
+        return true;
+    }
+    let ext = entry
+        .path()
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    INSTRUCTION_EXTS.contains(&ext.as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+
+    fn write(p: &Path, c: &str) {
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::File::create(p)
+            .unwrap()
+            .write_all(c.as_bytes())
+            .unwrap();
+    }
+
+    #[test]
+    fn scan_dir_finds_block_in_nested_markdown() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write(
+            &root.join("proj-a/CLAUDE.md"),
+            "intro\n<!-- icm:start -->\nx\n<!-- icm:end -->\nrest\n",
+        );
+        write(
+            &root.join("proj-b/sub/AGENTS.md"),
+            "<!-- icm:start -->\nonly\n<!-- icm:end -->\n",
+        );
+        // Decoy: contains the marker but inside a skip-dir.
+        write(
+            &root.join("proj-a/node_modules/pkg/README.md"),
+            "<!-- icm:start -->\nignored\n<!-- icm:end -->\n",
+        );
+        let hits = scan_dir(root).unwrap();
+        let paths: Vec<_> = hits.iter().map(|h| h.path.display().to_string()).collect();
+        assert_eq!(hits.len(), 2, "got: {paths:?}");
+        assert!(paths.iter().any(|p| p.ends_with("proj-a/CLAUDE.md")));
+        assert!(paths.iter().any(|p| p.ends_with("proj-b/sub/AGENTS.md")));
+        // Decoy must be ignored.
+        assert!(!paths.iter().any(|p| p.contains("node_modules")));
+    }
+
+    #[test]
+    fn scan_dir_respects_max_depth() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut p = tmp.path().to_path_buf();
+        // Bury the file 12 dirs deep — beyond MAX_DEPTH.
+        for i in 0..12 {
+            p = p.join(format!("d{i}"));
+        }
+        write(
+            &p.join("CLAUDE.md"),
+            "<!-- icm:start -->\nx\n<!-- icm:end -->\n",
+        );
+        let hits = scan_dir(tmp.path()).unwrap();
+        assert!(hits.is_empty(), "deep file unexpectedly found: {hits:?}");
+    }
+
+    #[test]
+    fn scan_dir_returns_empty_for_missing_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hits = scan_dir(&tmp.path().join("does/not/exist")).unwrap();
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn scan_dir_ignores_files_without_markdown_extension_or_known_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(
+            &tmp.path().join("script.sh"),
+            "# <!-- icm:start --> trap\n<!-- icm:end -->\n",
+        );
+        write(
+            &tmp.path().join("config.txt"),
+            "<!-- icm:start -->\nx\n<!-- icm:end -->\n",
+        );
+        let hits = scan_dir(tmp.path()).unwrap();
+        assert!(hits.is_empty(), "non-markdown files should be ignored");
+    }
+}

--- a/crates/icm-cli/tests/uninstall_integration.rs
+++ b/crates/icm-cli/tests/uninstall_integration.rs
@@ -150,6 +150,12 @@ fn uninstall_is_idempotent_when_already_clean() {
     );
 }
 
+// `directories::ProjectDirs` returns OS-specific data/cache paths that
+// don't match the Linux XDG layout this test seeds. Gate it to Linux
+// where seed and code agree — the macOS/Windows path resolution is
+// covered by the unit tests inside the binary which use the real
+// `directories` crate at the right side of the boundary.
+#[cfg(target_os = "linux")]
 #[test]
 fn purge_data_does_not_recreate_db_dir() {
     let tmp = tempfile::tempdir().unwrap();

--- a/crates/icm-cli/tests/uninstall_integration.rs
+++ b/crates/icm-cli/tests/uninstall_integration.rs
@@ -1,0 +1,261 @@
+//! End-to-end integration tests for `icm uninstall` (issue #229).
+//!
+//! Each test spawns the compiled `icm` binary inside a private
+//! `HOME=<tempdir>` so the user's real configuration is never touched.
+//! These tests complement the in-binary unit tests in
+//! `crates/icm-cli/src/uninstall/*.rs` by validating the full
+//! discovery → mutation → re-scan loop through the public CLI surface.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Path to the `icm` binary built for the current test run. Cargo
+/// injects `CARGO_BIN_EXE_<bin-name>` into the test process environment.
+const ICM: &str = env!("CARGO_BIN_EXE_icm");
+
+fn write(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, content).unwrap();
+}
+
+fn icm_in(home: &Path, cwd: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(ICM)
+        .env("HOME", home)
+        // Wipe any inherited tool-config overrides so the test sees a
+        // clean view of the fake home.
+        .env_remove("CLAUDE_CONFIG_DIR")
+        .env_remove("GEMINI_CONFIG_DIR")
+        .env_remove("CODEX_HOME")
+        .env_remove("COPILOT_HOME")
+        .env_remove("XDG_DATA_HOME")
+        .env_remove("XDG_CACHE_HOME")
+        .env_remove("XDG_CONFIG_HOME")
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .expect("spawn icm")
+}
+
+fn seed_minimal_residue(home: &Path) {
+    // One JSON mcpServers entry.
+    write(
+        &home.join(".claude.json"),
+        r#"{"mcpServers":{"icm":{"command":"/x/icm","args":["serve"]},"other":{"command":"/x/o"}}}"#,
+    );
+    // One hooks block (Claude shape).
+    write(
+        &home.join(".claude/settings.json"),
+        r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"/x/icm hook pre"}]}]}}"#,
+    );
+    // One TOML mcp.
+    write(
+        &home.join(".codex/config.toml"),
+        "[mcp_servers.icm]\ncommand=\"/x/icm\"\nargs=[\"serve\"]\n",
+    );
+    // One owned skill file.
+    write(
+        &home.join(".claude/commands/recall.md"),
+        "Search ICM memory for: $ARGUMENTS\n",
+    );
+}
+
+#[test]
+fn check_exits_one_when_residue_present_then_zero_after_uninstall() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let cwd = home.join("proj");
+    std::fs::create_dir_all(&cwd).unwrap();
+    seed_minimal_residue(home);
+
+    let pre = icm_in(home, &cwd, &["uninstall", "--check"]);
+    assert_eq!(
+        pre.status.code(),
+        Some(1),
+        "expected --check exit 1, got {:?}\nstdout: {}\nstderr: {}",
+        pre.status.code(),
+        String::from_utf8_lossy(&pre.stdout),
+        String::from_utf8_lossy(&pre.stderr),
+    );
+
+    let run = icm_in(home, &cwd, &["uninstall", "-y"]);
+    assert!(
+        run.status.success() || run.status.code() == Some(0),
+        "uninstall should exit 0; got {:?}\nstdout: {}\nstderr: {}",
+        run.status.code(),
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr),
+    );
+
+    let post = icm_in(home, &cwd, &["uninstall", "--check"]);
+    assert_eq!(
+        post.status.code(),
+        Some(0),
+        "expected --check exit 0 after uninstall; got {:?}\nstdout: {}",
+        post.status.code(),
+        String::from_utf8_lossy(&post.stdout),
+    );
+}
+
+#[test]
+fn dry_run_does_not_modify_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let cwd = home.join("proj");
+    std::fs::create_dir_all(&cwd).unwrap();
+    seed_minimal_residue(home);
+
+    let before = std::fs::read_to_string(home.join(".claude.json")).unwrap();
+    let before_settings = std::fs::read_to_string(home.join(".claude/settings.json")).unwrap();
+    let before_toml = std::fs::read_to_string(home.join(".codex/config.toml")).unwrap();
+    let before_skill = std::fs::read_to_string(home.join(".claude/commands/recall.md")).unwrap();
+
+    let out = icm_in(home, &cwd, &["uninstall", "--dry-run"]);
+    assert_eq!(out.status.code(), Some(0));
+
+    let after = std::fs::read_to_string(home.join(".claude.json")).unwrap();
+    let after_settings = std::fs::read_to_string(home.join(".claude/settings.json")).unwrap();
+    let after_toml = std::fs::read_to_string(home.join(".codex/config.toml")).unwrap();
+    let after_skill = std::fs::read_to_string(home.join(".claude/commands/recall.md")).unwrap();
+
+    assert_eq!(before, after, "--dry-run modified .claude.json");
+    assert_eq!(
+        before_settings, after_settings,
+        "--dry-run modified settings"
+    );
+    assert_eq!(before_toml, after_toml, "--dry-run modified TOML");
+    assert_eq!(before_skill, after_skill, "--dry-run modified skill file");
+}
+
+#[test]
+fn uninstall_is_idempotent_when_already_clean() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let cwd = home.join("proj");
+    std::fs::create_dir_all(&cwd).unwrap();
+    // No seeding — fake home is already pristine.
+
+    let out = icm_in(home, &cwd, &["uninstall", "-y"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "uninstall on a clean home should exit 0; got {:?}",
+        out.status.code(),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Nothing to uninstall") || stdout.contains("already clean"),
+        "expected an 'already clean' message; got: {stdout}"
+    );
+}
+
+#[test]
+fn purge_data_does_not_recreate_db_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let cwd = home.join("proj");
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    // Seed both a config residue and the ProjectDirs data directory so
+    // --purge-data has something to delete.
+    seed_minimal_residue(home);
+    let data_dir = home.join(".local/share/icm");
+    let cache_dir = home.join(".cache/icm/models");
+    std::fs::create_dir_all(&data_dir).unwrap();
+    std::fs::create_dir_all(&cache_dir).unwrap();
+    write(&data_dir.join("memories.db"), "stub");
+    write(&cache_dir.join("model.onnx"), "stub-model");
+
+    assert!(data_dir.exists(), "precondition: data dir must exist");
+    assert!(cache_dir.exists(), "precondition: cache dir must exist");
+
+    let out = icm_in(home, &cwd, &["uninstall", "-y", "--purge-data"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "uninstall --purge-data should exit 0; got {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        !data_dir.exists(),
+        "--purge-data should have deleted {}",
+        data_dir.display()
+    );
+    assert!(
+        !cache_dir.exists(),
+        "--purge-data should have deleted {}",
+        cache_dir.display()
+    );
+
+    // Regression for the C5 fix: the subsequent --check invocation
+    // must NOT re-create the data directory by accidentally opening
+    // the SQLite store.
+    let post = icm_in(home, &cwd, &["uninstall", "--check"]);
+    assert_eq!(
+        post.status.code(),
+        Some(0),
+        "post-purge --check must be clean"
+    );
+    assert!(
+        !data_dir.exists(),
+        "subsequent `uninstall --check` re-created {}; the open_store bypass regressed",
+        data_dir.display()
+    );
+}
+
+#[test]
+fn scan_dir_strips_block_from_nested_project_clone() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let cwd = home.join("primary-proj");
+    std::fs::create_dir_all(&cwd).unwrap();
+
+    let other = home.join("other-proj/sub");
+    std::fs::create_dir_all(&other).unwrap();
+    let target = other.join("CLAUDE.md");
+    write(
+        &target,
+        "preamble\n\n<!-- icm:start -->\nblock\n<!-- icm:end -->\n\ntrailing\n",
+    );
+    // Decoy: same block inside a skip-dir must be ignored.
+    let decoy_dir = home.join("other-proj/node_modules/foo");
+    std::fs::create_dir_all(&decoy_dir).unwrap();
+    let decoy = decoy_dir.join("README.md");
+    write(&decoy, "<!-- icm:start -->\ndecoy\n<!-- icm:end -->\n");
+
+    let out = icm_in(
+        home,
+        &cwd,
+        &[
+            "uninstall",
+            "-y",
+            "--scan-dir",
+            other.parent().unwrap().to_str().unwrap(),
+        ],
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let after = std::fs::read_to_string(&target).unwrap();
+    assert!(
+        !after.contains("<!-- icm:start -->"),
+        "scan-dir target was not stripped: {after}"
+    );
+    assert!(after.contains("preamble"));
+    assert!(after.contains("trailing"));
+
+    // Decoy must be untouched.
+    let decoy_after = std::fs::read_to_string(&decoy).unwrap();
+    assert!(
+        decoy_after.contains("<!-- icm:start -->"),
+        "decoy under node_modules was modified; skip-dir filter failed"
+    );
+}

--- a/crates/icm-cli/tests/uninstall_integration.rs
+++ b/crates/icm-cli/tests/uninstall_integration.rs
@@ -5,6 +5,13 @@
 //! These tests complement the in-binary unit tests in
 //! `crates/icm-cli/src/uninstall/*.rs` by validating the full
 //! discovery → mutation → re-scan loop through the public CLI surface.
+//!
+//! Gated to Linux: the assertions hard-code XDG-style data paths and
+//! the seeded JSON command literals use a sample binary path
+//! (`/x/icm`) that doesn't fit Windows. The in-binary unit tests
+//! exercise the cross-OS logic directly through `directories`.
+
+#![cfg(target_os = "linux")]
 
 use std::path::Path;
 use std::process::Command;


### PR DESCRIPTION
## Summary

Implements the `icm uninstall` command requested in #229. Inverts every
mutation `cmd_init` performs across 25+ AI-tool configuration files
(Claude Code/Desktop, Codex, Gemini, Cursor, Roo, Windsurf, Zed, VS Code
+ Cline/Roo/Kilo, OpenCode, Copilot CLI, Amp, Amazon Q, Continue.dev) —
plus `~/.icm-uninstall-backups/<ts>/` timestamped backups (sha256
manifest) so every change is reversible with `cp -a files/. /`.

### CLI surface

```
icm uninstall --dry-run         # preview, exit 0
icm uninstall --audit           # same as dry-run, alt header
icm uninstall --check           # exit 0 iff clean, 1 if residue
icm uninstall                   # interactive [y/N] confirmation
icm uninstall -y                # skip confirmation
icm uninstall -y --purge-data   # also delete SQLite DB + fastembed cache
icm uninstall --scan-dir <PATH> # scan a project tree for free-form refs
icm uninstall --no-backup       # disable backups (not recommended)
icm uninstall --backup-dir <P>  # override backup root
```

Exit codes: `0` clean · `1` `--check` found residue · `2` user declined ·
`3` partial (ambiguous YAML / residue after run / symlink refused) ·
`4` mutation error.

### Format-aware mutation

| Format | Source helper inverted | Cascade clean-up |
|--------|------------------------|------------------|
| JSON `mcpServers` / `servers` / `mcp` / `context_servers` (incl. dotted `amp.mcpServers`) | `inject_mcp_server` / `inject_*_mcp_server` | drops emptied parent |
| JSON `hooks.<Event>[].hooks[]` (Claude/Gemini/Codex) | `inject_settings_hook` / `inject_codex_hook` | drops empty inner `hooks[]`, then empty event arr, then `hooks{}` |
| JSON `hooks.<event>[]` bash field (Copilot CLI) | `inject_copilot_hooks` | same cascade |
| TOML `[mcp_servers.icm]` | `inject_codex_mcp_server` | drops empty parent table |
| YAML `- name: icm` block (Continue.dev) | `inject_continue_mcp_server` | regex + structural validation (`command:`/`args:` required) — ambiguous block → exit 3, no destruction |
| Markdown `<!-- icm:start --> ... <!-- icm:end -->` | `inject_icm_block` | deletes the whole file if block was the only content |
| Owned files (recall.md, remember.md, icm.mdc, icm.ts, …) | `install_skill` / OpenCode plugin write | full file delete |
| Data dirs (memories.db + WAL/SHM, fastembed cache) | (preserved by default) | only with `--purge-data` |

### Safety

- **Backups always on** unless explicitly `--no-backup`. Layout mirrors the
  original absolute paths under `<root>/files/<canonical>/`, plus a
  `manifest.json` with sha256 per file. Restore = `cp -a files/. /`.
- **DB preserved by default**. `--purge-data` is opt-in and refuses to run
  while `icm serve` processes are detected unless `-y` is also passed
  (WAL-corruption protection).
- **Process detection is read-only** — Linux walks `/proc/<pid>/cmdline`,
  macOS uses `ps`. No kill, no signal — by design.
- **Symlinks are refused**: backup deliberately doesn't deref them, and the
  mutator now refuses to write through one either (would silently mutate
  a shared target without a backup record). Reported as `Ambiguous` → exit 3.
- **`Commands::Uninstall` is dispatched before `open_store()`** so
  `--purge-data` cannot be silently undone by the default DB-init that
  every other subcommand triggers.

### Code organization

New submodule `crates/icm-cli/src/uninstall/` (multi-file, matching the
`cloud.rs` / `web.rs` / `config.rs` pattern in this crate):

- `locations.rs` — static catalog mirroring `cmd_init` + env overrides
- `discover.rs` — format-aware scanner → `RemovalPlan`
- `formats.rs` — pure strippers (no I/O), one per format
- `backup.rs` — `BackupSession` with ISO timestamps (Windows-safe)
- `mutate.rs` — orchestrator, groups hits by path, threads backup
- `process.rs` — `icm serve` detector (Linux/macOS, no kill)
- `scan_dir.rs` — walkdir-based project tree scan (depth 8, skip-dirs)
- `report.rs` — audit / check / apply summary formatters

`main.rs` change is 1 dispatch line + a guarded `Commands::Uninstall(_) =>
unreachable!()` in the post-`open_store` match. Three small `pub(crate)`
upgrades on `home_dir_str`, `cli_config_dir`, `cmd_matches_icm_pattern`,
`parse_json_config` so the catalog can reuse init's path resolution and
detection rules.

One new workspace dep: `walkdir = "2"`.

### Tests

- **35 in-binary unit tests** covering strippers (cascade clean-up,
  idempotency, ambiguous YAML, markdown delete-file path, Copilot bash
  field, dotted servers_key), backup layout, ISO timestamp, civil-from-
  days reference point, scan_dir depth cap + skip-dirs, process self-PID
  filter.
- **5 integration tests** in `tests/uninstall_integration.rs` spawning
  the real `icm` binary in a fake `HOME=<tempdir>`:
  - `--check` exits 1 with residue, 0 after uninstall
  - `--dry-run` makes zero filesystem changes
  - uninstall on a clean home is idempotent
  - `--purge-data` deletes data dirs AND a follow-up `--check` does NOT
    recreate them (regression for the `open_store` bypass)
  - `--scan-dir` strips block from nested CLAUDE.md, skips `node_modules`
- **50 ad-hoc shell-harness assertions** covering preserve-siblings,
  symlink refusal, corrupted-JSON tolerance, manifest sha256 integrity,
  cumulative init cycles, round-trip restore byte-identical.

Total: 217 tests passing in the `icm-cli` suite. `cargo clippy
-- -D warnings` is clean.

### Known limitation / follow-up

`cmd_init` currently writes instruction files, skills, and hooks
**without** calling `detect_tool()` — only the MCP injection path is
guarded. The uninstall surface therefore has to clean up residue from
tools the user never had installed. Also discovered during this work:
`inject_settings_hook` doesn't `create_dir_all(parent)` before writing,
so `icm init --mode hook` (without standard/all) crashes on a fresh
home. Both fixes — plus an install manifest written at init time so
uninstall doesn't have to derive the surface from a hard-coded list —
are tracked for a follow-up PR.

## Test plan

- [x] `cargo build -p icm-cli`
- [x] `cargo clippy -p icm-cli -- -D warnings`
- [x] `cargo test -p icm-cli` (217 passed)
- [x] Manual smoke: `HOME=\$(mktemp -d) icm init --mode all --force` then
      `icm uninstall -y` round-trip → `--check` exits 0
- [x] Round-trip restore byte-identical (backup → uninstall → cp -a → re-sha256)
- [x] `--scan-dir` against a synthetic nested project tree (skips node_modules)
- [x] `--purge-data` against a real-looking data dir (no DB recreation by follow-up `--check`)
- [x] 7-scenario fixture suite under `/tmp/testicms/`, 50-assertion shell harness, 5x stress loops with mixed modes
- [x] Audit on the maintainer's real `$HOME` — 39 residue items detected,
      zero mutation

Closes #229