### PR TITLE
fix(init): gate by detect_tool, install manifest, global paths by default

### DIFF
--- a/crates/icm-cli/src/install_manifest.rs
+++ b/crates/icm-cli/src/install_manifest.rs
@@ -1,0 +1,333 @@
+//! Install manifest written by `icm init`.
+//!
+//! Every time `icm init` configures an AI tool, it records the touched
+//! path here. The manifest persists across invocations: subsequent
+//! `icm init` runs update entries in place, and `icm uninstall` (a
+//! future PR) consumes it to know exactly what to clean up — without
+//! having to derive the surface from a hard-coded list.
+//!
+//! Path: `<icm-data-dir>/install-manifest.json`
+//! - Linux/WSL: `~/.local/share/icm/install-manifest.json`
+//! - macOS:     `~/Library/Application Support/icm/install-manifest.json`
+//! - Windows:   `%APPDATA%\icm\icm\data\install-manifest.json`
+//!
+//! Schema is versioned (`schema_version` field) so future migrations
+//! stay backwards-compatible.
+
+#![allow(dead_code)] // consumed by cmd_init in the next commit
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+const CURRENT_SCHEMA: u32 = 1;
+
+/// Top-level install manifest persisted at `<data_dir>/install-manifest.json`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct InstallManifest {
+    /// Bumped on incompatible field changes. Always read on load; reject
+    /// unknown versions with a clear error so older binaries don't
+    /// silently truncate a newer manifest.
+    pub schema_version: u32,
+    /// Version of the `icm` binary that wrote / last updated this file.
+    pub icm_version: String,
+    /// ISO-8601 timestamp of the last write.
+    pub updated_at: String,
+    /// One entry per configuration target.
+    pub entries: Vec<ManifestEntry>,
+}
+
+/// One configuration mutation recorded by init.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct ManifestEntry {
+    /// Absolute path of the configuration file ICM wrote to.
+    pub path: PathBuf,
+    /// Human-readable label of the AI tool ("Claude Code", "Codex CLI",
+    /// "OpenCode plugin", "Cursor rule", ...).
+    pub tool: String,
+    /// What kind of mutation init performed at this path.
+    pub kind: EntryKind,
+    /// SHA-256 of the file contents before init touched it. `None` when
+    /// the file did not exist (a pure-create write).
+    pub sha256_before: Option<String>,
+    /// File size in bytes before init touched it. 0 for pure creates.
+    pub bytes_before: u64,
+}
+
+/// What `cmd_init` did at this path.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) enum EntryKind {
+    /// JSON file with an `mcpServers.icm` (or sibling) entry inserted.
+    JsonMcpServer,
+    /// JSON file with hook entries inserted (Claude/Gemini/Codex shape).
+    JsonHooks,
+    /// JSON file with Copilot's `bash` field hooks.
+    JsonCopilotHooks,
+    /// TOML file (Codex `config.toml`) with `[mcp_servers.icm]`.
+    TomlMcpServer,
+    /// YAML file (Continue.dev) with a `- name: icm` block appended.
+    YamlContinue,
+    /// Markdown file with an `<!-- icm:start --> ... <!-- icm:end -->`
+    /// block injected.
+    MarkdownBlock,
+    /// Whole-file artifact owned solely by init (skill / plugin).
+    OwnedFile,
+}
+
+impl InstallManifest {
+    /// Empty manifest scaffold.
+    pub fn empty() -> Self {
+        Self {
+            schema_version: CURRENT_SCHEMA,
+            icm_version: env!("CARGO_PKG_VERSION").to_string(),
+            updated_at: iso_timestamp(),
+            entries: Vec::new(),
+        }
+    }
+
+    /// Read the manifest at `path`, or return an empty one if the file
+    /// does not exist yet. Rejects unknown `schema_version`s loudly.
+    pub fn load(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::empty());
+        }
+        let raw = std::fs::read_to_string(path)
+            .with_context(|| format!("cannot read manifest at {}", path.display()))?;
+        let m: InstallManifest = serde_json::from_str(&raw)
+            .with_context(|| format!("invalid JSON in manifest {}", path.display()))?;
+        if m.schema_version > CURRENT_SCHEMA {
+            anyhow::bail!(
+                "install manifest {} was written by a newer icm \
+                (schema {} > {}). Upgrade icm or back up the manifest \
+                before re-running init.",
+                path.display(),
+                m.schema_version,
+                CURRENT_SCHEMA,
+            );
+        }
+        Ok(m)
+    }
+
+    /// Write the manifest, creating the parent directory if needed.
+    /// Bumps `updated_at` and `icm_version` on every save.
+    pub fn save(&mut self, path: &Path) -> Result<()> {
+        self.updated_at = iso_timestamp();
+        self.icm_version = env!("CARGO_PKG_VERSION").to_string();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("cannot create {}", parent.display()))?;
+        }
+        let json = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, json)
+            .with_context(|| format!("cannot write manifest {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Record (or update) an entry for `path`. If an entry with the
+    /// same path already exists, its metadata is left intact —
+    /// `sha256_before` reflects the state **before init ever touched
+    /// the path**, not the state before this particular run.
+    pub fn record(&mut self, entry: ManifestEntry) {
+        if self.entries.iter().any(|e| e.path == entry.path) {
+            return;
+        }
+        self.entries.push(entry);
+    }
+
+    /// Build a `ManifestEntry` by inspecting `path` on disk. Caller
+    /// should invoke this **before** the mutation so the hash captures
+    /// the pre-mutation state.
+    pub fn entry_from_disk(path: &Path, tool: &str, kind: EntryKind) -> Result<ManifestEntry> {
+        if !path.exists() {
+            return Ok(ManifestEntry {
+                path: path.to_path_buf(),
+                tool: tool.to_string(),
+                kind,
+                sha256_before: None,
+                bytes_before: 0,
+            });
+        }
+        let meta =
+            std::fs::metadata(path).with_context(|| format!("cannot stat {}", path.display()))?;
+        let bytes_before = meta.len();
+        let sha256_before = Some(sha256_of(path)?);
+        Ok(ManifestEntry {
+            path: path.to_path_buf(),
+            tool: tool.to_string(),
+            kind,
+            sha256_before,
+            bytes_before,
+        })
+    }
+
+    /// Number of recorded entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// Resolve the manifest path from `ProjectDirs`. Falls back to
+/// `<cwd>/install-manifest.json` only when ProjectDirs is unavailable
+/// (stripped sandboxes).
+pub(crate) fn default_manifest_path() -> PathBuf {
+    directories::ProjectDirs::from("dev", "icm", "icm")
+        .map(|d| d.data_dir().join("install-manifest.json"))
+        .unwrap_or_else(|| PathBuf::from("install-manifest.json"))
+}
+
+fn sha256_of(path: &Path) -> Result<String> {
+    use sha2::{Digest, Sha256};
+    let mut f = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut f, &mut hasher)?;
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// `YYYY-MM-DDTHH:MM:SSZ` UTC. Manifest is JSON so colons are fine
+/// here, unlike the backup directory name.
+fn iso_timestamp() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let (y, mo, d, h, mi, s) = epoch_to_ymdhms(secs);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+fn epoch_to_ymdhms(secs: u64) -> (i32, u32, u32, u32, u32, u32) {
+    let days = (secs / 86_400) as i64;
+    let sec_of_day = secs % 86_400;
+    let h = (sec_of_day / 3600) as u32;
+    let mi = ((sec_of_day % 3600) / 60) as u32;
+    let s = (sec_of_day % 60) as u32;
+
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let mo = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+    let y = if mo <= 2 { y + 1 } else { y };
+    (y as i32, mo, d, h, mi, s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_manifest_has_current_schema_and_no_entries() {
+        let m = InstallManifest::empty();
+        assert_eq!(m.schema_version, CURRENT_SCHEMA);
+        assert!(m.entries.is_empty());
+        assert!(!m.icm_version.is_empty());
+    }
+
+    #[test]
+    fn load_returns_empty_when_file_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("does-not-exist.json");
+        let m = InstallManifest::load(&missing).unwrap();
+        assert!(m.is_empty());
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nested/install-manifest.json");
+        let mut m = InstallManifest::empty();
+        m.record(ManifestEntry {
+            path: PathBuf::from("/x/.claude.json"),
+            tool: "Claude Code".into(),
+            kind: EntryKind::JsonMcpServer,
+            sha256_before: Some("abc".into()),
+            bytes_before: 42,
+        });
+        m.save(&path).unwrap();
+
+        let m2 = InstallManifest::load(&path).unwrap();
+        assert_eq!(m2.entries.len(), 1);
+        assert_eq!(m2.entries[0].tool, "Claude Code");
+        assert_eq!(m2.entries[0].kind, EntryKind::JsonMcpServer);
+    }
+
+    #[test]
+    fn record_is_idempotent_per_path() {
+        let mut m = InstallManifest::empty();
+        let entry1 = ManifestEntry {
+            path: PathBuf::from("/x"),
+            tool: "A".into(),
+            kind: EntryKind::JsonMcpServer,
+            sha256_before: Some("aa".into()),
+            bytes_before: 1,
+        };
+        let entry2 = ManifestEntry {
+            path: PathBuf::from("/x"),
+            tool: "B".into(),
+            kind: EntryKind::TomlMcpServer,
+            sha256_before: Some("bb".into()),
+            bytes_before: 2,
+        };
+        m.record(entry1);
+        m.record(entry2);
+        assert_eq!(m.entries.len(), 1);
+        // First write wins — preserves the pre-mutation state.
+        assert_eq!(m.entries[0].tool, "A");
+        assert_eq!(m.entries[0].sha256_before.as_deref(), Some("aa"));
+    }
+
+    #[test]
+    fn entry_from_disk_captures_pre_mutation_sha256() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("a.json");
+        std::fs::write(&path, "hello").unwrap();
+        let entry = InstallManifest::entry_from_disk(&path, "Test", EntryKind::OwnedFile).unwrap();
+        assert_eq!(entry.bytes_before, 5);
+        // sha256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+        assert_eq!(
+            entry.sha256_before.as_deref(),
+            Some("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+        );
+    }
+
+    #[test]
+    fn entry_from_disk_handles_missing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("no.json");
+        let entry =
+            InstallManifest::entry_from_disk(&missing, "Test", EntryKind::OwnedFile).unwrap();
+        assert_eq!(entry.bytes_before, 0);
+        assert!(entry.sha256_before.is_none());
+    }
+
+    #[test]
+    fn load_rejects_unknown_schema_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("m.json");
+        std::fs::write(
+            &path,
+            format!(
+                r#"{{"schema_version":{},"icm_version":"99","updated_at":"x","entries":[]}}"#,
+                CURRENT_SCHEMA + 1
+            ),
+        )
+        .unwrap();
+        let err = InstallManifest::load(&path).unwrap_err();
+        assert!(format!("{err:#}").contains("newer icm"));
+    }
+
+    #[test]
+    fn iso_timestamp_known_reference_point() {
+        let (y, mo, d, h, mi, s) = epoch_to_ymdhms(1_700_000_000);
+        assert_eq!((y, mo, d, h, mi, s), (2023, 11, 14, 22, 13, 20));
+    }
+}

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -304,6 +304,15 @@ enum Commands {
         /// are left untouched, even if their binary path no longer exists.
         #[arg(short, long)]
         force: bool,
+
+        /// Also write project-level instruction files into the current
+        /// directory (`CLAUDE.md`, `AGENTS.md`, `.windsurfrules`,
+        /// `.aider.conventions.md`, `.github/copilot-instructions.md`).
+        /// Default behavior writes only to global per-tool paths
+        /// (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, etc.) so init
+        /// doesn't pollute every project tree.
+        #[arg(long)]
+        per_project: bool,
     },
 
     /// Diagnose ICM integration: check hook binary paths in Claude Code settings
@@ -1329,7 +1338,11 @@ fn main() -> Result<()> {
                 cmd_memoir_distill(&store, &from_topic, &into)
             }
         },
-        Commands::Init { mode, force } => cmd_init(mode, force),
+        Commands::Init {
+            mode,
+            force,
+            per_project,
+        } => cmd_init(mode, force, per_project),
         Commands::Doctor => cmd_doctor(),
         Commands::Extract {
             project,
@@ -3284,7 +3297,7 @@ fn cmd_matches_icm_pattern(cmd: &str, pattern: &str) -> bool {
     cmd.contains(&format!("{pattern}.exe"))
 }
 
-fn cmd_init(mode: InitMode, force: bool) -> Result<()> {
+fn cmd_init(mode: InitMode, force: bool, per_project: bool) -> Result<()> {
     let icm_bin = std::env::current_exe().context("cannot determine icm binary path")?;
     let icm_bin_str = portable_command_path(&icm_bin);
     let home = home_dir_str()?;
@@ -3496,6 +3509,17 @@ fn cmd_init(mode: InitMode, force: bool) -> Result<()> {
     }
 
     // --- CLI mode: inject instructions into each tool's file ---
+    //
+    // Two write surfaces:
+    //   - GLOBAL paths (the default): each tool's HOME-level instruction
+    //     file. Claude Code reads CLAUDE.md upward to $HOME, Codex
+    //     scans for AGENTS.md, Gemini reads ~/.gemini/GEMINI.md, etc.
+    //     One file per tool, used across every project.
+    //   - PROJECT paths (the `--per-project` flag): cwd-level files for
+    //     tools that only support per-project (Copilot, Windsurf,
+    //     Aider) or for users who want project-specific overrides.
+    //     This is the pre-fix/init-secure behaviour, kept available
+    //     opt-in.
     if do_cli {
         let cwd = std::env::current_dir().context("failed to get current directory")?;
 
@@ -3533,25 +3557,71 @@ icm topics                                # list all topics\n\
 ```\n\
 <!-- icm:end -->";
 
-        // (tool_label, detect_name, path)
-        // `detect_name` is the key used by `detect_tool`; `tool_label`
-        // is what we print and record in the manifest.
-        let instruction_files: Vec<(&str, &str, PathBuf)> = vec![
-            ("Claude Code", "Claude Code", cwd.join("CLAUDE.md")),
-            ("Codex", "Codex CLI", cwd.join("AGENTS.md")),
+        // Global write targets: (tool_label, detect_name, path).
+        // Tools that support a HOME-level instruction file get one here
+        // and the cwd file is only written when --per-project is set.
+        let global_files: Vec<(&str, &str, PathBuf)> = vec![
+            ("Claude Code", "Claude Code", claude_dir.join("CLAUDE.md")),
+            ("Codex", "Codex CLI", codex_dir.join("AGENTS.md")),
             ("Gemini", "Gemini", gemini_dir.join("GEMINI.md")),
+        ];
+
+        // Project-only write targets (no global equivalent at the tool):
+        // Copilot, Windsurf, Aider only support per-project context
+        // files. Skipped unless --per-project is given.
+        let project_only_files: Vec<(&str, &str, PathBuf)> = vec![
             (
                 "Copilot",
                 "Copilot CLI",
                 cwd.join(".github/copilot-instructions.md"),
             ),
             ("Windsurf", "Windsurf", cwd.join(".windsurfrules")),
-            // Aider has no `detect_tool` entry — keep the previous
-            // permissive behavior by always writing when do_cli is on.
             ("Aider", "Aider", cwd.join(".aider.conventions.md")),
         ];
 
-        for (label, detect, path) in &instruction_files {
+        for (label, detect, path) in &global_files {
+            if !force && !detect_tool(detect, &home, &vscode_data) {
+                println!("[cli] {label:<16} skipped (not detected)");
+                continue;
+            }
+            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                path,
+                label,
+                install_manifest::EntryKind::MarkdownBlock,
+            ) {
+                manifest.record(e);
+            }
+            let status = inject_icm_block(path, icm_block)?;
+            println!("[cli] {label:<16} {status}");
+
+            // With --per-project, also drop the cwd-level marker so
+            // users who manually open this project in a fresh editor
+            // session still get the bloc in-tree.
+            if per_project {
+                let cwd_path = match *label {
+                    "Claude Code" => Some(cwd.join("CLAUDE.md")),
+                    "Codex" => Some(cwd.join("AGENTS.md")),
+                    _ => None,
+                };
+                if let Some(p) = cwd_path {
+                    if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                        &p,
+                        label,
+                        install_manifest::EntryKind::MarkdownBlock,
+                    ) {
+                        manifest.record(e);
+                    }
+                    let status = inject_icm_block(&p, icm_block)?;
+                    println!("[cli] {label:<16} (cwd) {status}");
+                }
+            }
+        }
+
+        for (label, detect, path) in &project_only_files {
+            if !per_project {
+                println!("[cli] {label:<16} skipped (project-level only — pass --per-project)");
+                continue;
+            }
             if !force && !detect_tool(detect, &home, &vscode_data) {
                 println!("[cli] {label:<16} skipped (not detected)");
                 continue;

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -6,6 +6,7 @@ mod config;
 mod extract;
 mod extract_semantic;
 mod import;
+mod install_manifest;
 #[cfg(test)]
 mod learn_tests;
 mod recall_format;

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -4043,6 +4043,12 @@ fn inject_settings_hook(
     let mut config: Value = if settings_path.exists() {
         parse_json_config(settings_path)?
     } else {
+        // Create the parent directory eagerly. `inject_codex_hook` and
+        // friends already do this; without it, `icm init --mode hook`
+        // crashes on a fresh home when ~/.claude/ does not exist yet.
+        if let Some(parent) = settings_path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
         serde_json::json!({})
     };
 

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -3303,6 +3303,19 @@ fn cmd_init(mode: InitMode, force: bool) -> Result<()> {
     let do_skill = matches!(mode, InitMode::Skill | InitMode::All | InitMode::Standard);
     let do_hook = matches!(mode, InitMode::Hook | InitMode::All | InitMode::Standard);
 
+    // Shared across every mode for tool detection.
+    let vscode_data = if cfg!(target_os = "macos") {
+        PathBuf::from(&home).join("Library/Application Support/Code/User")
+    } else {
+        PathBuf::from(&home).join(".config/Code/User")
+    };
+
+    // Load (or create) the install manifest. Every configured path gets
+    // recorded so a future `icm uninstall` doesn't have to derive the
+    // surface from a hard-coded mirror of this function.
+    let manifest_path = install_manifest::default_manifest_path();
+    let mut manifest = install_manifest::InstallManifest::load(&manifest_path)?;
+
     // --- MCP mode: configure MCP servers for all detected tools ---
     if do_mcp {
         let icm_server_entry = serde_json::json!({
@@ -3310,12 +3323,6 @@ fn cmd_init(mode: InitMode, force: bool) -> Result<()> {
             "args": ["serve"],
             "env": {}
         });
-
-        let vscode_data = if cfg!(target_os = "macos") {
-            PathBuf::from(&home).join("Library/Application Support/Code/User")
-        } else {
-            PathBuf::from(&home).join(".config/Code/User")
-        };
 
         // Claude Code's legacy MCP config lives at `~/.claude.json` (a
         // sibling of `~/.claude/`). When the user has set
@@ -3392,6 +3399,13 @@ fn cmd_init(mode: InitMode, force: bool) -> Result<()> {
                 println!("[mcp] {name:<16} skipped (not detected)");
                 continue;
             }
+            if let Ok(entry) = install_manifest::InstallManifest::entry_from_disk(
+                config_path,
+                name,
+                install_manifest::EntryKind::JsonMcpServer,
+            ) {
+                manifest.record(entry);
+            }
             let status = inject_mcp_server(config_path, "icm", &icm_server_entry, key)?;
             println!("[mcp] {name:<16} {status}");
         }
@@ -3405,6 +3419,13 @@ fn cmd_init(mode: InitMode, force: bool) -> Result<()> {
         if !force && !detect_tool("Zed", &home, &vscode_data) {
             println!("[mcp] {:<16} skipped (not detected)", "Zed");
         } else {
+            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                &zed_path,
+                "Zed",
+                install_manifest::EntryKind::JsonMcpServer,
+            ) {
+                manifest.record(e);
+            }
             let zed_status = inject_zed_mcp_server(&zed_path, "icm", &icm_bin_str)?;
             println!("[mcp] {:<16} {zed_status}", "Zed");
         }
@@ -3414,6 +3435,13 @@ fn cmd_init(mode: InitMode, force: bool) -> Result<()> {
         if !force && !detect_tool("Codex CLI", &home, &vscode_data) {
             println!("[mcp] {:<16} skipped (not detected)", "Codex CLI");
         } else {
+            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                &codex_path,
+                "Codex CLI",
+                install_manifest::EntryKind::TomlMcpServer,
+            ) {
+                manifest.record(e);
+            }
             let codex_status = inject_codex_mcp_server(&codex_path, "icm", &icm_bin_str)?;
             println!("[mcp] {:<16} {codex_status}", "Codex CLI");
         }
@@ -3423,6 +3451,13 @@ fn cmd_init(mode: InitMode, force: bool) -> Result<()> {
         if !force && !detect_tool("OpenCode", &home, &vscode_data) {
             println!("[mcp] {:<16} skipped (not detected)", "OpenCode");
         } else {
+            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                &opencode_path,
+                "OpenCode",
+                install_manifest::EntryKind::JsonMcpServer,
+            ) {
+                manifest.record(e);
+            }
             let opencode_status = inject_opencode_mcp_server(&opencode_path, "icm", &icm_bin_str)?;
             println!("[mcp] {:<16} {opencode_status}", "OpenCode");
         }
@@ -3432,6 +3467,13 @@ fn cmd_init(mode: InitMode, force: bool) -> Result<()> {
         if !force && !detect_tool("Copilot CLI", &home, &vscode_data) {
             println!("[mcp] {:<16} skipped (not detected)", "Copilot CLI");
         } else {
+            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                &copilot_path,
+                "Copilot CLI",
+                install_manifest::EntryKind::JsonMcpServer,
+            ) {
+                manifest.record(e);
+            }
             let copilot_status = inject_copilot_cli_mcp_server(&copilot_path, "icm", &icm_bin_str)?;
             println!("[mcp] {:<16} {copilot_status}", "Copilot CLI");
         }
@@ -3441,6 +3483,13 @@ fn cmd_init(mode: InitMode, force: bool) -> Result<()> {
         if !force && !detect_tool("Continue.dev", &home, &vscode_data) {
             println!("[mcp] {:<16} skipped (not detected)", "Continue.dev");
         } else {
+            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                &continue_path,
+                "Continue.dev",
+                install_manifest::EntryKind::YamlContinue,
+            ) {
+                manifest.record(e);
+            }
             let continue_status = inject_continue_mcp_server(&continue_path, "icm", &icm_bin_str)?;
             println!("[mcp] {:<16} {continue_status}", "Continue.dev");
         }
@@ -3484,19 +3533,38 @@ icm topics                                # list all topics\n\
 ```\n\
 <!-- icm:end -->";
 
-        // Each AI tool uses its own instruction file
-        let instruction_files: Vec<(&str, PathBuf)> = vec![
-            ("Claude Code", cwd.join("CLAUDE.md")),
-            ("Codex", cwd.join("AGENTS.md")),
-            ("Gemini", gemini_dir.join("GEMINI.md")),
-            ("Copilot", cwd.join(".github/copilot-instructions.md")),
-            ("Windsurf", cwd.join(".windsurfrules")),
-            ("Aider", cwd.join(".aider.conventions.md")),
+        // (tool_label, detect_name, path)
+        // `detect_name` is the key used by `detect_tool`; `tool_label`
+        // is what we print and record in the manifest.
+        let instruction_files: Vec<(&str, &str, PathBuf)> = vec![
+            ("Claude Code", "Claude Code", cwd.join("CLAUDE.md")),
+            ("Codex", "Codex CLI", cwd.join("AGENTS.md")),
+            ("Gemini", "Gemini", gemini_dir.join("GEMINI.md")),
+            (
+                "Copilot",
+                "Copilot CLI",
+                cwd.join(".github/copilot-instructions.md"),
+            ),
+            ("Windsurf", "Windsurf", cwd.join(".windsurfrules")),
+            // Aider has no `detect_tool` entry — keep the previous
+            // permissive behavior by always writing when do_cli is on.
+            ("Aider", "Aider", cwd.join(".aider.conventions.md")),
         ];
 
-        for (tool_name, path) in &instruction_files {
+        for (label, detect, path) in &instruction_files {
+            if !force && !detect_tool(detect, &home, &vscode_data) {
+                println!("[cli] {label:<16} skipped (not detected)");
+                continue;
+            }
+            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                path,
+                label,
+                install_manifest::EntryKind::MarkdownBlock,
+            ) {
+                manifest.record(e);
+            }
             let status = inject_icm_block(path, icm_block)?;
-            println!("[cli] {tool_name:<16} {status}");
+            println!("[cli] {label:<16} {status}");
         }
     }
 
@@ -3521,18 +3589,31 @@ icm store -t \"note\" -c \"$ARGUMENTS\"
 
         // Claude Code: ~/.claude/commands/ (or $CLAUDE_CONFIG_DIR/commands/)
         let claude_skills_dir = claude_dir.join("commands");
-        install_skill(
-            &claude_skills_dir,
-            "recall.md",
-            icm_recall_prompt,
-            "Claude Code /recall",
-        )?;
-        install_skill(
-            &claude_skills_dir,
-            "remember.md",
-            icm_remember_prompt,
-            "Claude Code /remember",
-        )?;
+        if force || detect_tool("Claude Code", &home, &vscode_data) {
+            for fname in ["recall.md", "remember.md"] {
+                if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                    &claude_skills_dir.join(fname),
+                    "Claude Code skill",
+                    install_manifest::EntryKind::OwnedFile,
+                ) {
+                    manifest.record(e);
+                }
+            }
+            install_skill(
+                &claude_skills_dir,
+                "recall.md",
+                icm_recall_prompt,
+                "Claude Code /recall",
+            )?;
+            install_skill(
+                &claude_skills_dir,
+                "remember.md",
+                icm_remember_prompt,
+                "Claude Code /remember",
+            )?;
+        } else {
+            println!("[skill] {:<16} skipped (not detected)", "Claude Code");
+        }
 
         // Cursor: ~/.cursor/rules/ (project or global)
         let cursor_rules_dir = PathBuf::from(&home).join(".cursor/rules");
@@ -3559,230 +3640,326 @@ icm recall \"query\"
 
 Do this BEFORE responding to the user. Not optional.
 ";
-        install_skill(&cursor_rules_dir, "icm.mdc", cursor_icm_rule, "Cursor rule")?;
+        if force || detect_tool("Cursor", &home, &vscode_data) {
+            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                &cursor_rules_dir.join("icm.mdc"),
+                "Cursor rule",
+                install_manifest::EntryKind::OwnedFile,
+            ) {
+                manifest.record(e);
+            }
+            install_skill(&cursor_rules_dir, "icm.mdc", cursor_icm_rule, "Cursor rule")?;
+        } else {
+            println!("[skill] {:<16} skipped (not detected)", "Cursor");
+        }
 
         // Roo Code: ~/.roo/rules/ (global)
         let roo_rules_dir = PathBuf::from(&home).join(".roo/rules");
-        install_skill(&roo_rules_dir, "icm.md", cursor_icm_rule, "Roo Code rule")?;
+        if force || detect_tool("Roo Code", &home, &vscode_data) {
+            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                &roo_rules_dir.join("icm.md"),
+                "Roo Code rule",
+                install_manifest::EntryKind::OwnedFile,
+            ) {
+                manifest.record(e);
+            }
+            install_skill(&roo_rules_dir, "icm.md", cursor_icm_rule, "Roo Code rule")?;
+        } else {
+            println!("[skill] {:<16} skipped (not detected)", "Roo Code");
+        }
 
         // Amp: ~/.config/amp/skills/
         let amp_skills_dir = PathBuf::from(&home).join(".config/amp/skills");
-        install_skill(
-            &amp_skills_dir,
-            "icm-recall.md",
-            icm_recall_prompt,
-            "Amp /icm-recall",
-        )?;
-        install_skill(
-            &amp_skills_dir,
-            "icm-remember.md",
-            icm_remember_prompt,
-            "Amp /icm-remember",
-        )?;
+        if force || detect_tool("Amp", &home, &vscode_data) {
+            for fname in ["icm-recall.md", "icm-remember.md"] {
+                if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                    &amp_skills_dir.join(fname),
+                    "Amp skill",
+                    install_manifest::EntryKind::OwnedFile,
+                ) {
+                    manifest.record(e);
+                }
+            }
+            install_skill(
+                &amp_skills_dir,
+                "icm-recall.md",
+                icm_recall_prompt,
+                "Amp /icm-recall",
+            )?;
+            install_skill(
+                &amp_skills_dir,
+                "icm-remember.md",
+                icm_remember_prompt,
+                "Amp /icm-remember",
+            )?;
+        } else {
+            println!("[skill] {:<16} skipped (not detected)", "Amp");
+        }
     }
 
-    // --- Hook mode: install Claude Code hooks (full Rust, no shell scripts) ---
+    // --- Hook mode: install hooks for each detected tool ---
     if do_hook {
         let claude_settings_path = claude_dir.join("settings.json");
+        let claude_installed = force || detect_tool("Claude Code", &home, &vscode_data);
 
-        // PreToolUse hook: `icm hook pre` (auto-allow icm commands)
-        let pre_cmd = format!("{} hook pre", icm_bin_str);
-        let pre_status = inject_settings_hook(
-            &claude_settings_path,
-            "PreToolUse",
-            &pre_cmd,
-            Some("Bash"),
-            &["icm-pretool", "icm hook pre"],
-            force,
-        )?;
-        println!("[hook] Claude Code PreToolUse (auto-allow): {pre_status}");
+        if !claude_installed {
+            println!("[hook] {:<16} skipped (not detected)", "Claude Code");
+        } else {
+            // Record manifest once for this file before any mutation.
+            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                &claude_settings_path,
+                "Claude Code hooks",
+                install_manifest::EntryKind::JsonHooks,
+            ) {
+                manifest.record(e);
+            }
+        }
 
-        // PostToolUse hook: `icm hook post` (auto-extract context)
-        let post_cmd = format!("{} hook post", icm_bin_str);
-        let post_status = inject_settings_hook(
-            &claude_settings_path,
-            "PostToolUse",
-            &post_cmd,
-            None,
-            &["icm hook", "icm-post-tool"],
-            force,
-        )?;
-        println!("[hook] Claude Code PostToolUse (auto-extract): {post_status}");
+        if claude_installed {
+            // PreToolUse hook: `icm hook pre` (auto-allow icm commands)
+            let pre_status = inject_settings_hook(
+                &claude_settings_path,
+                "PreToolUse",
+                &format!("{} hook pre", icm_bin_str),
+                Some("Bash"),
+                &["icm-pretool", "icm hook pre"],
+                force,
+            )?;
+            println!("[hook] Claude Code PreToolUse (auto-allow): {pre_status}");
 
-        // PreCompact hook: `icm hook compact` (extract from transcript before compression)
-        let compact_cmd = format!("{} hook compact", icm_bin_str);
-        let compact_status = inject_settings_hook(
-            &claude_settings_path,
-            "PreCompact",
-            &compact_cmd,
-            None,
-            &["icm hook", "icm-post-tool"],
-            force,
-        )?;
-        println!("[hook] Claude Code PreCompact (transcript extract): {compact_status}");
+            // PostToolUse hook: `icm hook post` (auto-extract context)
+            let post_status = inject_settings_hook(
+                &claude_settings_path,
+                "PostToolUse",
+                &format!("{} hook post", icm_bin_str),
+                None,
+                &["icm hook", "icm-post-tool"],
+                force,
+            )?;
+            println!("[hook] Claude Code PostToolUse (auto-extract): {post_status}");
 
-        // UserPromptSubmit hook: `icm hook prompt` (recall context on each prompt)
-        let prompt_cmd = format!("{} hook prompt", icm_bin_str);
-        let prompt_status = inject_settings_hook(
-            &claude_settings_path,
-            "UserPromptSubmit",
-            &prompt_cmd,
-            None,
-            &["icm hook", "icm-post-tool"],
-            force,
-        )?;
-        println!("[hook] Claude Code UserPromptSubmit (auto-recall): {prompt_status}");
+            // PreCompact: extract from transcript before compression
+            let compact_status = inject_settings_hook(
+                &claude_settings_path,
+                "PreCompact",
+                &format!("{} hook compact", icm_bin_str),
+                None,
+                &["icm hook", "icm-post-tool"],
+                force,
+            )?;
+            println!("[hook] Claude Code PreCompact (transcript extract): {compact_status}");
 
-        // SessionStart hook: `icm hook start` (inject wake-up pack of critical facts)
-        let start_cmd = format!("{} hook start", icm_bin_str);
-        let start_status = inject_settings_hook(
-            &claude_settings_path,
-            "SessionStart",
-            &start_cmd,
-            None,
-            &["icm hook start", "icm hook", "icm-post-tool"],
-            force,
-        )?;
-        println!("[hook] Claude Code SessionStart (wake-up pack): {start_status}");
+            // UserPromptSubmit: recall context on each prompt
+            let prompt_status = inject_settings_hook(
+                &claude_settings_path,
+                "UserPromptSubmit",
+                &format!("{} hook prompt", icm_bin_str),
+                None,
+                &["icm hook", "icm-post-tool"],
+                force,
+            )?;
+            println!("[hook] Claude Code UserPromptSubmit (auto-recall): {prompt_status}");
 
-        // SessionEnd hook: `icm hook end` (extract from transcript before /exit, /clear, etc.)
-        // Catches the path PreCompact misses — compaction does not fire on /clear.
-        let end_cmd = format!("{} hook end", icm_bin_str);
-        let end_status = inject_settings_hook(
-            &claude_settings_path,
-            "SessionEnd",
-            &end_cmd,
-            None,
-            &["icm hook end", "icm hook", "icm-post-tool"],
-            force,
-        )?;
-        println!("[hook] Claude Code SessionEnd (transcript extract): {end_status}");
+            // SessionStart: inject wake-up pack of critical facts
+            let start_status = inject_settings_hook(
+                &claude_settings_path,
+                "SessionStart",
+                &format!("{} hook start", icm_bin_str),
+                None,
+                &["icm hook start", "icm hook", "icm-post-tool"],
+                force,
+            )?;
+            println!("[hook] Claude Code SessionStart (wake-up pack): {start_status}");
+
+            // SessionEnd: extract before /exit, /clear (PreCompact doesn't fire on /clear).
+            let end_status = inject_settings_hook(
+                &claude_settings_path,
+                "SessionEnd",
+                &format!("{} hook end", icm_bin_str),
+                None,
+                &["icm hook end", "icm hook", "icm-post-tool"],
+                force,
+            )?;
+            println!("[hook] Claude Code SessionEnd (transcript extract): {end_status}");
+        }
 
         // OpenCode plugin: install TS plugin using native @opencode-ai/plugin SDK
         let opencode_plugins_dir = PathBuf::from(&home).join(".config/opencode/plugins");
         let opencode_plugin_path = opencode_plugins_dir.join("icm.ts");
-        // Remove old .js plugin if it exists
-        let old_js_plugin = opencode_plugins_dir.join("icm.js");
-        if old_js_plugin.exists() {
-            std::fs::remove_file(&old_js_plugin).ok();
-        }
-        if opencode_plugin_path.exists() {
-            println!("[hook] OpenCode plugin: already configured");
+        if force || detect_tool("OpenCode", &home, &vscode_data) {
+            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                &opencode_plugin_path,
+                "OpenCode plugin",
+                install_manifest::EntryKind::OwnedFile,
+            ) {
+                manifest.record(e);
+            }
+            let old_js_plugin = opencode_plugins_dir.join("icm.js");
+            if old_js_plugin.exists() {
+                std::fs::remove_file(&old_js_plugin).ok();
+            }
+            if opencode_plugin_path.exists() {
+                println!("[hook] OpenCode plugin: already configured");
+            } else {
+                std::fs::create_dir_all(&opencode_plugins_dir).ok();
+                let plugin_content = include_str!("../../../plugins/opencode-icm.ts");
+                std::fs::write(&opencode_plugin_path, plugin_content)
+                    .with_context(|| format!("cannot write {}", opencode_plugin_path.display()))?;
+                println!("[hook] OpenCode plugin: installed");
+            }
         } else {
-            std::fs::create_dir_all(&opencode_plugins_dir).ok();
-            let plugin_content = include_str!("../../../plugins/opencode-icm.ts");
-            std::fs::write(&opencode_plugin_path, plugin_content)
-                .with_context(|| format!("cannot write {}", opencode_plugin_path.display()))?;
-            println!("[hook] OpenCode plugin: installed");
+            println!("[hook] {:<16} skipped (not detected)", "OpenCode");
         }
 
-        // --- Gemini CLI hooks (same settings.json format as Claude Code, different event names) ---
+        // --- Gemini CLI hooks (same shape as Claude, different event names) ---
         let gemini_settings_path = gemini_dir.join("settings.json");
         let detect = &["icm hook", "icm-post-tool"];
 
-        // SessionStart → same name in Gemini CLI
-        let status = inject_settings_hook(
-            &gemini_settings_path,
-            "SessionStart",
-            &format!("{} hook start", icm_bin_str),
-            None,
-            &["icm hook start", "icm hook", "icm-post-tool"],
-            force,
-        )?;
-        println!("[hook] Gemini CLI SessionStart (wake-up pack): {status}");
+        if force || detect_tool("Gemini", &home, &vscode_data) {
+            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                &gemini_settings_path,
+                "Gemini CLI hooks",
+                install_manifest::EntryKind::JsonHooks,
+            ) {
+                manifest.record(e);
+            }
+            let status = inject_settings_hook(
+                &gemini_settings_path,
+                "SessionStart",
+                &format!("{} hook start", icm_bin_str),
+                None,
+                &["icm hook start", "icm hook", "icm-post-tool"],
+                force,
+            )?;
+            println!("[hook] Gemini CLI SessionStart (wake-up pack): {status}");
 
-        // BeforeTool → equivalent of PreToolUse (auto-allow icm commands)
-        // Gemini CLI uses "run_shell_command" as the Bash tool name
-        let status = inject_settings_hook(
-            &gemini_settings_path,
-            "BeforeTool",
-            &format!("{} hook pre", icm_bin_str),
-            Some("run_shell_command"),
-            &["icm-pretool", "icm hook pre"],
-            force,
-        )?;
-        println!("[hook] Gemini CLI BeforeTool (auto-allow): {status}");
+            let status = inject_settings_hook(
+                &gemini_settings_path,
+                "BeforeTool",
+                &format!("{} hook pre", icm_bin_str),
+                Some("run_shell_command"),
+                &["icm-pretool", "icm hook pre"],
+                force,
+            )?;
+            println!("[hook] Gemini CLI BeforeTool (auto-allow): {status}");
 
-        // AfterTool → equivalent of PostToolUse (auto-extract context)
-        let status = inject_settings_hook(
-            &gemini_settings_path,
-            "AfterTool",
-            &format!("{} hook post", icm_bin_str),
-            None,
-            detect,
-            force,
-        )?;
-        println!("[hook] Gemini CLI AfterTool (auto-extract): {status}");
+            let status = inject_settings_hook(
+                &gemini_settings_path,
+                "AfterTool",
+                &format!("{} hook post", icm_bin_str),
+                None,
+                detect,
+                force,
+            )?;
+            println!("[hook] Gemini CLI AfterTool (auto-extract): {status}");
 
-        // PreCompress → equivalent of PreCompact (extract from transcript)
-        let status = inject_settings_hook(
-            &gemini_settings_path,
-            "PreCompress",
-            &format!("{} hook compact", icm_bin_str),
-            None,
-            detect,
-            force,
-        )?;
-        println!("[hook] Gemini CLI PreCompress (transcript extract): {status}");
+            let status = inject_settings_hook(
+                &gemini_settings_path,
+                "PreCompress",
+                &format!("{} hook compact", icm_bin_str),
+                None,
+                detect,
+                force,
+            )?;
+            println!("[hook] Gemini CLI PreCompress (transcript extract): {status}");
 
-        // BeforeAgent → equivalent of UserPromptSubmit (auto-recall on each prompt)
-        let status = inject_settings_hook(
-            &gemini_settings_path,
-            "BeforeAgent",
-            &format!("{} hook prompt", icm_bin_str),
-            None,
-            detect,
-            force,
-        )?;
-        println!("[hook] Gemini CLI BeforeAgent (auto-recall): {status}");
+            let status = inject_settings_hook(
+                &gemini_settings_path,
+                "BeforeAgent",
+                &format!("{} hook prompt", icm_bin_str),
+                None,
+                detect,
+                force,
+            )?;
+            println!("[hook] Gemini CLI BeforeAgent (auto-recall): {status}");
+        } else {
+            println!("[hook] {:<16} skipped (not detected)", "Gemini");
+        }
 
         // --- Codex CLI hooks (separate hooks.json file) ---
         let codex_hooks_path = codex_dir.join("hooks.json");
 
-        let status = inject_codex_hook(
-            &codex_hooks_path,
-            "SessionStart",
-            &format!("{} hook start", icm_bin_str),
-            None,
-            &["icm hook start", "icm hook"],
-        )?;
-        println!("[hook] Codex CLI SessionStart (wake-up pack): {status}");
+        if force || detect_tool("Codex CLI", &home, &vscode_data) {
+            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                &codex_hooks_path,
+                "Codex CLI hooks",
+                install_manifest::EntryKind::JsonHooks,
+            ) {
+                manifest.record(e);
+            }
+            let status = inject_codex_hook(
+                &codex_hooks_path,
+                "SessionStart",
+                &format!("{} hook start", icm_bin_str),
+                None,
+                &["icm hook start", "icm hook"],
+            )?;
+            println!("[hook] Codex CLI SessionStart (wake-up pack): {status}");
 
-        let status = inject_codex_hook(
-            &codex_hooks_path,
-            "PreToolUse",
-            &format!("{} hook pre", icm_bin_str),
-            Some("Bash"),
-            &["icm-pretool", "icm hook pre"],
-        )?;
-        println!("[hook] Codex CLI PreToolUse (auto-allow): {status}");
+            let status = inject_codex_hook(
+                &codex_hooks_path,
+                "PreToolUse",
+                &format!("{} hook pre", icm_bin_str),
+                Some("Bash"),
+                &["icm-pretool", "icm hook pre"],
+            )?;
+            println!("[hook] Codex CLI PreToolUse (auto-allow): {status}");
 
-        let status = inject_codex_hook(
-            &codex_hooks_path,
-            "PostToolUse",
-            &format!("{} hook post", icm_bin_str),
-            None,
-            detect,
-        )?;
-        println!("[hook] Codex CLI PostToolUse (auto-extract): {status}");
+            let status = inject_codex_hook(
+                &codex_hooks_path,
+                "PostToolUse",
+                &format!("{} hook post", icm_bin_str),
+                None,
+                detect,
+            )?;
+            println!("[hook] Codex CLI PostToolUse (auto-extract): {status}");
 
-        let status = inject_codex_hook(
-            &codex_hooks_path,
-            "UserPromptSubmit",
-            &format!("{} hook prompt", icm_bin_str),
-            None,
-            detect,
-        )?;
-        println!("[hook] Codex CLI UserPromptSubmit (auto-recall): {status}");
+            let status = inject_codex_hook(
+                &codex_hooks_path,
+                "UserPromptSubmit",
+                &format!("{} hook prompt", icm_bin_str),
+                None,
+                detect,
+            )?;
+            println!("[hook] Codex CLI UserPromptSubmit (auto-recall): {status}");
+        } else {
+            println!("[hook] {:<16} skipped (not detected)", "Codex CLI");
+        }
 
         // --- Copilot CLI hooks (user-global ~/.copilot/settings.json) ---
-        let copilot_status = inject_copilot_hooks(&copilot_dir, &icm_bin_str)?;
-        println!("[hook] Copilot CLI (all hooks): {copilot_status}");
+        if force || detect_tool("Copilot CLI", &home, &vscode_data) {
+            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                &copilot_dir.join("settings.json"),
+                "Copilot CLI hooks",
+                install_manifest::EntryKind::JsonCopilotHooks,
+            ) {
+                manifest.record(e);
+            }
+            let copilot_status = inject_copilot_hooks(&copilot_dir, &icm_bin_str)?;
+            println!("[hook] Copilot CLI (all hooks): {copilot_status}");
+        } else {
+            println!("[hook] {:<16} skipped (not detected)", "Copilot CLI");
+        }
+    }
+
+    // Persist the install manifest. Subsequent `icm uninstall` reads
+    // it instead of re-deriving paths from a hard-coded mirror of this
+    // function.
+    if !manifest.is_empty() {
+        manifest.save(&manifest_path)?;
     }
 
     println!();
-    println!("  binary: {icm_bin_str}");
-    println!("  db:     {}", default_db_path().display());
+    println!("  binary:   {icm_bin_str}");
+    println!("  db:       {}", default_db_path().display());
+    if !manifest.is_empty() {
+        println!(
+            "  manifest: {} ({} entr{})",
+            manifest_path.display(),
+            manifest.len(),
+            if manifest.len() == 1 { "y" } else { "ies" }
+        );
+    }
     println!();
     println!("Restart your AI tool to activate.");
 
@@ -4411,6 +4588,8 @@ fn detect_tool(name: &str, home: &str, vscode_data: &Path) -> bool {
         "Continue.dev" => {
             vscode_present() && vscode_data.join("globalStorage/continue.continue").exists()
         }
+        // Aider is a Python CLI (pip-installable); check the binary.
+        "Aider" => binary_in_path("aider"),
         _ => true,
     }
 }

--- a/crates/icm-cli/tests/init_secure_integration.rs
+++ b/crates/icm-cli/tests/init_secure_integration.rs
@@ -1,0 +1,266 @@
+//! End-to-end integration tests for the fix/init-secure changes:
+//! `icm init` now (a) gates every mode by `detect_tool`, (b) persists
+//! an install manifest, (c) writes instruction files to global per-tool
+//! paths by default — and only mirrors them to the cwd when
+//! `--per-project` is passed.
+//!
+//! Each test spawns the compiled `icm` binary inside a private
+//! `HOME=<tempdir>` with a stripped `PATH` so no real AI binary is
+//! detected.
+
+use std::path::Path;
+use std::process::Command;
+
+const ICM: &str = env!("CARGO_BIN_EXE_icm");
+
+fn icm_in(home: &Path, cwd: &Path, path_env: &str, args: &[&str]) -> std::process::Output {
+    Command::new(ICM)
+        .env_clear()
+        .env("HOME", home)
+        .env("PATH", path_env)
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .expect("spawn icm")
+}
+
+fn make_home() -> (tempfile::TempDir, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cwd = tmp.path().join("proj");
+    std::fs::create_dir_all(&cwd).unwrap();
+    let cwd_path = cwd.clone();
+    (tmp, cwd_path)
+}
+
+#[test]
+fn init_with_no_detected_tools_writes_zero_files() {
+    let (tmp, cwd) = make_home();
+    let out = icm_in(tmp.path(), &cwd, "/dev/null", &["init", "--mode", "all"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "init should succeed; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // Walk the fake HOME and assert no instruction / config file was
+    // written. The DB directory (~/.local/share/icm/) is opened by
+    // every subcommand and is allowed to exist.
+    let touched = list_user_writes(tmp.path());
+    assert!(
+        touched.is_empty(),
+        "init with no detected tools wrote files: {touched:?}\n\
+        stdout was:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+}
+
+#[test]
+fn init_with_no_tools_does_not_persist_an_empty_manifest() {
+    let (tmp, cwd) = make_home();
+    let _ = icm_in(tmp.path(), &cwd, "/dev/null", &["init", "--mode", "all"]);
+
+    let manifest = tmp.path().join(".local/share/icm/install-manifest.json");
+    assert!(
+        !manifest.exists(),
+        "manifest written even though zero entries were recorded"
+    );
+}
+
+#[test]
+fn init_force_writes_global_paths_and_records_manifest() {
+    let (tmp, cwd) = make_home();
+    let out = icm_in(
+        tmp.path(),
+        &cwd,
+        "/dev/null",
+        &["init", "--mode", "cli", "--force"],
+    );
+    assert_eq!(out.status.code(), Some(0));
+
+    // With --force, global per-tool paths get written even without
+    // detection.
+    let global_claude = tmp.path().join(".claude/CLAUDE.md");
+    let global_codex = tmp.path().join(".codex/AGENTS.md");
+    let global_gemini = tmp.path().join(".gemini/GEMINI.md");
+    assert!(
+        global_claude.exists(),
+        "expected {}",
+        global_claude.display()
+    );
+    assert!(global_codex.exists(), "expected {}", global_codex.display());
+    assert!(
+        global_gemini.exists(),
+        "expected {}",
+        global_gemini.display()
+    );
+
+    // Cwd files must NOT exist (no --per-project flag).
+    let cwd_claude = cwd.join("CLAUDE.md");
+    let cwd_agents = cwd.join("AGENTS.md");
+    let cwd_windsurf = cwd.join(".windsurfrules");
+    assert!(
+        !cwd_claude.exists(),
+        "cwd CLAUDE.md was created without --per-project"
+    );
+    assert!(
+        !cwd_agents.exists(),
+        "cwd AGENTS.md was created without --per-project"
+    );
+    assert!(
+        !cwd_windsurf.exists(),
+        "cwd .windsurfrules was created without --per-project"
+    );
+
+    // Manifest must list each global path.
+    let manifest = tmp.path().join(".local/share/icm/install-manifest.json");
+    assert!(
+        manifest.exists(),
+        "manifest must exist after a successful init"
+    );
+    let raw = std::fs::read_to_string(&manifest).unwrap();
+    assert!(
+        raw.contains("Claude Code"),
+        "manifest missing Claude Code entry: {raw}"
+    );
+    assert!(
+        raw.contains("schema_version"),
+        "manifest missing schema_version"
+    );
+}
+
+#[test]
+fn init_per_project_force_writes_both_global_and_cwd() {
+    let (tmp, cwd) = make_home();
+    let out = icm_in(
+        tmp.path(),
+        &cwd,
+        "/dev/null",
+        &["init", "--mode", "cli", "--per-project", "--force"],
+    );
+    assert_eq!(out.status.code(), Some(0));
+
+    let pairs = [
+        // (global, cwd)
+        (tmp.path().join(".claude/CLAUDE.md"), cwd.join("CLAUDE.md")),
+        (tmp.path().join(".codex/AGENTS.md"), cwd.join("AGENTS.md")),
+    ];
+    for (g, c) in &pairs {
+        assert!(g.exists(), "global path missing: {}", g.display());
+        assert!(c.exists(), "cwd path missing: {}", c.display());
+    }
+
+    // Project-only tools (Copilot/Windsurf/Aider) get their cwd files
+    // when --per-project is on AND detection passes (here via --force).
+    assert!(cwd.join(".github/copilot-instructions.md").exists());
+    assert!(cwd.join(".windsurfrules").exists());
+    assert!(cwd.join(".aider.conventions.md").exists());
+}
+
+#[test]
+fn init_is_idempotent_first_sha_wins_in_manifest() {
+    let (tmp, cwd) = make_home();
+    let manifest = tmp.path().join(".local/share/icm/install-manifest.json");
+
+    // First run: writes from scratch.
+    icm_in(
+        tmp.path(),
+        &cwd,
+        "/dev/null",
+        &["init", "--mode", "cli", "--force"],
+    );
+    let raw1 = std::fs::read_to_string(&manifest).unwrap();
+
+    // Second run: paths already exist with the block. Manifest must
+    // still load + re-save, but the recorded sha256_before should be
+    // the pre-FIRST-run state — which is None (file didn't exist
+    // before the first run).
+    icm_in(
+        tmp.path(),
+        &cwd,
+        "/dev/null",
+        &["init", "--mode", "cli", "--force"],
+    );
+    let raw2 = std::fs::read_to_string(&manifest).unwrap();
+
+    // Both runs should yield a manifest with at least Claude Code.
+    assert!(raw1.contains("Claude Code"));
+    assert!(raw2.contains("Claude Code"));
+
+    // The `sha256_before` for Claude Code must be null in both runs:
+    // run 1 captured pre-init = None, run 2 short-circuited via the
+    // idempotent `record()` so the field was never overwritten.
+    let v1: serde_json::Value = serde_json::from_str(&raw1).unwrap();
+    let v2: serde_json::Value = serde_json::from_str(&raw2).unwrap();
+    let sha1 = v1["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["tool"] == "Claude Code")
+        .unwrap()["sha256_before"]
+        .clone();
+    let sha2 = v2["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["tool"] == "Claude Code")
+        .unwrap()["sha256_before"]
+        .clone();
+    assert_eq!(sha1, sha2, "sha256_before must be stable across init runs");
+    assert!(
+        sha1.is_null(),
+        "first run never had a pre-state — sha must be null"
+    );
+}
+
+#[test]
+fn hook_only_mode_no_longer_crashes_on_fresh_home() {
+    // Regression test for the missing create_dir_all bug.
+    let (tmp, cwd) = make_home();
+    let out = icm_in(
+        tmp.path(),
+        &cwd,
+        "/dev/null",
+        &["init", "--mode", "hook", "--force"],
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        tmp.path().join(".claude/settings.json").exists(),
+        ".claude/settings.json must be created"
+    );
+}
+
+/// Walk `home` and return every regular file path EXCLUDING data dirs
+/// `.local/share/icm/` and `.cache/icm/` (those exist by side effect of
+/// the SQLite store being opened at startup).
+fn list_user_writes(home: &Path) -> Vec<std::path::PathBuf> {
+    fn walk(dir: &Path, acc: &mut Vec<std::path::PathBuf>) {
+        let Ok(rd) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in rd.flatten() {
+            let p = entry.path();
+            let s = p.to_string_lossy();
+            if s.contains("/.local/share/icm") || s.contains("/.cache/icm") {
+                continue;
+            }
+            if let Ok(meta) = std::fs::symlink_metadata(&p) {
+                if meta.is_file() {
+                    acc.push(p);
+                } else if meta.is_dir() {
+                    walk(&p, acc);
+                }
+            }
+        }
+    }
+    let mut acc = Vec::new();
+    walk(home, &mut acc);
+    acc
+}

--- a/crates/icm-cli/tests/init_secure_integration.rs
+++ b/crates/icm-cli/tests/init_secure_integration.rs
@@ -7,6 +7,16 @@
 //! Each test spawns the compiled `icm` binary inside a private
 //! `HOME=<tempdir>` with a stripped `PATH` so no real AI binary is
 //! detected.
+//!
+//! Gated to Linux: these assertions hard-code XDG-style paths
+//! (`.local/share/icm`, `.claude/CLAUDE.md`, etc.). On macOS the
+//! `directories` crate routes data to `Library/Application Support/icm/`
+//! and on Windows to `%APPDATA%\icm\icm\data\`, so the same fake-HOME
+//! scaffolding doesn't line up. The cross-OS logic itself is exercised
+//! by the in-binary unit tests in `crates/icm-cli/src/install_manifest.rs`
+//! which use the real `directories` crate on both sides.
+
+#![cfg(target_os = "linux")]
 
 use std::path::Path;
 use std::process::Command;


### PR DESCRIPTION
## Summary

Tightens `icm init` so it stops polluting the user's machine with
configuration files for AI tools they don't have installed. Companion
PR to #243 (`icm uninstall`).

Three behavioural fixes + new install manifest + breaking change in
default cli targets:

### 1. `detect_tool()` now gates every mode

Previously only `--mode mcp` consulted `detect_tool`. `cli`, `skill`,
and `hook` wrote unconditionally. Result: a single
`icm init --mode standard` on a fresh home dropped ~25+ files into
config dirs for Cline / Roo / Kilo / Amp / Amazon Q / OpenCode /
Copilot CLI / Gemini CLI / Codex CLI / Zed / etc. — even if none of
those tools were installed.

Each tool group is now wrapped in `if force || detect_tool(name) { ... }`
with a clear `[mode] Tool             skipped (not detected)` line. On
an empty PATH (no AI binary present), init writes **zero**
configuration files.

### 2. Install manifest at `<icm-data-dir>/install-manifest.json`

New `crates/icm-cli/src/install_manifest.rs` module persists every
path init touched, with the pre-mutation sha256 and bytes. Schema is
versioned (`schema_version = 1`); loading rejects newer schemas
loudly. Idempotent `record()` keeps the first-ever pre-mutation state
across repeated init runs. Future `icm uninstall` reads the manifest
instead of deriving the location catalog from a hard-coded list.

### 3. Default cli mode writes global, not cwd

`--mode cli` (the default of `--mode standard` too) now writes the
icm:start/icm:end block into the **global** per-tool path:

| Tool        | Old (cwd)                             | New (global)              |
|-------------|---------------------------------------|---------------------------|
| Claude Code | `<cwd>/CLAUDE.md`                     | `~/.claude/CLAUDE.md`     |
| Codex       | `<cwd>/AGENTS.md`                     | `~/.codex/AGENTS.md`      |
| Gemini      | `~/.gemini/GEMINI.md` *(unchanged)*   | `~/.gemini/GEMINI.md`     |

Claude Code and Codex both walk upward from cwd to $HOME looking for
their instruction file, so the global write is read in every project
without polluting any of them.

Tools that only support per-project instruction files (Copilot,
Windsurf, Aider) are **skipped by default**. Pass `--per-project` to
opt in to the legacy behaviour, which also drops cwd duplicates for
Claude/Codex.

### 4. Fix: `--mode hook` standalone no longer crashes

`inject_settings_hook` did not `create_dir_all(parent)` before
writing. `--mode standard` and `--mode all` worked by side effect
(skill/cli created `~/.claude/`), but `--mode hook` on a fresh home
crashed with `No such file or directory`. One-line fix mirroring what
`inject_codex_hook` already did.

## Breaking changes

- A fresh `icm init` no longer touches the current project tree.
  Previously every project where you ever ran init carried the
  icm:start/icm:end block. To restore the legacy behaviour run
  `icm init --per-project`.
- Old project files (left by previous icm init runs) are NOT migrated.
  Clean them up with `icm uninstall --scan-dir <path>` from #243.

## Test plan

- [x] `cargo build -p icm-cli` (no warnings, no clippy issues)
- [x] `cargo test -p icm-cli` — 191 passed, 0 failed (8 manifest unit
      tests + 6 init_secure integration tests + the existing suite)
- [x] Manual smoke: `env -i HOME=$(mktemp -d) PATH=/dev/null icm init --mode all`
      → 25 lines of "skipped (not detected)", zero files written,
      manifest not persisted.
- [x] Manual smoke: `icm init --mode cli --force` → 3 files written
      (global paths only).
- [x] Manual smoke: `icm init --mode cli --per-project --force` →
      8 files written (3 global + 2 cwd duplicates + 3 project-only).
- [x] Manual smoke: `icm init --mode hook --force` standalone on a
      fresh home → all hook configs created.

## Companion to PR #243

#243 ships the uninstall side. Combined, every existing user can now:
1. Run `icm uninstall --scan-dir ~/dev` to clean up old per-project
   pollution from previous init runs.
2. Re-run `icm init` and have it only touch tools they actually have.

Once both land, a follow-up PR can teach uninstall to consume the
manifest directly (today it still uses its static catalog).

Closes the security follow-up promised in #243.