### PR TITLE
ci(release-please): mint GitHub App token so release PR can be created

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -117,8 +117,18 @@ jobs:
       release_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs['crates/icm-cli--tag_name'] }}
     steps:
+      # The default workflow token cannot open PRs in this org; mint a
+      # short-lived token from the configured GitHub App instead.
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
   build-release:
     name: Build and upload release assets


### PR DESCRIPTION
## Problème

La release stable est bloquée à **0.10.49**. Depuis le merge `develop → main` (#241), le workflow `CD` échoue sur le job `release-please` avant de pouvoir ouvrir la PR de release pour 0.10.50 :

- `2026-05-20` : `GitHub Actions is not permitted to create or approve pull requests`
- re-run `2026-05-23` : `Bad credentials`

## Cause racine

Le job `release-please` utilise le `GITHUB_TOKEN` par défaut, que l'org interdit de créer des PRs. Le job `back-merge-develop` contourne déjà ce problème en mintant un token GitHub App (cf. commentaire ligne 168), mais ce même fix avait été **oublié sur le job `release-please`**.

## Fix

Mintage d'un token GitHub App court (`actions/create-github-app-token@v3`) passé à `release-please-action`, en réutilisant les secrets existants `APP_CLIENT_ID` / `APP_PRIVATE_KEY` — exactement le pattern déjà en place pour le back-merge.

Une fois mergé sur `develop` puis `develop → main`, le push sur `main` re-déclenchera `release-please` avec le token App et la PR de release 0.10.50 pourra enfin être créée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)