### PR TITLE
refactor: extract find_similar_memory helper, add dedup check to cmd_store

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -26,9 +26,10 @@ use clap::{Parser, Subcommand, ValueEnum};
 use serde_json::Value;
 
 use icm_core::{
-    build_wake_up, format_local, is_preference_topic, keyword_matches, project_matches,
-    topic_matches, Concept, ConceptLink, Feedback, FeedbackStore, Importance, Label, Memoir,
-    MemoirStore, Memory, MemoryStore, Relation, WakeUpFormat, WakeUpOptions, MSG_NO_MEMORIES,
+    build_wake_up, find_similar_memory, format_local, is_preference_topic, keyword_matches,
+    project_matches, topic_matches, Concept, ConceptLink, Feedback, FeedbackStore, Importance,
+    Label, Memoir, MemoirStore, Memory, MemoryStore, Relation, WakeUpFormat, WakeUpOptions,
+    DEDUP_SIMILARITY_THRESHOLD, MSG_NO_MEMORIES,
 };
 use icm_store::SqliteStore;
 
@@ -1659,6 +1660,46 @@ fn cmd_store(
         match emb.embed(&memory.embed_text()) {
             Ok(vec) => memory.embedding = Some(vec),
             Err(e) => eprintln!("warning: embedding failed: {e}"),
+        }
+    }
+
+    // Dedup: if a very similar memory already exists in the same topic, update it instead
+    if let Some(ref emb) = memory.embedding {
+        if let Ok(Some((existing, score))) = find_similar_memory(
+            store,
+            &memory.embed_text(),
+            emb,
+            &topic,
+            DEDUP_SIMILARITY_THRESHOLD,
+        ) {
+            let updated = Memory {
+                id: existing.id.clone(),
+                created_at: existing.created_at,
+                updated_at: chrono::Utc::now(),
+                last_accessed: existing.last_accessed,
+                access_count: existing.access_count,
+                weight: 1.0,
+                topic: existing.topic.clone(),
+                summary: memory.summary.clone(),
+                raw_excerpt: memory.raw_excerpt.clone().or(existing.raw_excerpt),
+                keywords: if memory.keywords.is_empty() {
+                    existing.keywords
+                } else {
+                    memory.keywords.clone()
+                },
+                embedding: memory.embedding.clone(),
+                importance,
+                source: existing.source,
+                related_ids: existing.related_ids,
+                scope: existing.scope,
+            };
+            store.update(&updated)?;
+            println!(
+                "Updated existing memory (similarity {score:.2}): {}",
+                updated.id
+            );
+            maybe_auto_consolidate(store, embedder, &topic, memory_cfg);
+            return Ok(());
         }
     }
 

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -29,7 +29,7 @@ pub use memoir_store::MemoirStore;
 pub use memory::{
     Importance, Memory, MemorySource, PatternCluster, Scope, StoreStats, TopicHealth,
 };
-pub use store::MemoryStore;
+pub use store::{find_similar_memory, MemoryStore, DEDUP_SIMILARITY_THRESHOLD};
 pub use transcript::{Message, Role, Session, TranscriptHit, TranscriptStats};
 pub use transcript_store::TranscriptStore;
 pub use wake_up::{

--- a/crates/icm-core/src/store.rs
+++ b/crates/icm-core/src/store.rs
@@ -1,6 +1,26 @@
 use crate::error::IcmResult;
 use crate::memory::{Memory, StoreStats, TopicHealth};
 
+/// Similarity score above which a new memory is considered a duplicate of an existing one.
+pub const DEDUP_SIMILARITY_THRESHOLD: f32 = 0.85;
+
+/// Find an existing memory that is similar enough to be considered a duplicate.
+///
+/// Returns the closest match and its similarity score if the score exceeds `threshold`
+/// and the match belongs to the same topic. Returns `None` otherwise.
+pub fn find_similar_memory(
+    store: &dyn MemoryStore,
+    embed_text: &str,
+    embedding: &[f32],
+    topic: &str,
+    threshold: f32,
+) -> IcmResult<Option<(Memory, f32)>> {
+    let similar = store.search_hybrid(embed_text, embedding, 1)?;
+    Ok(similar
+        .into_iter()
+        .find(|(m, score)| *score > threshold && m.topic == topic))
+}
+
 pub trait MemoryStore {
     // CRUD
     fn store(&self, memory: Memory) -> IcmResult<String>;

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -2,10 +2,11 @@ use chrono::Utc;
 use serde_json::{json, Value};
 
 use icm_core::{
-    add_backrefs, auto_link_memory, build_wake_up, format_local, is_preference_topic,
-    keyword_matches, project_matches, topic_matches, AutoLinkOptions, Concept, ConceptLink,
-    Embedder, Feedback, FeedbackStore, Label, Memoir, MemoirStore, Memory, MemoryStore, Relation,
-    WakeUpFormat, WakeUpOptions, MSG_NO_MEMORIES,
+    add_backrefs, auto_link_memory, build_wake_up, find_similar_memory, format_local,
+    is_preference_topic, keyword_matches, project_matches, topic_matches, AutoLinkOptions, Concept,
+    ConceptLink, Embedder, Feedback, FeedbackStore, Label, Memoir, MemoirStore, Memory,
+    MemoryStore, Relation, WakeUpFormat, WakeUpOptions, DEDUP_SIMILARITY_THRESHOLD,
+    MSG_NO_MEMORIES,
 };
 use icm_store::SqliteStore;
 
@@ -13,9 +14,6 @@ use crate::protocol::ToolResult;
 
 /// Default threshold for auto-consolidation (can be overridden by config).
 const AUTO_CONSOLIDATE_THRESHOLD: usize = 10;
-
-/// Similarity score above which a new memory is considered a duplicate of an existing one.
-const DEDUP_SIMILARITY_THRESHOLD: f32 = 0.85;
 
 /// Maximum allowed length for topic names. Must stay <= the store
 /// layer's `MAX_TOPIC_BYTES` so the MCP-level rejection happens
@@ -998,49 +996,50 @@ fn tool_store(
 
     // Dedup check: if a very similar memory exists in the same topic, update it instead
     if let Some(ref query_emb) = embed_vec {
-        if let Ok(similar) = store.search_hybrid(&embed_text, query_emb, 1) {
-            if let Some((existing, score)) = similar.first() {
-                if *score > DEDUP_SIMILARITY_THRESHOLD && existing.topic == topic {
-                    // Very similar content in same topic — update instead of duplicate
-                    let updated = Memory {
-                        id: existing.id.clone(),
-                        created_at: existing.created_at,
-                        last_accessed: existing.last_accessed,
-                        access_count: existing.access_count,
-                        weight: 1.0, // Reset weight on update
-                        topic: existing.topic.clone(),
-                        summary: content.to_string(),
-                        raw_excerpt: get_str(args, "raw_excerpt")
-                            .map(|r| r.into())
-                            .or_else(|| existing.raw_excerpt.clone()),
-                        keywords: {
-                            let kw = parse_keywords(args);
-                            if kw.is_empty() {
-                                existing.keywords.clone()
-                            } else {
-                                kw
-                            }
-                        },
-                        embedding: Some(query_emb.clone()),
-                        importance,
-                        source: existing.source.clone(),
-                        related_ids: existing.related_ids.clone(),
-                        updated_at: Utc::now(),
-                        scope: existing.scope,
-                    };
-                    if let Err(e) = store.update(&updated) {
-                        return ToolResult::error(format!("failed to update: {e}"));
-                    }
-                    return if compact {
-                        ToolResult::text(format!("ok:{}", updated.id))
+        if let Ok(Some((existing, score))) = find_similar_memory(
+            store,
+            &embed_text,
+            query_emb,
+            topic,
+            DEDUP_SIMILARITY_THRESHOLD,
+        ) {
+            let updated = Memory {
+                id: existing.id.clone(),
+                created_at: existing.created_at,
+                last_accessed: existing.last_accessed,
+                access_count: existing.access_count,
+                weight: 1.0,
+                topic: existing.topic.clone(),
+                summary: content.to_string(),
+                raw_excerpt: get_str(args, "raw_excerpt")
+                    .map(|r| r.into())
+                    .or_else(|| existing.raw_excerpt.clone()),
+                keywords: {
+                    let kw = parse_keywords(args);
+                    if kw.is_empty() {
+                        existing.keywords.clone()
                     } else {
-                        ToolResult::text(format!(
-                            "Updated existing memory (similarity {score:.2}): {}",
-                            updated.id
-                        ))
-                    };
-                }
+                        kw
+                    }
+                },
+                embedding: Some(query_emb.clone()),
+                importance,
+                source: existing.source.clone(),
+                related_ids: existing.related_ids.clone(),
+                updated_at: Utc::now(),
+                scope: existing.scope,
+            };
+            if let Err(e) = store.update(&updated) {
+                return ToolResult::error(format!("failed to update: {e}"));
             }
+            return if compact {
+                ToolResult::text(format!("ok:{}", updated.id))
+            } else {
+                ToolResult::text(format!(
+                    "Updated existing memory (similarity {score:.2}): {}",
+                    updated.id
+                ))
+            };
         }
     }
 


### PR DESCRIPTION
Move the dedup check out of the MCP path and into shared helper so the CLI can leverage it too.