### PR TITLE
fix(init): /recall skill uses icm wake-up when called with no args

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -3735,7 +3735,11 @@ Search ICM memory for: $ARGUMENTS
 
 Run:
 ```bash
-icm recall \"$ARGUMENTS\"
+if [ -z \"$ARGUMENTS\" ]; then
+  icm wake-up --max-tokens 800
+else
+  icm recall \"$ARGUMENTS\" --limit 10
+fi
 ```
 ";
         let icm_remember_prompt = "\


### PR DESCRIPTION
Have a plain `/recall` run `wake-up` instead (I use this at the start of a session), which is much more useful than random memories.