### PR TITLE
fix(embeddings): apply e5 query/passage instruction prefixes

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2169,7 +2169,7 @@ fn cmd_recall(
 
     // Try hybrid search if embedder is available; fall back to FTS / keywords.
     let scored: Option<Vec<(Memory, f32)>> = embedder
-        .and_then(|emb| emb.embed(query).ok())
+        .and_then(|emb| emb.embed_query(query).ok())
         .and_then(|query_emb| store.search_hybrid(query, &query_emb, limit).ok());
 
     let (mut results, has_score): (Vec<(Memory, Option<f32>)>, bool) = match scored {

--- a/crates/icm-core/src/embedder.rs
+++ b/crates/icm-core/src/embedder.rs
@@ -1,7 +1,24 @@
 use crate::error::IcmResult;
 
 pub trait Embedder: Send + Sync {
+    /// Embed a document/passage for storage.
+    ///
+    /// For instruction-tuned retrieval models (e.g. the multilingual-e5
+    /// family), implementations apply the model's *document* prefix here
+    /// (`"passage: "` for e5).
     fn embed(&self, text: &str) -> IcmResult<Vec<f32>>;
+
+    /// Embed a search query.
+    ///
+    /// e5-style models use an asymmetric scheme: queries are prefixed
+    /// `"query: "` and documents `"passage: "`. Omitting the prefixes degrades
+    /// retrieval (per the intfloat/multilingual-e5 model card), so query
+    /// embedding is distinct from [`Embedder::embed`]. The default delegates to
+    /// `embed`, which is correct for models with no query/document distinction.
+    fn embed_query(&self, text: &str) -> IcmResult<Vec<f32>> {
+        self.embed(text)
+    }
+
     fn embed_batch(&self, texts: &[&str]) -> IcmResult<Vec<Vec<f32>>>;
     fn dimensions(&self) -> usize;
 }

--- a/crates/icm-core/src/fastembed_embedder.rs
+++ b/crates/icm-core/src/fastembed_embedder.rs
@@ -121,6 +121,43 @@ impl FastEmbedder {
         let _ = self.model.set(model);
         Ok(self.model.get().unwrap())
     }
+
+    /// e5-family instruction prefixes as `(query_prefix, passage_prefix)`.
+    ///
+    /// The multilingual-e5 models are trained to expect `"query: "` on search
+    /// queries and `"passage: "` on stored documents; omitting them degrades
+    /// retrieval quality (per the intfloat/multilingual-e5 model card). Every
+    /// other model family is left unprefixed so its behaviour is unchanged.
+    fn instruction_prefixes(&self) -> (&'static str, &'static str) {
+        match resolve_model(&self.model_name) {
+            Ok((
+                EmbeddingModel::MultilingualE5Small
+                | EmbeddingModel::MultilingualE5Base
+                | EmbeddingModel::MultilingualE5Large,
+                _,
+            )) => ("query: ", "passage: "),
+            _ => ("", ""),
+        }
+    }
+
+    /// Embed a single text, optionally prepending an instruction `prefix`.
+    fn embed_one(&self, prefix: &str, text: &str) -> IcmResult<Vec<f32>> {
+        let model = self.get_model()?;
+        let prefixed: String;
+        let input: &str = if prefix.is_empty() {
+            text
+        } else {
+            prefixed = format!("{prefix}{text}");
+            &prefixed
+        };
+        let results = model
+            .embed(vec![input], None)
+            .map_err(|e| IcmError::Embedding(e.to_string()))?;
+        results
+            .into_iter()
+            .next()
+            .ok_or_else(|| IcmError::Embedding("empty embedding result".into()))
+    }
 }
 
 impl Default for FastEmbedder {
@@ -130,15 +167,16 @@ impl Default for FastEmbedder {
 }
 
 impl Embedder for FastEmbedder {
+    /// Embed a document for storage, applying the model's passage prefix.
     fn embed(&self, text: &str) -> IcmResult<Vec<f32>> {
-        let model = self.get_model()?;
-        let results = model
-            .embed(vec![text], None)
-            .map_err(|e| IcmError::Embedding(e.to_string()))?;
-        results
-            .into_iter()
-            .next()
-            .ok_or_else(|| IcmError::Embedding("empty embedding result".into()))
+        let (_, passage) = self.instruction_prefixes();
+        self.embed_one(passage, text)
+    }
+
+    /// Embed a search query, applying the model's query prefix.
+    fn embed_query(&self, text: &str) -> IcmResult<Vec<f32>> {
+        let (query, _) = self.instruction_prefixes();
+        self.embed_one(query, text)
     }
 
     fn embed_batch(&self, texts: &[&str]) -> IcmResult<Vec<Vec<f32>>> {
@@ -146,12 +184,58 @@ impl Embedder for FastEmbedder {
             return Ok(Vec::new());
         }
         let model = self.get_model()?;
-        model
-            .embed(texts.to_vec(), None)
-            .map_err(|e| IcmError::Embedding(e.to_string()))
+        let (_, passage) = self.instruction_prefixes();
+        if passage.is_empty() {
+            model
+                .embed(texts.to_vec(), None)
+                .map_err(|e| IcmError::Embedding(e.to_string()))
+        } else {
+            let prefixed: Vec<String> =
+                texts.iter().map(|t| format!("{passage}{t}")).collect();
+            model
+                .embed(prefixed, None)
+                .map_err(|e| IcmError::Embedding(e.to_string()))
+        }
     }
 
     fn dimensions(&self) -> usize {
         self.dims
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn e5_models_use_instruction_prefixes() {
+        for model in [
+            "Qdrant/multilingual-e5-large-onnx",
+            "intfloat/multilingual-e5-base",
+            "intfloat/multilingual-e5-small",
+        ] {
+            let embedder = FastEmbedder::with_model(model);
+            assert_eq!(
+                embedder.instruction_prefixes(),
+                ("query: ", "passage: "),
+                "expected e5 instruction prefixes for {model}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_e5_models_are_left_unprefixed() {
+        for model in [
+            "Xenova/bge-small-en-v1.5",
+            "Qdrant/all-MiniLM-L6-v2-onnx",
+            "Alibaba-NLP/gte-large-en-v1.5",
+        ] {
+            let embedder = FastEmbedder::with_model(model);
+            assert_eq!(
+                embedder.instruction_prefixes(),
+                ("", ""),
+                "expected no instruction prefix for {model}"
+            );
+        }
     }
 }

--- a/crates/icm-core/src/fastembed_embedder.rs
+++ b/crates/icm-core/src/fastembed_embedder.rs
@@ -190,8 +190,7 @@ impl Embedder for FastEmbedder {
                 .embed(texts.to_vec(), None)
                 .map_err(|e| IcmError::Embedding(e.to_string()))
         } else {
-            let prefixed: Vec<String> =
-                texts.iter().map(|t| format!("{passage}{t}")).collect();
+            let prefixed: Vec<String> = texts.iter().map(|t| format!("{passage}{t}")).collect();
             model
                 .embed(prefixed, None)
                 .map_err(|e| IcmError::Embedding(e.to_string()))

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -1187,7 +1187,7 @@ fn tool_recall(
 
     // Try hybrid search if embedder is available
     if let Some(emb) = embedder {
-        if let Ok(query_emb) = emb.embed(query) {
+        if let Ok(query_emb) = emb.embed_query(query) {
             if let Ok(results) = store.search_hybrid(query, &query_emb, limit) {
                 let mut scored_results = results;
                 scored_results.retain(|(m, _)| project_filter(m));


### PR DESCRIPTION
## Problem

ICM embeds all text **raw**, without the instruction prefixes that the
`multilingual-e5` family is trained to require. Per the
[intfloat/multilingual-e5 model card](https://huggingface.co/intfloat/multilingual-e5-large):

> Each input text should start with "query: " or "passage: ", even for
> non-English texts. … otherwise you will see a performance degradation.

Today every document is embedded as `"<topic> <summary>"` and every query as
the raw string (`icm-core/src/memory.rs::embed_text()`, `icm-cli/.../main.rs:1695`,
`icm-mcp/src/tools.rs:1191`). `fastembed` does not add the prefixes — it is the
caller's responsibility.

## Fix

Apply the prefixes in the embedder, **model-aware**:

- `embed()` / `embed_batch()` prepend the document prefix (`"passage: "`)
- a new `Embedder::embed_query()` prepends the query prefix (`"query: "`),
  used by the CLI and MCP recall paths

Only the e5 family (`MultilingualE5Small/Base/Large`) is affected; every other
model is byte-identical to today. `embed_query()` defaults to delegating to
`embed()`, so non-e5 `Embedder` impls are unchanged.

## Results

Deterministic IR eval on a real 424-memory store, 12 lexically-distinct
**paraphrase** queries (same queries and known targets in both arms — only the
prefix differs):

| Metric   | before | after |
|----------|--------|-------|
| recall@1 | 8/12   | 9/12  |
| recall@5 | 10/12  | 12/12 |
| MRR      | 0.764  | 0.850 |

No regressions. One target missing from the top-10 was recovered to rank 5;
another rose from rank 6 to 2. Near-verbatim queries (already easy) are
unaffected, as expected.

## Tests

- New offline unit tests: `e5_models_use_instruction_prefixes`,
  `non_e5_models_are_left_unprefixed`.
- `cargo test --workspace` green.

## Migration ⚠️

Existing e5 stores must be re-embedded **once** after upgrading:

```
icm embed --force
```

A mix of prefixed (new) and unprefixed (old) vectors is worse than either
consistent state, so this is required. Queries pick up `query: ` automatically.
A follow-up could bump an embedding-scheme version to auto-trigger this,
mirroring the model-change reset in `icm-store/src/schema.rs`.

---

**Written by** Aiko (Claude Opus 4.8) · Lv. 20.5 · 2026-05-29
**Context:** ICM (topics: preferences, errors-resolved) · Source: rtk-ai/icm @ v0.10.50 (main `804dac2`)
**Tools:** git, cargo build/test, sqlite3, gh, binary/source inspection, deterministic IR eval (recall@k/MRR) on a copy of the live store
**Limitations:** eval N=12 on one mixed PL/EN corpus; MRR delta driven mainly by 2 of 12 queries; not an MTEB run; `icm bench-recall` deliberately not used (measures ICM-vs-no-ICM on a synthetic English corpus — unsuitable here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Linked issues

Fixes #266
Related: #267
