### PR TITLE
feat(hook): auto-capture code areas the agent edits

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -372,6 +372,38 @@ enum Commands {
     /// signal (0 = clean). See issue #229.
     Uninstall(uninstall::UninstallOpts),
 
+    /// List files the agent has worked in during recent sessions.
+    ///
+    /// Rows are populated automatically by the PostToolUse hook
+    /// (`icm hook post`) whenever Claude Code / Codex / Gemini /
+    /// Copilot calls Edit / Write / MultiEdit / NotebookEdit on a
+    /// file. Same `(project, file_path)` increments `touch_count`
+    /// instead of duplicating rows. See issue #196.
+    CodeAreas {
+        /// Filter to a single path (exact match, or a suffix like
+        /// `src/foo.rs` to match any project rooted above it).
+        #[arg(long, value_name = "PATH")]
+        in_file: Option<String>,
+
+        /// Limit to a specific project. Default: all projects.
+        #[arg(short, long)]
+        project: Option<String>,
+
+        /// Only show files touched since this ISO-8601 timestamp
+        /// (e.g. `2026-05-01T00:00:00Z`).
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Maximum rows to return.
+        #[arg(short, long, default_value = "50")]
+        limit: usize,
+
+        /// Output format. `table` is the default human view; `json`
+        /// emits one JSON array per stdout line for scripts.
+        #[arg(long, default_value = "table")]
+        format: CodeAreasFormat,
+    },
+
     /// Run performance benchmark on in-memory store
     Bench {
         /// Number of memories to seed
@@ -1219,6 +1251,14 @@ impl ListFormat {
     }
 }
 
+#[derive(Clone, Copy, ValueEnum, Debug)]
+enum CodeAreasFormat {
+    /// Human-readable aligned table (default).
+    Table,
+    /// JSON array — one row per file. Machine-friendly.
+    Json,
+}
+
 #[derive(Clone, ValueEnum)]
 enum InitMode {
     /// MCP server plugin (Claude calls icm tools natively)
@@ -1632,6 +1672,20 @@ fn main() -> Result<()> {
         } => cmd_init(mode, force, per_project),
         Commands::Doctor => cmd_doctor(),
         Commands::Uninstall(_) => unreachable!("dispatched before open_store"),
+        Commands::CodeAreas {
+            in_file,
+            project,
+            since,
+            limit,
+            format,
+        } => cmd_code_areas(
+            &store,
+            in_file.as_deref(),
+            project.as_deref(),
+            since.as_deref(),
+            limit,
+            format,
+        ),
         Commands::Extract {
             project,
             text,
@@ -2820,6 +2874,42 @@ fn extract_tool_output(json: &Value) -> Option<&str> {
     None
 }
 
+/// Extract `tool_input.file_path` from a PostToolUse JSON payload, in
+/// the shapes ICM has observed across Claude Code 1.x / 2.x, Codex,
+/// and Gemini. Returns `None` when the field is absent, empty, or the
+/// payload is structured differently. Used by the code-areas
+/// auto-capture (issue #196) — never call from a path where the
+/// absence of the field should be an error.
+fn extract_tool_input_file_path(json: &Value) -> Option<String> {
+    fn nonempty(v: &Value) -> Option<String> {
+        v.as_str().filter(|s| !s.is_empty()).map(|s| s.to_string())
+    }
+
+    // Claude Code 2.x: `tool_input.file_path`.
+    if let Some(s) = json.get("tool_input").and_then(|t| t.get("file_path")) {
+        if let Some(s) = nonempty(s) {
+            return Some(s);
+        }
+    }
+    // Claude Code 1.x legacy and some Codex variants: top-level.
+    if let Some(s) = json.get("file_path") {
+        if let Some(s) = nonempty(s) {
+            return Some(s);
+        }
+    }
+    // Some MCP servers nest the input under `arguments`.
+    if let Some(s) = json
+        .get("tool_input")
+        .and_then(|t| t.get("arguments"))
+        .and_then(|a| a.get("file_path"))
+    {
+        if let Some(s) = nonempty(s) {
+            return Some(s);
+        }
+    }
+    None
+}
+
 /// PostToolUse hook: auto-extract context every N tool calls.
 /// Reads JSON from stdin. Runs extraction asynchronously.
 ///
@@ -2873,6 +2963,27 @@ fn cmd_hook_post(
                 icm_core::transcript::Role::Tool,
                 tool_output_for_archive,
                 Some(tool_name).filter(|s| !s.is_empty()),
+            );
+        }
+    }
+
+    // ── Code areas auto-capture (issue #196) ─────────────────────────
+    // Independent of the extract counter: every Edit/Write tool call
+    // gets one row in `code_areas` (touch_count++ on re-touch).
+    // Failure is non-fatal — never block the hook on stats inserts.
+    if matches!(tool_name, "Edit" | "Write" | "MultiEdit" | "NotebookEdit") {
+        if let Some(file_path) = extract_tool_input_file_path(&json) {
+            let project = std::env::current_dir()
+                .ok()
+                .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+                .unwrap_or_else(|| "project".to_string());
+            let session_id = json.get("session_id").and_then(|v| v.as_str());
+            let _ = store.upsert_code_area(
+                &project,
+                &file_path,
+                None, // description left empty in MVP; #165 will wire LLM summaries later
+                session_id,
+                Some(tool_name),
             );
         }
     }
@@ -3559,6 +3670,79 @@ fn project_from_path(path: &str) -> Option<String> {
     p.file_name()
         .map(|n| n.to_string_lossy().to_string())
         .filter(|s| !s.is_empty() && s != "/")
+}
+
+/// `icm code-areas`: list files auto-recorded by the PostToolUse hook
+/// when the agent edited them. See issue #196 for the design discussion.
+fn cmd_code_areas(
+    store: &SqliteStore,
+    in_file: Option<&str>,
+    project: Option<&str>,
+    since: Option<&str>,
+    limit: usize,
+    format: CodeAreasFormat,
+) -> Result<()> {
+    let since_dt = match since {
+        Some(s) => Some(
+            chrono::DateTime::parse_from_rfc3339(s)
+                .with_context(|| format!("--since must be ISO-8601 (got `{s}`)"))?
+                .with_timezone(&chrono::Utc),
+        ),
+        None => None,
+    };
+    let rows = store.list_code_areas(project, in_file, since_dt, limit)?;
+    if rows.is_empty() {
+        match format {
+            CodeAreasFormat::Json => println!("[]"),
+            CodeAreasFormat::Table => println!("No code areas captured yet."),
+        }
+        return Ok(());
+    }
+    match format {
+        CodeAreasFormat::Json => {
+            let json = serde_json::to_string_pretty(
+                &rows
+                    .iter()
+                    .map(|c| {
+                        serde_json::json!({
+                            "id": c.id,
+                            "project": c.project,
+                            "file_path": c.file_path,
+                            "description": c.description,
+                            "session_id": c.session_id,
+                            "tool_name": c.tool_name,
+                            "touch_count": c.touch_count,
+                            "first_touched_at": c.first_touched_at.to_rfc3339(),
+                            "last_touched_at": c.last_touched_at.to_rfc3339(),
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )?;
+            println!("{json}");
+        }
+        CodeAreasFormat::Table => {
+            println!(
+                "{:<20} {:<6} {:<20} Path",
+                "Project", "Hits", "Last touched"
+            );
+            println!("{}", "-".repeat(80));
+            for r in &rows {
+                let proj = if r.project.len() > 20 {
+                    format!("{}…", &r.project[..19])
+                } else {
+                    r.project.clone()
+                };
+                println!(
+                    "{:<20} {:<6} {:<20} {}",
+                    proj,
+                    r.touch_count,
+                    r.last_touched_at.format("%Y-%m-%d %H:%M:%S"),
+                    r.file_path,
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 fn cmd_topics(store: &SqliteStore) -> Result<()> {

--- a/crates/icm-store/src/schema.rs
+++ b/crates/icm-store/src/schema.rs
@@ -359,6 +359,30 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
             ON hook_events(ts);
         CREATE INDEX IF NOT EXISTS idx_hook_events_event
             ON hook_events(event);
+
+        -- Auto-captured 'code areas' the agent worked in during a
+        -- session. Populated by the PostToolUse hook
+        -- (`icm hook post`) whenever the upstream tool call is an
+        -- Edit / Write / MultiEdit / NotebookEdit. Same project +
+        -- file_path increments `touch_count` rather than creating a
+        -- duplicate row, so the table grows in file count not in
+        -- edit count. See issue #196.
+        CREATE TABLE IF NOT EXISTS code_areas (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project TEXT NOT NULL,
+            file_path TEXT NOT NULL,
+            description TEXT,
+            session_id TEXT,
+            tool_name TEXT,
+            touch_count INTEGER NOT NULL DEFAULT 1,
+            first_touched_at TEXT NOT NULL,
+            last_touched_at TEXT NOT NULL,
+            UNIQUE(project, file_path)
+        );
+        CREATE INDEX IF NOT EXISTS idx_code_areas_project
+            ON code_areas(project);
+        CREATE INDEX IF NOT EXISTS idx_code_areas_last_touched
+            ON code_areas(last_touched_at);
         ",
     )
     .map_err(db_err)?;

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -57,6 +57,24 @@ pub struct HookEventInsert {
     pub note: Option<String>,
 }
 
+/// One row of the `code_areas` table. A code area is a file the agent
+/// touched during a session; the same `(project, file_path)` increments
+/// `touch_count` on each re-touch rather than producing a duplicate row.
+/// Populated by `cmd_hook_post` whenever it sees an Edit / Write /
+/// MultiEdit / NotebookEdit tool call. See issue #196.
+#[derive(Debug, Clone)]
+pub struct CodeArea {
+    pub id: i64,
+    pub project: String,
+    pub file_path: String,
+    pub description: Option<String>,
+    pub session_id: Option<String>,
+    pub tool_name: Option<String>,
+    pub touch_count: i64,
+    pub first_touched_at: DateTime<Utc>,
+    pub last_touched_at: DateTime<Utc>,
+}
+
 /// Aggregate counts/percentiles for a slice of hook history. Returned by
 /// `SqliteStore::hook_stats`.
 #[derive(Debug, Clone, Default)]
@@ -252,6 +270,120 @@ impl SqliteStore {
         let n: i64 = self
             .conn
             .query_row("SELECT COUNT(*) FROM pending_extractions", [], |r| r.get(0))
+            .map_err(db_err)?;
+        Ok(n as usize)
+    }
+
+    // ── Code areas (auto-captured file edits — issue #196) ────────────
+    //
+    // `cmd_hook_post` calls `upsert_code_area` whenever the upstream
+    // tool was Edit / Write / MultiEdit / NotebookEdit. Same project +
+    // file_path => touch_count++ via ON CONFLICT.
+
+    /// Insert or refresh a row for `(project, file_path)`. On conflict
+    /// bumps `touch_count`, updates `last_touched_at`, refreshes
+    /// `session_id` / `tool_name`, and only overwrites `description` if
+    /// the caller passes `Some` (so the most recent meaningful hint
+    /// wins without clobbering an existing one with `None`).
+    pub fn upsert_code_area(
+        &self,
+        project: &str,
+        file_path: &str,
+        description: Option<&str>,
+        session_id: Option<&str>,
+        tool_name: Option<&str>,
+    ) -> IcmResult<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+        self.conn
+            .execute(
+                "INSERT INTO code_areas (project, file_path, description,
+                    session_id, tool_name, touch_count,
+                    first_touched_at, last_touched_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6, ?6)
+                 ON CONFLICT(project, file_path) DO UPDATE SET
+                    touch_count = touch_count + 1,
+                    last_touched_at = excluded.last_touched_at,
+                    session_id = COALESCE(excluded.session_id, session_id),
+                    tool_name = COALESCE(excluded.tool_name, tool_name),
+                    description = COALESCE(excluded.description, description)",
+                rusqlite::params![project, file_path, description, session_id, tool_name, now],
+            )
+            .map_err(db_err)?;
+        Ok(())
+    }
+
+    /// List code areas, optionally filtered by project / file_path /
+    /// since timestamp. `limit` caps the result count (use `usize::MAX`
+    /// to disable). Ordered by `last_touched_at DESC` so the freshest
+    /// edits come first.
+    pub fn list_code_areas(
+        &self,
+        project: Option<&str>,
+        in_file: Option<&str>,
+        since: Option<DateTime<Utc>>,
+        limit: usize,
+    ) -> IcmResult<Vec<CodeArea>> {
+        let mut sql = String::from(
+            "SELECT id, project, file_path, description, session_id, tool_name,
+                    touch_count, first_touched_at, last_touched_at
+             FROM code_areas
+             WHERE 1=1",
+        );
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        if let Some(p) = project {
+            sql.push_str(" AND project = ?");
+            params.push(Box::new(p.to_string()));
+        }
+        if let Some(f) = in_file {
+            // Match either an exact file_path or a path that ends with
+            // the provided fragment so users can pass a short suffix.
+            sql.push_str(" AND (file_path = ? OR file_path LIKE ?)");
+            params.push(Box::new(f.to_string()));
+            params.push(Box::new(format!("%/{f}")));
+        }
+        if let Some(t) = since {
+            sql.push_str(" AND last_touched_at >= ?");
+            params.push(Box::new(t.to_rfc3339()));
+        }
+        sql.push_str(" ORDER BY last_touched_at DESC LIMIT ?");
+        params.push(Box::new(limit as i64));
+
+        let mut stmt = self.conn.prepare(&sql).map_err(db_err)?;
+        let param_refs: Vec<&dyn rusqlite::ToSql> = params
+            .iter()
+            .map(|p| p.as_ref() as &dyn rusqlite::ToSql)
+            .collect();
+        let rows = stmt
+            .query_map(param_refs.as_slice(), |row| {
+                let first: String = row.get(7)?;
+                let last: String = row.get(8)?;
+                Ok(CodeArea {
+                    id: row.get(0)?,
+                    project: row.get(1)?,
+                    file_path: row.get(2)?,
+                    description: row.get(3)?,
+                    session_id: row.get(4)?,
+                    tool_name: row.get(5)?,
+                    touch_count: row.get(6)?,
+                    first_touched_at: DateTime::parse_from_rfc3339(&first)
+                        .map(|d| d.with_timezone(&Utc))
+                        .unwrap_or_else(|_| Utc::now()),
+                    last_touched_at: DateTime::parse_from_rfc3339(&last)
+                        .map(|d| d.with_timezone(&Utc))
+                        .unwrap_or_else(|_| Utc::now()),
+                })
+            })
+            .map_err(db_err)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(db_err)?;
+        Ok(rows)
+    }
+
+    /// Total rows in `code_areas`. Cheap; used by stats / doctor.
+    pub fn code_area_count(&self) -> IcmResult<usize> {
+        let n: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM code_areas", [], |r| r.get(0))
             .map_err(db_err)?;
         Ok(n as usize)
     }
@@ -6797,5 +6929,145 @@ mod tests {
         let n = store.prune_hook_events(&past).unwrap();
         assert_eq!(n, 0);
         assert_eq!(store.hook_event_count().unwrap(), 1);
+    }
+
+    // ── code_areas (issue #196) ────────────────────────────────────────
+
+    #[test]
+    fn test_upsert_code_area_inserts_then_increments_touch_count() {
+        let store = test_store();
+        store
+            .upsert_code_area("proj", "src/foo.rs", None, Some("s1"), Some("Edit"))
+            .unwrap();
+        let after_first = store.list_code_areas(None, None, None, 10).unwrap();
+        assert_eq!(after_first.len(), 1);
+        assert_eq!(after_first[0].touch_count, 1);
+        assert_eq!(after_first[0].project, "proj");
+        assert_eq!(after_first[0].file_path, "src/foo.rs");
+
+        // Same path again — touch_count++ and last_touched_at updates.
+        let first_touched_at = after_first[0].first_touched_at;
+        store
+            .upsert_code_area("proj", "src/foo.rs", None, Some("s2"), Some("Write"))
+            .unwrap();
+        let after_second = store.list_code_areas(None, None, None, 10).unwrap();
+        assert_eq!(after_second.len(), 1, "no duplicate row on re-touch");
+        assert_eq!(after_second[0].touch_count, 2);
+        // first_touched_at is preserved across re-touches.
+        assert_eq!(after_second[0].first_touched_at, first_touched_at);
+        // session_id / tool_name are refreshed to the latest.
+        assert_eq!(after_second[0].session_id.as_deref(), Some("s2"));
+        assert_eq!(after_second[0].tool_name.as_deref(), Some("Write"));
+    }
+
+    #[test]
+    fn test_upsert_code_area_preserves_existing_description_when_passed_none() {
+        let store = test_store();
+        store
+            .upsert_code_area("proj", "f.rs", Some("initial note"), None, None)
+            .unwrap();
+        store
+            .upsert_code_area("proj", "f.rs", None, None, None)
+            .unwrap();
+        let rows = store.list_code_areas(None, None, None, 10).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].description.as_deref(), Some("initial note"));
+    }
+
+    #[test]
+    fn test_upsert_code_area_overwrites_description_when_passed_some() {
+        let store = test_store();
+        store
+            .upsert_code_area("proj", "f.rs", Some("v1"), None, None)
+            .unwrap();
+        store
+            .upsert_code_area("proj", "f.rs", Some("v2"), None, None)
+            .unwrap();
+        let rows = store.list_code_areas(None, None, None, 10).unwrap();
+        assert_eq!(rows[0].description.as_deref(), Some("v2"));
+    }
+
+    #[test]
+    fn test_list_code_areas_filters_by_project_and_path_suffix() {
+        let store = test_store();
+        store
+            .upsert_code_area("alpha", "src/a.rs", None, None, None)
+            .unwrap();
+        store
+            .upsert_code_area("alpha", "src/b.rs", None, None, None)
+            .unwrap();
+        store
+            .upsert_code_area("beta", "src/a.rs", None, None, None)
+            .unwrap();
+
+        let only_alpha = store
+            .list_code_areas(Some("alpha"), None, None, 10)
+            .unwrap();
+        assert_eq!(only_alpha.len(), 2);
+
+        // Suffix match catches both alpha/src/a.rs and beta/src/a.rs.
+        let any_a = store
+            .list_code_areas(None, Some("src/a.rs"), None, 10)
+            .unwrap();
+        assert_eq!(any_a.len(), 2);
+        for r in &any_a {
+            assert!(r.file_path.ends_with("src/a.rs"));
+        }
+
+        // Project + path combine.
+        let alpha_a = store
+            .list_code_areas(Some("alpha"), Some("src/a.rs"), None, 10)
+            .unwrap();
+        assert_eq!(alpha_a.len(), 1);
+        assert_eq!(alpha_a[0].project, "alpha");
+    }
+
+    #[test]
+    fn test_list_code_areas_filters_by_since_timestamp() {
+        let store = test_store();
+        store
+            .upsert_code_area("p", "old.rs", None, None, None)
+            .unwrap();
+        // Cutoff one hour ahead skips everything we just inserted.
+        let cutoff = chrono::Utc::now() + chrono::Duration::hours(1);
+        let after = store.list_code_areas(None, None, Some(cutoff), 10).unwrap();
+        assert!(after.is_empty());
+        // Cutoff one hour behind keeps the row.
+        let past = chrono::Utc::now() - chrono::Duration::hours(1);
+        let after = store.list_code_areas(None, None, Some(past), 10).unwrap();
+        assert_eq!(after.len(), 1);
+    }
+
+    #[test]
+    fn test_list_code_areas_orders_by_last_touched_desc() {
+        let store = test_store();
+        store
+            .upsert_code_area("p", "first.rs", None, None, None)
+            .unwrap();
+        // Sleep so the second insert lands at a strictly later second.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        store
+            .upsert_code_area("p", "second.rs", None, None, None)
+            .unwrap();
+        let rows = store.list_code_areas(None, None, None, 10).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].file_path, "second.rs");
+        assert_eq!(rows[1].file_path, "first.rs");
+    }
+
+    #[test]
+    fn test_code_area_count_matches_unique_paths() {
+        let store = test_store();
+        assert_eq!(store.code_area_count().unwrap(), 0);
+        store
+            .upsert_code_area("p", "f.rs", None, None, None)
+            .unwrap();
+        store
+            .upsert_code_area("p", "f.rs", None, None, None)
+            .unwrap(); // re-touch
+        store
+            .upsert_code_area("p", "g.rs", None, None, None)
+            .unwrap();
+        assert_eq!(store.code_area_count().unwrap(), 2);
     }
 }


### PR DESCRIPTION
## Summary

Closes #196.

Adds a hook-driven, no-MCP equivalent of Context-Engine's
`record_code_area`: every time Claude Code / Codex / Gemini / Copilot
calls `Edit` / `Write` / `MultiEdit` / `NotebookEdit`, the existing
PostToolUse hook (`icm hook post`) extracts `tool_input.file_path` and
upserts a row in a new `code_areas` table. Same `(project, file_path)`
increments `touch_count` instead of duplicating, so the table grows in
*file count*, not edit count.

## What's new

- **Schema**: new `code_areas(id, project, file_path, description,
  session_id, tool_name, touch_count, first_touched_at,
  last_touched_at)` table with `UNIQUE(project, file_path)` constraint
  driving the upsert.
- **Store API**:
  - `SqliteStore::upsert_code_area(project, file_path, description,
    session_id, tool_name)` — ON CONFLICT bumps `touch_count`,
    refreshes `last_touched_at` / `session_id` / `tool_name`, and only
    overwrites `description` when the caller passes `Some` (preserves
    the most recent meaningful hint via `COALESCE`).
  - `SqliteStore::list_code_areas(project, in_file, since, limit)` —
    filter by exact or suffix path; ordered by `last_touched_at DESC`.
  - `SqliteStore::code_area_count()`.
- **Hook integration**: `extract_tool_input_file_path()` covers three
  shapes seen across Claude Code 1.x / 2.x, Codex, and Gemini
  (`tool_input.file_path`, top-level `file_path`,
  `tool_input.arguments.file_path`). `cmd_hook_post` calls
  `upsert_code_area` **before** the extract counter — independent of
  the throttle, errors swallowed so telemetry never blocks the hook.
- **CLI**: new `icm code-areas` command with `--in-file`, `--project`,
  `--since` (ISO-8601), `--limit`, `--format {table,json}`.

## Why no MCP

Per the issue thread: tying this to the PostToolUse hook gives **100%
coverage** across every AI tool already `icm init`'d. No new MCP tool
to expose, no need for the agent to comply via system prompt. The
existing hook chain already runs after every tool call.

## Notes

- `description` is `None` in the MVP. Once #165 (LLM-summarized
  briefing) ships, the same provider infrastructure can feed a diff
  summary into `description` opt-in.
- No new dependencies. Hook + transcript + sqlite plumbing was already
  in place — the patch reuses all of it.
- Source MCP tool (`Context-Engine-AI/Context-Engine`) is
  source-available proprietary; ICM ships an Apache-2.0 equivalent
  built from scratch.

## Tests

- 7 new unit tests in `icm-store` (upsert idempotency, touch_count
  increment, description `COALESCE` behaviour, project + path-suffix
  filters, `since` filter, `last_touched_at DESC` ordering, count).
- **513 tests pass** across the workspace, `cargo clippy --workspace
  --all-targets -- -D warnings` clean.
- Manual smoke against the release binary:
  - 3 hook payloads (`Edit` / `Write` / `MultiEdit`) → 2 unique paths
    captured.
  - `auth.rs` re-touched → `touch_count` = 2.
  - `Bash` payload → correctly ignored (no code-area row).
  - `--in-file` filter and `--format json` both verified.

## Sample output

```
$ icm code-areas
Project              Hits   Last touched         Path
--------------------------------------------------------------------------------
icm                  2      2026-05-31 09:26:47  src/auth.rs
icm                  1      2026-05-31 09:26:47  src/login.rs

$ icm code-areas --in-file src/auth.rs --format json
[
  {
    "id": 1,
    "project": "icm",
    "file_path": "src/auth.rs",
    "description": null,
    "session_id": null,
    "tool_name": "Write",
    "touch_count": 2,
    "first_touched_at": "2026-05-31T09:26:47.203993069+00:00",
    "last_touched_at": "2026-05-31T09:26:47.211044445+00:00"
  }
]
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (513 passed)
- [x] Manual hook smoke (3 tool variants + 1 non-edit)
- [x] `icm code-areas` end-to-end with `--in-file`, `--format json`

Closes #196.