### PR TITLE
fix(config): display auto_consolidate_enabled and auto_consolidate_threshold

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -5145,6 +5145,14 @@ fn cmd_config() -> Result<()> {
     println!("  default_importance = {}", cfg.memory.default_importance);
     println!("  decay_rate = {}", cfg.memory.decay_rate);
     println!("  prune_threshold = {}", cfg.memory.prune_threshold);
+    println!(
+        "  auto_consolidate_enabled = {}",
+        cfg.memory.auto_consolidate_enabled
+    );
+    println!(
+        "  auto_consolidate_threshold = {}",
+        cfg.memory.auto_consolidate_threshold
+    );
     println!();
     println!("[embeddings]");
     println!("  model = {}", cfg.embeddings.model);


### PR DESCRIPTION
## Summary

`cmd_config` prints every field of `MemoryConfig` by hand but omits `auto_consolidate_enabled` and `auto_consolidate_threshold`. Both fields are correctly parsed from `config.toml` and respected at runtime — they just never appeared in `icm config`, making it impossible to confirm they were active without reading the raw TOML file.

- Add the two missing `println!` lines in the `[memory]` section of `cmd_config`

## Test plan

- [x] `icm config` output includes `auto_consolidate_enabled` and `auto_consolidate_threshold` under `[memory]`
- [x] Values reflect what is set in `config.toml` (or the compiled-in defaults when no file is present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)