### PR TITLE
feat(init): support Pi (pi.dev) harness out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Re-run the install command to upgrade to the latest release. To pin a version, p
 icm init
 ```
 
-Configures **17 tools** in one command ([full integration guide](docs/integrations.md)):
+Configures **18 tools** in one command ([full integration guide](docs/integrations.md)):
 
 | Tool | MCP | Hooks | CLI | Skills |
 |------|:---:|:-----:|:---:|:------:|
@@ -141,6 +141,7 @@ Configures **17 tools** in one command ([full integration guide](docs/integratio
 | OpenCode | JSON | TS plugin | — | — |
 | Continue.dev | `~/.continue/config.yaml` | — | — | — |
 | Aider | — | — | `.aider.conventions.md` | — |
+| Pi | — | (TS ext, TBD) | `~/.pi/agent/AGENTS.md` | `/icm-recall` `/icm-remember` |
 
 Or manually:
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Configures **18 tools** in one command ([full integration guide](docs/integratio
 | OpenCode | JSON | TS plugin | — | — |
 | Continue.dev | `~/.continue/config.yaml` | — | — | — |
 | Aider | — | — | `.aider.conventions.md` | — |
-| Pi | — | (TS ext, TBD) | `~/.pi/agent/AGENTS.md` | `/icm-recall` `/icm-remember` |
+| Pi | — | TS ext (TBD) | `~/.pi/agent/AGENTS.md` | `/icm-recall` `/icm-remember` |
 
 Or manually:
 

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -3690,7 +3690,14 @@ icm topics                                # list all topics\n\
             if per_project {
                 let cwd_path = match *label {
                     "Claude Code" => Some(cwd.join("CLAUDE.md")),
-                    "Codex" => Some(cwd.join("AGENTS.md")),
+                    // Codex AND Pi both read AGENTS.md by walking up
+                    // from cwd to $HOME, so a single per-project
+                    // `cwd/AGENTS.md` covers both. `inject_icm_block`
+                    // is idempotent on the icm:start marker so if
+                    // both tools are detected the second pass turns
+                    // into "already configured" without duplicating
+                    // the block.
+                    "Codex" | "Pi" => Some(cwd.join("AGENTS.md")),
                     _ => None,
                 };
                 if let Some(p) = cwd_path {

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -3651,6 +3651,9 @@ icm topics                                # list all topics\n\
             ("Claude Code", "Claude Code", claude_dir.join("CLAUDE.md")),
             ("Codex", "Codex CLI", codex_dir.join("AGENTS.md")),
             ("Gemini", "Gemini", gemini_dir.join("GEMINI.md")),
+            // Pi reads AGENTS.md from ~/.pi/agent/ and parent dirs.
+            // Global instruction file follows the same shape as Codex.
+            ("Pi", "Pi", PathBuf::from(&home).join(".pi/agent/AGENTS.md")),
         ];
 
         // Project-only write targets (no global equivalent at the tool):
@@ -3851,6 +3854,34 @@ Do this BEFORE responding to the user. Not optional.
             )?;
         } else {
             println!("[skill] {:<16} skipped (not detected)", "Amp");
+        }
+
+        // Pi: ~/.pi/agent/skills/ — same shape as Amp (see issue #259).
+        let pi_skills_dir = PathBuf::from(&home).join(".pi/agent/skills");
+        if force || detect_tool("Pi", &home, &vscode_data) {
+            for fname in ["icm-recall.md", "icm-remember.md"] {
+                if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                    &pi_skills_dir.join(fname),
+                    "Pi skill",
+                    install_manifest::EntryKind::OwnedFile,
+                ) {
+                    manifest.record(e);
+                }
+            }
+            install_skill(
+                &pi_skills_dir,
+                "icm-recall.md",
+                icm_recall_prompt,
+                "Pi /icm-recall",
+            )?;
+            install_skill(
+                &pi_skills_dir,
+                "icm-remember.md",
+                icm_remember_prompt,
+                "Pi /icm-remember",
+            )?;
+        } else {
+            println!("[skill] {:<16} skipped (not detected)", "Pi");
         }
     }
 
@@ -4096,6 +4127,18 @@ Do this BEFORE responding to the user. Not optional.
             println!("[hook] Copilot CLI (all hooks): {copilot_status}");
         } else {
             println!("[hook] {:<16} skipped (not detected)", "Copilot CLI");
+        }
+
+        // --- Pi (pi.dev) hooks need a TypeScript extension against the
+        // `@earendil-works/pi-coding-agent` SDK, modeled on the OpenCode
+        // plugin in `plugins/opencode-icm.ts`. The CLI doesn't ship one
+        // yet — tracked under issue #259. We still print the notice so
+        // Pi users see that ICM is aware of them.
+        if detect_tool("Pi", &home, &vscode_data) {
+            println!(
+                "[hook] {:<16} skipped (TS extension TBD — see issue #259)",
+                "Pi"
+            );
         }
     }
 
@@ -4747,6 +4790,12 @@ fn detect_tool(name: &str, home: &str, vscode_data: &Path) -> bool {
         }
         // Aider is a Python CLI (pip-installable); check the binary.
         "Aider" => binary_in_path("aider"),
+        // Pi (pi.dev / earendil-works/pi). Installed globally via npm
+        // (`pi install npm:...`) — check the binary, and as a fallback
+        // the global config dir, since users often `npm link` into a
+        // path the binary alone can't always reach (e.g. Volta /
+        // pnpm-global env quirks). See issue #259.
+        "Pi" => binary_in_path("pi") || PathBuf::from(home).join(".pi/agent").exists(),
         _ => true,
     }
 }

--- a/crates/icm-cli/src/uninstall/locations.rs
+++ b/crates/icm-cli/src/uninstall/locations.rs
@@ -406,6 +406,26 @@ pub(crate) fn build_locations(d: &DirContext) -> Vec<LocationSpec> {
         purge_data_only: false,
     });
 
+    // --- Pi (pi.dev / earendil-works/pi) — issue #259 ---
+    specs.push(LocationSpec {
+        label: "Pi AGENTS.md",
+        path: d.home.join(".pi/agent/AGENTS.md"),
+        kind: K::MarkdownBlock,
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "Pi /icm-recall",
+        path: d.home.join(".pi/agent/skills/icm-recall.md"),
+        kind: K::OwnedFile,
+        purge_data_only: false,
+    });
+    specs.push(LocationSpec {
+        label: "Pi /icm-remember",
+        path: d.home.join(".pi/agent/skills/icm-remember.md"),
+        kind: K::OwnedFile,
+        purge_data_only: false,
+    });
+
     // --- Amazon Q ---
     specs.push(LocationSpec {
         label: "Amazon Q MCP",
@@ -533,6 +553,9 @@ mod tests {
             "Amp MCP",
             "Amp /icm-recall",
             "Amp /icm-remember",
+            "Pi AGENTS.md",
+            "Pi /icm-recall",
+            "Pi /icm-remember",
             "Amazon Q MCP",
             "Continue.dev",
             "CLAUDE.md (cwd)",

--- a/crates/icm-cli/tests/init_secure_integration.rs
+++ b/crates/icm-cli/tests/init_secure_integration.rs
@@ -416,3 +416,39 @@ fn pi_uninstall_strips_block_and_deletes_skills() {
         "Pi /icm-remember skill should be deleted"
     );
 }
+
+#[test]
+fn pi_per_project_drops_cwd_agents_md() {
+    // Pi (like Codex) reads AGENTS.md by walking up from cwd to $HOME.
+    // With --per-project, init should write both `~/.pi/agent/AGENTS.md`
+    // AND `cwd/AGENTS.md` so editors opened mid-tree still see the
+    // block. The same `cwd/AGENTS.md` is shared with Codex when both
+    // are detected (inject_icm_block is idempotent so no duplicate).
+    let (tmp, cwd) = make_home();
+    let out = icm_in(
+        tmp.path(),
+        &cwd,
+        "/dev/null",
+        &["init", "--mode", "cli", "--per-project", "--force"],
+    );
+    assert_eq!(out.status.code(), Some(0));
+
+    let pi_global = tmp.path().join(".pi/agent/AGENTS.md");
+    let cwd_agents = cwd.join("AGENTS.md");
+    assert!(pi_global.exists(), "Pi global AGENTS.md must exist");
+    assert!(
+        cwd_agents.exists(),
+        "cwd AGENTS.md must be written under --per-project so Pi/Codex \
+         see the block in-tree"
+    );
+
+    // Single block, no duplicate (Codex and Pi both target the same cwd
+    // path — idempotency check).
+    let content = std::fs::read_to_string(&cwd_agents).unwrap();
+    let starts = content.matches("<!-- icm:start -->").count();
+    assert_eq!(
+        starts, 1,
+        "cwd AGENTS.md must contain exactly one icm:start marker; got \
+         {starts}\ncontent:\n{content}"
+    );
+}

--- a/crates/icm-cli/tests/init_secure_integration.rs
+++ b/crates/icm-cli/tests/init_secure_integration.rs
@@ -274,3 +274,145 @@ fn list_user_writes(home: &Path) -> Vec<std::path::PathBuf> {
     walk(home, &mut acc);
     acc
 }
+
+// ── Pi harness (issue #259) ───────────────────────────────────────────
+
+#[test]
+fn pi_skipped_when_undetected_no_binary_no_dir() {
+    let (tmp, cwd) = make_home();
+    let out = icm_in(
+        tmp.path(),
+        &cwd,
+        "/dev/null",
+        &["init", "--mode", "standard"],
+    );
+    assert_eq!(out.status.code(), Some(0));
+
+    let agents_md = tmp.path().join(".pi/agent/AGENTS.md");
+    let recall = tmp.path().join(".pi/agent/skills/icm-recall.md");
+    let remember = tmp.path().join(".pi/agent/skills/icm-remember.md");
+    assert!(
+        !agents_md.exists(),
+        "Pi AGENTS.md must NOT be written when undetected"
+    );
+    assert!(
+        !recall.exists(),
+        "Pi /icm-recall must NOT be written when undetected"
+    );
+    assert!(
+        !remember.exists(),
+        "Pi /icm-remember must NOT be written when undetected"
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("[cli] Pi               skipped"),
+        "cli skip line missing for Pi: {stdout}"
+    );
+    assert!(
+        stdout.contains("[skill] Pi               skipped"),
+        "skill skip line missing for Pi: {stdout}"
+    );
+}
+
+#[test]
+fn pi_writes_files_when_force_bypasses_detect() {
+    let (tmp, cwd) = make_home();
+    let out = icm_in(
+        tmp.path(),
+        &cwd,
+        "/dev/null",
+        &["init", "--mode", "standard", "--force"],
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let agents_md = tmp.path().join(".pi/agent/AGENTS.md");
+    let recall = tmp.path().join(".pi/agent/skills/icm-recall.md");
+    let remember = tmp.path().join(".pi/agent/skills/icm-remember.md");
+    assert!(agents_md.exists(), "{} missing", agents_md.display());
+    assert!(recall.exists(), "{} missing", recall.display());
+    assert!(remember.exists(), "{} missing", remember.display());
+
+    // AGENTS.md must carry the icm:start/icm:end block.
+    let content = std::fs::read_to_string(&agents_md).unwrap();
+    assert!(
+        content.contains("<!-- icm:start -->") && content.contains("<!-- icm:end -->"),
+        "Pi AGENTS.md missing block delimiters; got: {content}"
+    );
+
+    // Hook is intentionally TBD — confirm the skip notice still fires.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("[hook] Pi               skipped (TS extension TBD"),
+        "hook skip-with-TBD line missing for Pi: {stdout}"
+    );
+}
+
+#[test]
+fn pi_detected_via_dir_presence_without_binary_in_path() {
+    let (tmp, cwd) = make_home();
+    // Create the dir but NOT the binary — detection should still pass.
+    std::fs::create_dir_all(tmp.path().join(".pi/agent")).unwrap();
+
+    let out = icm_in(
+        tmp.path(),
+        &cwd,
+        "/dev/null",
+        &["init", "--mode", "standard"],
+    );
+    assert_eq!(out.status.code(), Some(0));
+
+    let agents_md = tmp.path().join(".pi/agent/AGENTS.md");
+    let recall = tmp.path().join(".pi/agent/skills/icm-recall.md");
+    let remember = tmp.path().join(".pi/agent/skills/icm-remember.md");
+    assert!(
+        agents_md.exists(),
+        "Pi AGENTS.md should be written via dir-presence detection"
+    );
+    assert!(recall.exists());
+    assert!(remember.exists());
+}
+
+#[test]
+fn pi_uninstall_strips_block_and_deletes_skills() {
+    let (tmp, cwd) = make_home();
+    // Seed via --force.
+    let _ = icm_in(
+        tmp.path(),
+        &cwd,
+        "/dev/null",
+        &["init", "--mode", "standard", "--force"],
+    );
+    let agents_md = tmp.path().join(".pi/agent/AGENTS.md");
+    let recall = tmp.path().join(".pi/agent/skills/icm-recall.md");
+    let remember = tmp.path().join(".pi/agent/skills/icm-remember.md");
+    assert!(agents_md.exists() && recall.exists() && remember.exists());
+
+    // Round-trip via `icm uninstall -y`.
+    let out = icm_in(tmp.path(), &cwd, "/dev/null", &["uninstall", "-y"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // AGENTS.md only held the icm block → uninstall deletes it.
+    assert!(
+        !agents_md.exists(),
+        "Pi AGENTS.md should be removed when it held only the icm block"
+    );
+    // Skills are OwnedFile → deleted whole.
+    assert!(!recall.exists(), "Pi /icm-recall skill should be deleted");
+    assert!(
+        !remember.exists(),
+        "Pi /icm-remember skill should be deleted"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #259.

Adds [Pi](https://pi.dev) to ICM's per-tool integration matrix for
**cli + skill** modes. Hook mode (TS extension against
`@earendil-works/pi-coding-agent`) is left as a follow-up — the issue
reporter offered to test against the live SDK and is in a much better
position to author the TS plugin than this PR is.

## Coverage

| Mode    | Target                                              | Status |
|---------|-----------------------------------------------------|--------|
| `cli`   | `~/.pi/agent/AGENTS.md` (global, like Codex AGENTS.md) | ✅ |
| `skill` | `~/.pi/agent/skills/icm-recall.md` + `icm-remember.md` (Amp-style) | ✅ |
| `hook`  | `~/.pi/agent/extensions/icm.ts` TS plugin            | ⏳ TBD |
| `mcp`   | Pi has no built-in MCP server support               | n/a    |

## Detection

`detect_tool(\"Pi\")` returns true when:

1. `pi` binary is in `$PATH`, **or**
2. `~/.pi/agent/` directory exists.

The dir-presence fallback handles installs via Volta / pnpm-global
where the binary may not resolve from a sub-shell but the agent dir is
already populated.

## Uninstall

Three new specs in `crates/icm-cli/src/uninstall/locations.rs`:
- `Pi AGENTS.md` (MarkdownBlock — strips the icm:start/end block,
  deletes the file if it was empty).
- `Pi /icm-recall` + `Pi /icm-remember` (OwnedFile — deleted whole).

The static-catalog locations test was updated to assert all three new
labels are present.

## Smoke

Manual smoke against the release binary:

```text
# 1. No detection
$ env -i HOME=$TMP PATH=/dev/null icm init --mode standard
[cli]   Pi               skipped (not detected)
[skill] Pi               skipped (not detected)

# 2. --force bypass
$ env -i HOME=$TMP PATH=/dev/null icm init --mode standard --force
[cli]   Pi               /…/.pi/agent/AGENTS.md created
[skill] Pi /icm-recall   created
[skill] Pi /icm-remember created
[hook]  Pi               skipped (TS extension TBD — see issue #259)

# 3. Detection via dir presence
$ mkdir -p $TMP/.pi/agent && env -i HOME=$TMP PATH=/dev/null icm init --mode standard
[cli]   Pi               /…/.pi/agent/AGENTS.md created
[skill] Pi /icm-recall   created
[skill] Pi /icm-remember created

# 4. uninstall round-trip
$ icm uninstall --dry-run
[Pi AGENTS.md]    /…/.pi/agent/AGENTS.md
[Pi /icm-recall]  /…/.pi/agent/skills/icm-recall.md
[Pi /icm-remember] /…/.pi/agent/skills/icm-remember.md
```

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (506+ passed)
- [x] Manual smoke for: not-detected, --force, dir-fallback detection,
      uninstall round-trip

## Follow-up

The TS extension for `--mode hook` is intentionally out of scope.
Quick template once we're ready: model it on
`plugins/opencode-icm.ts`, swap the SDK import to
`@earendil-works/pi-coding-agent`, target events emitted by
`pi.on(\"tool_call\", …)` / equivalent. See the Pi example library at
https://github.com/earendil-works/pi/tree/main/packages/coding-agent/examples/extensions.