### PR TITLE
feat(list): add --format json|toon|toml and --limit (closes #269)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"deb6a50d-55b4-44c8-bc29-9c66ac7039e0","pid":51325,"procStart":"428107","acquiredAt":1777721218484}
+{"sessionId":"be38cc41-6298-4324-91ce-0fc153c2c01b","pid":1280058,"procStart":"21943756","acquiredAt":1780986406100}

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -141,6 +141,17 @@ enum Commands {
         /// Sort by field
         #[arg(short, long, default_value = "weight")]
         sort: SortField,
+
+        /// Output format. `human` (default) is the legacy multi-line
+        /// labelled view kept for terminal users; `toon`, `json`, and
+        /// `toml` reuse the `icm recall` serializers so external
+        /// tooling can enumerate a topic programmatically (issue #269).
+        #[arg(short = 'f', long, default_value = "human")]
+        format: ListFormat,
+
+        /// Maximum rows to return. Default: no limit.
+        #[arg(short = 'l', long)]
+        limit: Option<usize>,
     },
 
     /// Forget (delete) a memory by ID, or all memories in a topic
@@ -1031,6 +1042,38 @@ enum SortField {
     Accessed,
 }
 
+/// Output format for `icm list` (issue #269).
+///
+/// `Human` is the legacy multi-line view kept as the default to avoid
+/// breaking terminal users; `Toon`, `Json`, and `Toml` route through
+/// `recall_format::render` so the structured output matches what
+/// `icm recall --format <…>` produces for consistency.
+#[derive(Clone, Copy, ValueEnum, Debug)]
+enum ListFormat {
+    /// Legacy multi-line labelled view, for terminal reading. Default.
+    Human,
+    /// Compact TOON (header + CSV rows). Best token cost for LLM piping.
+    Toon,
+    /// `serde_json` array. Machine-readable.
+    Json,
+    /// TOML `[[memories]]` array. Config-friendly.
+    Toml,
+}
+
+impl ListFormat {
+    /// Whether this format reuses the `recall_format` renderer. `Human`
+    /// is handled inline by `cmd_list` to preserve the existing
+    /// `print_memory_detail` output verbatim.
+    fn as_recall_format(self) -> Option<recall_format::RecallFormat> {
+        match self {
+            ListFormat::Human => None,
+            ListFormat::Toon => Some(recall_format::RecallFormat::Toon),
+            ListFormat::Json => Some(recall_format::RecallFormat::Json),
+            ListFormat::Toml => Some(recall_format::RecallFormat::Toml),
+        }
+    }
+}
+
 #[derive(Clone, ValueEnum)]
 enum InitMode {
     /// MCP server plugin (Claude calls icm tools natively)
@@ -1207,7 +1250,13 @@ fn main() -> Result<()> {
                 format,
             )
         }
-        Commands::List { topic, all, sort } => cmd_list(&store, topic.as_deref(), all, sort),
+        Commands::List {
+            topic,
+            all,
+            sort,
+            format,
+            limit,
+        } => cmd_list(&store, topic.as_deref(), all, sort, format, limit),
         Commands::Forget { id, topic } => cmd_forget(&store, id.as_deref(), topic.as_deref()),
         Commands::Update {
             id,
@@ -1838,7 +1887,14 @@ fn cmd_recall(
     Ok(())
 }
 
-fn cmd_list(store: &SqliteStore, topic: Option<&str>, all: bool, sort: SortField) -> Result<()> {
+fn cmd_list(
+    store: &SqliteStore,
+    topic: Option<&str>,
+    all: bool,
+    sort: SortField,
+    format: ListFormat,
+    limit: Option<usize>,
+) -> Result<()> {
     let mut memories = if let Some(t) = topic {
         store.get_by_topic(t)?
     } else if all {
@@ -1860,13 +1916,39 @@ fn cmd_list(store: &SqliteStore, topic: Option<&str>, all: bool, sort: SortField
         SortField::Accessed => memories.sort_by_key(|b| std::cmp::Reverse(b.last_accessed)),
     }
 
+    if let Some(n) = limit {
+        memories.truncate(n);
+    }
+
     if memories.is_empty() {
-        println!("{MSG_NO_MEMORIES}");
+        // Empty: keep the structured formats valid (`[]`, empty TOON
+        // header, empty TOML) so scripts can pipe straight in.
+        match format.as_recall_format() {
+            Some(f) => {
+                let rendered = recall_format::render(&[], f)?;
+                if !rendered.is_empty() {
+                    print!("{rendered}");
+                }
+            }
+            None => println!("{MSG_NO_MEMORIES}"),
+        }
         return Ok(());
     }
 
-    for mem in &memories {
-        print_memory_detail(mem, None);
+    match format.as_recall_format() {
+        Some(f) => {
+            // Reuse `recall`'s serializers. `score` is None for the
+            // list path since enumeration has no relevance score.
+            let pairs: Vec<(icm_core::Memory, Option<f32>)> =
+                memories.into_iter().map(|m| (m, None)).collect();
+            let rendered = recall_format::render(&pairs, f)?;
+            print!("{rendered}");
+        }
+        None => {
+            for mem in &memories {
+                print_memory_detail(mem, None);
+            }
+        }
     }
 
     Ok(())

--- a/crates/icm-cli/src/recall_format.rs
+++ b/crates/icm-cli/src/recall_format.rs
@@ -1,11 +1,15 @@
-//! Output formats for `icm recall`.
+//! Output formats for `icm recall` (and `icm list`, which reuses the
+//! same renderers).
 //!
-//! Three modes:
+//! Four modes:
 //! - `Toon` (default) — TOON one-row-per-memory, header declared once.
 //!   Smallest token cost when stdout gets piped into an LLM context.
 //! - `Detail` — the legacy multi-line labelled view, for humans reading
 //!   the terminal (also the format expected by older scripts).
 //! - `Json` — `serde_json` array, for tooling that wants to parse.
+//! - `Toml` — TOML `[[memories]]` array for config-friendly consumption
+//!   (issue #269 — used by TakoIA-style agents reading their memory map
+//!   straight from a TOML file).
 
 use anyhow::Result;
 use clap::ValueEnum;
@@ -20,6 +24,10 @@ pub enum RecallFormat {
     Detail,
     /// Machine-readable JSON array.
     Json,
+    /// TOML `[[memories]]` array. Config-friendly: easy to embed in
+    /// `~/.icm/config.toml`-style files or consume from Rust/Python TOML
+    /// parsers.
+    Toml,
 }
 
 /// Render a list of `(memory, score)` pairs into the chosen format.
@@ -33,6 +41,7 @@ pub fn render(results: &[(Memory, Option<f32>)], format: RecallFormat) -> Result
         RecallFormat::Toon => render_toon(results),
         RecallFormat::Detail => render_detail(results),
         RecallFormat::Json => render_json(results)?,
+        RecallFormat::Toml => render_toml(results)?,
     })
 }
 
@@ -140,6 +149,52 @@ fn render_json(results: &[(Memory, Option<f32>)]) -> Result<String> {
     Ok(serde_json::to_string_pretty(&rows)?)
 }
 
+fn render_toml(results: &[(Memory, Option<f32>)]) -> Result<String> {
+    /// Mirror of `Memory`'s public shape but `Serialize`-friendly for
+    /// `toml::to_string`. The base `Memory` impls already derive
+    /// `Serialize`, but we cherry-pick fields so the TOML stays compact
+    /// (skip `embedding`, the per-memory float vector — usually 384+
+    /// dims, useless in a human-readable TOML).
+    #[derive(Serialize)]
+    struct Row<'a> {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        score: Option<f32>,
+        id: &'a str,
+        topic: &'a str,
+        importance: String,
+        weight: f32,
+        access_count: u32,
+        created_at: String,
+        last_accessed: String,
+        summary: &'a str,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        keywords: Vec<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        raw_excerpt: Option<&'a str>,
+    }
+    #[derive(Serialize)]
+    struct Doc<'a> {
+        memories: Vec<Row<'a>>,
+    }
+    let rows: Vec<Row> = results
+        .iter()
+        .map(|(m, s)| Row {
+            score: *s,
+            id: &m.id,
+            topic: &m.topic,
+            importance: m.importance.to_string(),
+            weight: m.weight,
+            access_count: m.access_count,
+            created_at: m.created_at.to_rfc3339(),
+            last_accessed: m.last_accessed.to_rfc3339(),
+            summary: &m.summary,
+            keywords: m.keywords.iter().map(String::as_str).collect(),
+            raw_excerpt: m.raw_excerpt.as_deref(),
+        })
+        .collect();
+    Ok(toml::to_string(&Doc { memories: rows })?)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -216,5 +271,45 @@ mod tests {
         );
         assert_eq!(render_detail(&empty), "");
         assert_eq!(render_json(&empty).unwrap(), "[]");
+    }
+
+    #[test]
+    fn toml_round_trips_through_a_parser() {
+        // Take the fixture, render it as TOML, parse it back, and check
+        // we still see the field shape from issue #269.
+        let s = render_toml(&fixture()).unwrap();
+        let parsed: toml::Value = toml::from_str(&s).unwrap();
+        let memories = parsed
+            .get("memories")
+            .and_then(|v| v.as_array())
+            .expect("expected [[memories]] array");
+        assert_eq!(memories.len(), 2);
+        let first = &memories[0];
+        for required in [
+            "id",
+            "topic",
+            "importance",
+            "weight",
+            "access_count",
+            "created_at",
+            "last_accessed",
+            "summary",
+        ] {
+            assert!(
+                first.get(required).is_some(),
+                "missing field {required} in TOML row: {first}"
+            );
+        }
+    }
+
+    #[test]
+    fn toml_empty_list_renders_clean() {
+        let empty: Vec<(Memory, Option<f32>)> = Vec::new();
+        let s = render_toml(&empty).unwrap();
+        // toml crate emits no header line when the array is empty.
+        assert!(
+            s.trim().is_empty() || s == "memories = []\n",
+            "unexpected empty TOML: {s:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #269.

`icm list` now supports the same `--format` choices as `icm recall`,
plus a `--limit` cap. External tooling (TakoIA-style agents, scripts
building a per-topic memory map) can enumerate a topic with full
metadata programmatically — no more keeping a mirror DB just for
list-all.

## CLI surface

```
icm list --topic <T> --all --sort {weight|created|accessed} \
         --format {human|toon|json|toml} --limit <N>
```

- `human` (default) — legacy multi-line view, no regression for
  terminal users.
- `toon`, `json`, `toml` — reuse `recall_format::render` so structured
  output is byte-for-byte consistent with what `icm recall --format X`
  emits.
- `--limit N` — truncates **after** sorting so the top-N by weight (or
  by created / accessed) is what gets emitted.

## TOML format (new in `recall_format`)

`RecallFormat::Toml` emits `[[memories]]` arrays with `id`, `topic`,
`importance`, `weight`, `access_count`, `created_at`, `last_accessed`,
`summary`, and (when present) `keywords` / `raw_excerpt` / `score`. The
384-dim embedding vector is intentionally omitted — useless in a
human-readable TOML. Available on both `icm list --format toml` and
`icm recall --format toml` for consistency.

## Smoke against release binary

```
$ icm list --all --format json | head -10
[
  {
    \"id\": \"01K...\",
    \"topic\": \"takoia/agent/A\",
    \"importance\": \"high\",
    \"weight\": 1.0,
    \"access_count\": 0,
    ...

$ icm list --all --format toml
[[memories]]
id = \"01K...\"
topic = \"takoia/agent/A\"
importance = \"high\"
weight = 1.0
access_count = 0
created_at = \"2026-06-13T22:12:43.058988622+00:00\"
last_accessed = \"2026-06-13T22:12:43.058988622+00:00\"
summary = \"uses Postgres\"

$ icm list --all --format toon --limit 2
memories[2]{id,topic,importance,weight,summary}:
  01K..., takoia/agent/B, low, 1.000, uses SAML
  01K..., takoia/agent/A, high, 1.000, uses Postgres
```

## Tests

- 2 new unit tests in `recall_format.rs`:
  - \`toml_round_trips_through_a_parser\` — emits then re-parses via
    \`toml::Value\` and asserts every field from the issue's JSON shape
    is present.
  - \`toml_empty_list_renders_clean\` — empty input doesn't break the
    parser.
- All existing \`recall_format\` tests still pass.
- \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

## Test plan

- [x] cargo build -p icm-cli
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test workspace
- [x] Manual smoke: seed 3 memories, exercise human / json / toon / toml
      / --limit
- [ ] CI cross-OS (Linux / Windows / macOS) — pending push

Closes #269.