### PR TITLE
feat(hook): auto-archive sessions + icm sessions command (closes #272)

### DIFF
--- a/crates/icm-cli/src/archive.rs
+++ b/crates/icm-cli/src/archive.rs
@@ -1,0 +1,230 @@
+//! Hook auto-archive (issue #272).
+//!
+//! Tees user prompts and tool outputs into the verbatim
+//! `sessions`/`messages` tables so an FTS5-backed `icm sessions search`
+//! works at zero recall cost. Opt-in via `[archive].enabled = true`.
+//!
+//! Distinct from extraction (which is curated/lossy): archive keeps
+//! every event under a session keyed by the host agent's session id
+//! so re-fires within the same Claude Code / Codex / Gemini turn land
+//! under the same row.
+
+use icm_core::transcript::Role;
+use icm_core::TranscriptStore;
+use icm_store::SqliteStore;
+use serde_json::Value;
+
+use crate::config::ArchiveConfig;
+
+/// Truncate `s` at a UTF-8 char boundary so the tail of the cut never
+/// lands inside a multibyte sequence (issue #110 keeps biting us).
+/// `max_bytes == 0` disables truncation.
+fn cap_bytes(s: &str, max_bytes: usize) -> &str {
+    if max_bytes == 0 || s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// Try to pull a session id from the hook stdin JSON. Falls back to
+/// the basename of `transcript_path` (which Claude Code includes) when
+/// `session_id` is absent. Returns `None` only when neither is present
+/// — caller skips archiving rather than create a junk-keyed row.
+pub fn session_id_from_stdin(json: &Value) -> Option<String> {
+    if let Some(s) = json.get("session_id").and_then(|v| v.as_str()) {
+        if !s.is_empty() {
+            return Some(s.to_string());
+        }
+    }
+    json.get("transcript_path")
+        .and_then(|v| v.as_str())
+        .and_then(|p| {
+            std::path::Path::new(p)
+                .file_stem()
+                .map(|s| s.to_string_lossy().to_string())
+        })
+        .filter(|s| !s.is_empty())
+}
+
+/// Heuristic agent label from the hook env / payload. Best-effort —
+/// `unknown` is fine; we just want the column populated for the stats
+/// breakdown.
+pub fn agent_label_from_env() -> String {
+    if std::env::var("CURSOR_VERSION").is_ok() || std::env::var("CURSOR_PROJECT_DIR").is_ok() {
+        return "cursor".into();
+    }
+    if std::env::var("CLAUDE_CONFIG_DIR").is_ok() || std::env::var("CLAUDECODE").is_ok() {
+        return "claude-code".into();
+    }
+    if std::env::var("CODEX_HOME").is_ok() {
+        return "codex".into();
+    }
+    if std::env::var("GEMINI_CONFIG_DIR").is_ok() {
+        return "gemini".into();
+    }
+    "unknown".into()
+}
+
+/// Archive a single event. No-op when `[archive].enabled = false`.
+///
+/// Errors are swallowed and logged on stderr so a failure to archive
+/// never breaks the hook chain — the curated `Memory` path is the
+/// agent's source of truth; the archive is fallback fidelity.
+pub fn record_event(
+    store: &SqliteStore,
+    cfg: &ArchiveConfig,
+    json: &Value,
+    role: Role,
+    content: &str,
+    tool_name: Option<&str>,
+) {
+    if !cfg.enabled || content.is_empty() {
+        return;
+    }
+    let Some(session_id) = session_id_from_stdin(json) else {
+        return;
+    };
+
+    let project = json
+        .get("cwd")
+        .and_then(|v| v.as_str())
+        .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| std::path::PathBuf::from(p)))
+        .as_ref()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_string());
+
+    let agent = agent_label_from_env();
+    if let Err(e) = store.ensure_session(&session_id, &agent, project.as_deref(), None) {
+        eprintln!("[icm archive] ensure_session failed: {e}");
+        return;
+    }
+
+    let capped = cap_bytes(content, cfg.effective_max_bytes());
+    if let Err(e) = store.record_message(&session_id, role, capped, tool_name, None, None) {
+        eprintln!("[icm archive] record_message failed: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cap_bytes_disabled_when_zero() {
+        assert_eq!(cap_bytes("hello", 0), "hello");
+    }
+
+    #[test]
+    fn cap_bytes_passthrough_when_under_cap() {
+        assert_eq!(cap_bytes("hello", 100), "hello");
+    }
+
+    #[test]
+    fn cap_bytes_lands_on_char_boundary_for_multibyte() {
+        // 3 bytes per arrow, cap at 7 → must back off to 6.
+        let s = "\u{2192}\u{2192}\u{2192}";
+        let out = cap_bytes(s, 7);
+        assert!(out.len() <= 7);
+        assert!(s.is_char_boundary(out.len()));
+        assert!(out.chars().all(|c| c == '\u{2192}'));
+    }
+
+    #[test]
+    fn session_id_pulled_from_stdin() {
+        let v: Value = serde_json::from_str(r#"{"session_id":"abc-123","cwd":"/tmp"}"#).unwrap();
+        assert_eq!(session_id_from_stdin(&v).as_deref(), Some("abc-123"));
+    }
+
+    #[test]
+    fn session_id_falls_back_to_transcript_stem() {
+        let v: Value =
+            serde_json::from_str(r#"{"transcript_path":"/var/log/agent/sess-xyz.jsonl"}"#).unwrap();
+        assert_eq!(session_id_from_stdin(&v).as_deref(), Some("sess-xyz"));
+    }
+
+    #[test]
+    fn session_id_none_when_absent() {
+        let v: Value = serde_json::from_str("{}").unwrap();
+        assert_eq!(session_id_from_stdin(&v), None);
+    }
+
+    #[test]
+    fn record_event_is_noop_when_disabled() {
+        let store = SqliteStore::in_memory().unwrap();
+        let cfg = ArchiveConfig::default(); // enabled = false
+        let v: Value = serde_json::from_str(r#"{"session_id":"s1","cwd":"/tmp"}"#).unwrap();
+        record_event(&store, &cfg, &v, Role::User, "hello", None);
+        // No sessions table row, no messages.
+        let sessions = store.list_sessions(None, 10).unwrap();
+        assert!(sessions.is_empty(), "archive should be no-op when disabled");
+    }
+
+    #[test]
+    fn record_event_skips_when_no_session_id() {
+        let store = SqliteStore::in_memory().unwrap();
+        let cfg = ArchiveConfig {
+            enabled: true,
+            max_bytes_per_event: 0,
+        };
+        let v: Value = serde_json::from_str(r#"{"cwd":"/tmp"}"#).unwrap();
+        record_event(&store, &cfg, &v, Role::User, "hello", None);
+        let sessions = store.list_sessions(None, 10).unwrap();
+        assert!(
+            sessions.is_empty(),
+            "no session_id and no transcript_path → skip rather than create junk row",
+        );
+    }
+
+    #[test]
+    fn record_event_persists_under_external_id() {
+        let store = SqliteStore::in_memory().unwrap();
+        let cfg = ArchiveConfig {
+            enabled: true,
+            max_bytes_per_event: 0,
+        };
+        let v: Value = serde_json::from_str(r#"{"session_id":"s1","cwd":"/tmp"}"#).unwrap();
+        record_event(&store, &cfg, &v, Role::User, "first turn", None);
+        record_event(&store, &cfg, &v, Role::Tool, "tool output", Some("bash"));
+        let sessions = store.list_sessions(None, 10).unwrap();
+        assert_eq!(
+            sessions.len(),
+            1,
+            "should reuse the single session: {sessions:?}"
+        );
+        assert_eq!(sessions[0].id, "s1");
+        let msgs = store.list_session_messages("s1", 10, 0).unwrap();
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].content, "first turn");
+        assert_eq!(msgs[1].content, "tool output");
+        assert_eq!(msgs[1].tool_name.as_deref(), Some("bash"));
+    }
+
+    #[test]
+    fn record_event_truncates_at_byte_cap() {
+        let store = SqliteStore::in_memory().unwrap();
+        let cfg = ArchiveConfig {
+            enabled: true,
+            max_bytes_per_event: 16,
+        };
+        let v: Value = serde_json::from_str(r#"{"session_id":"s1","cwd":"/tmp"}"#).unwrap();
+        record_event(
+            &store,
+            &cfg,
+            &v,
+            Role::Tool,
+            &"abcdefghij".repeat(100),
+            Some("noisy"),
+        );
+        let msgs = store.list_session_messages("s1", 10, 0).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert!(
+            msgs[0].content.len() <= 16,
+            "expected truncation under 16 bytes, got {}",
+            msgs[0].content.len()
+        );
+    }
+}

--- a/crates/icm-cli/src/config.rs
+++ b/crates/icm-cli/src/config.rs
@@ -24,6 +24,7 @@ pub struct Config {
     pub mcp: McpConfig,
     pub web: WebConfig,
     pub cloud: CloudConfig,
+    pub archive: ArchiveConfig,
 }
 
 /// Database storage settings.
@@ -126,6 +127,38 @@ impl Default for WakeUpConfig {
 #[serde(default)]
 pub struct ConsolidateConfig {
     pub summarizer: SummarizerConfig,
+}
+
+/// Session-archive settings (issue #272).
+///
+/// When `enabled = true`, the post-tool and user-prompt hooks tee a
+/// verbatim copy of each event into the `sessions`/`messages` tables.
+/// Search via `icm sessions search …` (or the existing
+/// `icm_transcript_search` MCP tool). Off by default — turn on once
+/// secret scrubbing and a retention story are validated for the
+/// project at hand.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct ArchiveConfig {
+    /// Master switch for hook auto-archive.
+    pub enabled: bool,
+    /// Maximum bytes of tool output to archive per fire (truncate the
+    /// tail at a UTF-8 char boundary if exceeded). 0 = no cap.
+    /// Defaults to 32 KB — large enough for most CLI tool output,
+    /// small enough that a runaway log doesn't blow the DB out.
+    pub max_bytes_per_event: usize,
+}
+
+impl ArchiveConfig {
+    /// Resolved per-event cap. Centralized so the hook and the tests
+    /// agree.
+    pub fn effective_max_bytes(&self) -> usize {
+        if self.max_bytes_per_event == 0 {
+            32 * 1024
+        } else {
+            self.max_bytes_per_event
+        }
+    }
 }
 
 /// LLM-backed summarizer settings — applies to both `icm consolidate` and

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod archive;
 mod bench_data;
 mod bench_format;
 mod bench_knowledge;
@@ -199,6 +200,15 @@ enum Commands {
     Transcript {
         #[command(subcommand)]
         command: TranscriptCommands,
+    },
+
+    /// Session archive (issue #272) — UX-friendly entry point for the
+    /// verbatim sessions/messages tables that the hook auto-archive
+    /// feeds. Internally delegates to the same store as `transcript`,
+    /// but exposes the read-only subset most agents care about.
+    Sessions {
+        #[command(subcommand)]
+        command: SessionsCommands,
     },
 
     /// Detect recurring patterns in a topic and optionally create memoir concepts
@@ -987,6 +997,52 @@ enum TranscriptCommands {
     },
 }
 
+#[derive(Subcommand)]
+enum SessionsCommands {
+    /// Full-text search across archived messages (BM25)
+    Search {
+        /// Query (FTS5 syntax: `OR`, `*` prefix, `"phrase"`)
+        query: String,
+        /// Only within this session id
+        #[arg(short, long)]
+        session: Option<String>,
+        /// Only within this project
+        #[arg(short, long)]
+        project: Option<String>,
+        /// Max results
+        #[arg(short, long, default_value = "10")]
+        limit: usize,
+    },
+
+    /// List archived sessions, newest first
+    List {
+        /// Filter by project
+        #[arg(short, long)]
+        project: Option<String>,
+        /// Max results
+        #[arg(short, long, default_value = "20")]
+        limit: usize,
+    },
+
+    /// Replay the full message thread of a session, chronologically
+    Show {
+        /// Session id
+        session: String,
+        /// Max messages to show
+        #[arg(short, long, default_value = "200")]
+        limit: usize,
+    },
+
+    /// Show global session-archive statistics
+    Stats,
+
+    /// Delete an archived session and all its messages
+    Forget {
+        /// Session id
+        session: String,
+    },
+}
+
 #[derive(Clone, ValueEnum)]
 enum CliImportance {
     Critical,
@@ -1373,6 +1429,28 @@ fn main() -> Result<()> {
             TranscriptCommands::Stats => cmd_transcript_stats(&store),
             TranscriptCommands::Forget { session } => cmd_transcript_forget(&store, &session),
         },
+        Commands::Sessions { command } => match command {
+            SessionsCommands::Search {
+                query,
+                session,
+                project,
+                limit,
+            } => cmd_transcript_search(
+                &store,
+                &query,
+                session.as_deref(),
+                project.as_deref(),
+                limit,
+            ),
+            SessionsCommands::List { project, limit } => {
+                cmd_transcript_list_sessions(&store, project.as_deref(), limit)
+            }
+            SessionsCommands::Show { session, limit } => {
+                cmd_transcript_show(&store, &session, limit)
+            }
+            SessionsCommands::Stats => cmd_transcript_stats(&store),
+            SessionsCommands::Forget { session } => cmd_transcript_forget(&store, &session),
+        },
         Commands::ExtractPatterns {
             topic,
             memoir,
@@ -1633,6 +1711,7 @@ fn main() -> Result<()> {
                         extract_every,
                         cfg.extraction.store_raw,
                         &cfg.extraction.summarizer,
+                        &cfg.archive,
                     )
                 }
                 HookCommands::Compact => {
@@ -1642,7 +1721,7 @@ fn main() -> Result<()> {
                     let emb_ref: Option<&dyn icm_core::Embedder> = None;
                     cmd_hook_compact(&store, emb_ref, &cfg.memory)
                 }
-                HookCommands::Prompt => cmd_hook_prompt(&store),
+                HookCommands::Prompt => cmd_hook_prompt(&store, &cfg.archive),
                 HookCommands::Start { max_tokens } => {
                     let tokens = if max_tokens > 0 {
                         max_tokens
@@ -2693,6 +2772,7 @@ fn cmd_hook_post(
     extract_every: usize,
     store_raw: bool,
     extraction_summarizer: &crate::config::SummarizerConfig,
+    archive_cfg: &crate::config::ArchiveConfig,
 ) -> Result<()> {
     let Some(input) = read_stdin_utf8_lossy() else {
         return Ok(());
@@ -2708,6 +2788,24 @@ fn cmd_hook_post(
     // Skip ICM's own tools (avoid infinite loop)
     if tool_name.starts_with("icm_") || tool_name.starts_with("mcp__icm__") {
         return Ok(());
+    }
+
+    // Session archive (issue #272): tee every tool fire into the
+    // verbatim store BEFORE the extraction counter, so the searchable
+    // archive is independent of `extract_every`. No-op when
+    // `[archive].enabled = false`.
+    if archive_cfg.enabled {
+        let tool_output_for_archive = extract_tool_output(&json).unwrap_or("");
+        if !tool_output_for_archive.is_empty() {
+            archive::record_event(
+                store,
+                archive_cfg,
+                &json,
+                icm_core::transcript::Role::Tool,
+                tool_output_for_archive,
+                Some(tool_name).filter(|s| !s.is_empty()),
+            );
+        }
     }
 
     // Track tool calls in SQLite (atomic, persists across reboots)
@@ -3140,7 +3238,7 @@ pub(crate) fn truncate_tail_at_char_boundary(s: &str, max_bytes: usize) -> &str 
 /// UserPromptSubmit hook (Layer 2): inject recalled context at the start of each prompt.
 /// Reads JSON from stdin with `user_message`, recalls relevant memories,
 /// and prints context to stdout (Claude Code appends it as system-reminder).
-fn cmd_hook_prompt(store: &SqliteStore) -> Result<()> {
+fn cmd_hook_prompt(store: &SqliteStore, archive_cfg: &crate::config::ArchiveConfig) -> Result<()> {
     let Some(input) = read_stdin_utf8_lossy() else {
         return Ok(());
     };
@@ -3163,6 +3261,20 @@ fn cmd_hook_prompt(store: &SqliteStore) -> Result<()> {
 
     if message.is_empty() {
         return Ok(());
+    }
+
+    // Issue #272: archive the user turn verbatim before recall runs,
+    // so a subsequent `icm sessions search` can find it regardless of
+    // whether semantic recall matched anything.
+    if archive_cfg.enabled {
+        archive::record_event(
+            store,
+            archive_cfg,
+            &json,
+            icm_core::transcript::Role::User,
+            message,
+            None,
+        );
     }
 
     // Project name (from hook cwd) is used as a hard filter on recalled

--- a/crates/icm-core/src/transcript_store.rs
+++ b/crates/icm-core/src/transcript_store.rs
@@ -15,6 +15,20 @@ pub trait TranscriptStore {
         metadata: Option<&str>,
     ) -> IcmResult<String>;
 
+    /// Idempotent variant: ensure a session exists with the supplied
+    /// explicit `id` (typically the host agent's own session id). If
+    /// the row already exists, return its id unchanged; otherwise
+    /// insert a new row keyed by `id`. Used by hook auto-archive so
+    /// repeated hook fires within the same agent session land under
+    /// the same row (issue #272).
+    fn ensure_session(
+        &self,
+        id: &str,
+        agent: &str,
+        project: Option<&str>,
+        metadata: Option<&str>,
+    ) -> IcmResult<String>;
+
     /// Fetch a session by id.
     fn get_session(&self, id: &str) -> IcmResult<Option<Session>>;
 

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -2483,6 +2483,27 @@ impl TranscriptStore for SqliteStore {
         Ok(row)
     }
 
+    fn ensure_session(
+        &self,
+        id: &str,
+        agent: &str,
+        project: Option<&str>,
+        metadata: Option<&str>,
+    ) -> IcmResult<String> {
+        let conn = &self.conn;
+        let now = chrono::Utc::now().to_rfc3339();
+        // INSERT OR IGNORE keeps the first row stable across re-fires.
+        // The `id` is the host agent's session id (Claude Code, Codex,
+        // Gemini, etc.) so repeated hook posts route to the same row.
+        conn.execute(
+            "INSERT OR IGNORE INTO sessions (id, agent, project, started_at, updated_at, metadata)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![id, agent, project, now, now, metadata.unwrap_or("{}")],
+        )
+        .map_err(db_err)?;
+        Ok(id.to_string())
+    }
+
     fn list_sessions(&self, project: Option<&str>, limit: usize) -> IcmResult<Vec<Session>> {
         let conn = &self.conn;
         match project {
@@ -6072,6 +6093,89 @@ mod tests {
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].content, "hello world");
         assert_eq!(msgs[0].role, Role::User);
+    }
+
+    /// Issue #272 perf invariant: FTS5 search across a few thousand
+    /// archived messages must stay sub-second. The bench keeps the
+    /// budget loose so CI noise doesn't flake; the goal is a regression
+    /// bell, not microbenchmarking.
+    #[test]
+    fn perf_session_archive_search_2k_messages() {
+        let store = test_store();
+        let sid = store
+            .ensure_session("perf-sess", "claude-code", Some("icm"), None)
+            .unwrap();
+        for i in 0..2_000 {
+            // Sprinkle the keyword into ~1% of messages so search
+            // returns something but doesn't degenerate to a full scan.
+            let body = if i % 100 == 0 {
+                format!("turbofish needle hit {i}")
+            } else {
+                format!("filler payload number {i}")
+            };
+            store
+                .record_message(&sid, Role::User, &body, None, None, None)
+                .unwrap();
+        }
+        let start = std::time::Instant::now();
+        let hits = store
+            .search_transcripts("turbofish", None, None, 50)
+            .unwrap();
+        let elapsed = start.elapsed();
+        assert!(
+            hits.len() >= 10,
+            "expected at least 10 hits, got {}",
+            hits.len()
+        );
+        assert!(
+            elapsed.as_millis() < 1500,
+            "search across 2k archived messages took {}ms (budget 1500ms)",
+            elapsed.as_millis(),
+        );
+    }
+
+    /// Issue #272: `ensure_session` must be idempotent so repeated
+    /// hook fires keyed by the same external `session_id` land under
+    /// one row, not N.
+    #[test]
+    fn test_ensure_session_is_idempotent() {
+        let store = test_store();
+        let external_id = "claude-sess-abc-123";
+        let id1 = store
+            .ensure_session(external_id, "claude-code", Some("icm"), None)
+            .unwrap();
+        assert_eq!(id1, external_id);
+
+        // Re-call with the same id — must NOT create a new row.
+        let id2 = store
+            .ensure_session(external_id, "claude-code", Some("icm"), None)
+            .unwrap();
+        assert_eq!(id2, external_id);
+
+        let sessions = store.list_sessions(Some("icm"), 10).unwrap();
+        assert_eq!(
+            sessions.len(),
+            1,
+            "ensure_session must be idempotent, got: {sessions:?}",
+        );
+        assert_eq!(sessions[0].id, external_id);
+
+        // Recording into the same id works.
+        store
+            .record_message(external_id, Role::User, "first turn", None, None, None)
+            .unwrap();
+        store
+            .record_message(
+                external_id,
+                Role::Tool,
+                "tool out",
+                Some("bash"),
+                None,
+                None,
+            )
+            .unwrap();
+        let msgs = store.list_session_messages(external_id, 10, 0).unwrap();
+        assert_eq!(msgs.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- New opt-in `[archive]` config block. When `enabled = true`, the `hook prompt` and `hook post` paths tee every user message and tool output into the existing FTS5-indexed `sessions`/`messages` tables.
- Events are keyed by the host agent's session id (Claude Code / Codex / Gemini), via a new idempotent `TranscriptStore::ensure_session(id, …)` method — re-fires within one conversation land under a single row.
- New `icm sessions {search,list,show,stats,forget}` CLI: UX-friendly entry point that delegates to the existing transcript handlers.

## Why
Closes #272. ICM currently persists only *extracted* memories; if extraction misses something it's gone. Peer agent-memory systems (Hermes `session_search`, OpenClaw LCM) keep the full conversation in an FTS-indexed store as the lossless fallback. The infrastructure was already in place (`crates/icm-core/src/transcript_store.rs`, FTS5 schema, 5 MCP tools); this PR wires the hook ingestion.

Retention policy and secret scrubbing are tracked as open questions in the issue — landing this behind an opt-in switch keeps the door open for those follow-ups without forcing them now. Default: `enabled = false`.

## Public API
- `TranscriptStore::ensure_session(id, agent, project, metadata)` — idempotent insert (`INSERT OR IGNORE`).
- `crate::config::ArchiveConfig { enabled, max_bytes_per_event }`, default 32 KB per event.
- `icm sessions {search,list,show,stats,forget}` CLI surface.

## Test plan
- [x] `test_ensure_session_is_idempotent` in icm-store: same external id → 1 row across repeated calls.
- [x] 10 unit tests in `crates/icm-cli/src/archive.rs`: cap_bytes multibyte boundaries; session id from stdin / transcript_path / absent; record_event noop-when-disabled, skip-when-no-id, persist-under-external-id, truncation at byte cap.
- [x] `perf_session_archive_search_2k_messages`: FTS5 latency over 2k archived messages — debug budget 1500ms; release: <100ms.
- [x] End-to-end smoke (release binary, `[archive].enabled = true`): `hook post` and `hook prompt` archive under `sess-001`; `icm sessions list` returns the row; `icm sessions search bash`/`snapshot` returns verbatim content; `icm sessions show sess-001` replays chronologically.
- [x] `cargo test --workspace` green (537 tests).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)