### PR TITLE
feat(facts): structured (entity, key, value) layer with supersession (closes #273)

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -190,6 +190,15 @@ enum Commands {
         topic: Option<String>,
     },
 
+    /// Structured-facts subcommands (issue #273) — exact (entity, key,
+    /// value) lookup distinct from semantic recall. `set` on an
+    /// existing key supersedes the previous value while keeping the
+    /// history.
+    Facts {
+        #[command(subcommand)]
+        command: FactsCommands,
+    },
+
     /// Feedback subcommands — record and search prediction corrections
     Feedback {
         #[command(subcommand)]
@@ -842,6 +851,51 @@ enum MemoirCommands {
 }
 
 #[derive(Subcommand)]
+enum FactsCommands {
+    /// Set a fact: `entity.key = value`. If a row already exists for
+    /// the same `(entity, key)` and its value differs, the previous
+    /// row is marked `superseded_at = now` (history retained) and a
+    /// new active row is inserted.
+    Set {
+        /// Entity (e.g. "project:icm", "host:db-prod-1", "service:api")
+        entity: String,
+        /// Key (e.g. "gcp.project", "version", "owner")
+        key: String,
+        /// Value to set
+        value: String,
+        /// Where this fact came from (optional)
+        #[arg(short, long, default_value = "cli")]
+        source: String,
+    },
+
+    /// Get the active value for `entity.key`. Exits 1 if absent.
+    Get {
+        /// Entity to look up
+        entity: String,
+        /// Key to look up
+        key: String,
+    },
+
+    /// List active facts for an entity (optionally prefix-filtered).
+    List {
+        /// Entity to enumerate
+        entity: String,
+        /// Optional key prefix (e.g. "gcp." or "deploy.")
+        #[arg(short, long)]
+        prefix: Option<String>,
+    },
+
+    /// Show the supersession history for an `(entity, key)` slot.
+    History { entity: String, key: String },
+
+    /// Delete every row (active + history) for an `(entity, key)` slot.
+    Forget { entity: String, key: String },
+
+    /// Global facts statistics.
+    Stats,
+}
+
+#[derive(Subcommand)]
 enum FeedbackCommands {
     /// Record a prediction correction (what AI predicted vs what was correct)
     Record {
@@ -1362,6 +1416,21 @@ fn main() -> Result<()> {
             cmd_update(&store, emb_ref, &id, content, importance, keywords)
         }
         Commands::Health { topic } => cmd_health(&store, topic.as_deref()),
+        Commands::Facts { command } => match command {
+            FactsCommands::Set {
+                entity,
+                key,
+                value,
+                source,
+            } => cmd_facts_set(&store, &entity, &key, &value, &source),
+            FactsCommands::Get { entity, key } => cmd_facts_get(&store, &entity, &key),
+            FactsCommands::List { entity, prefix } => {
+                cmd_facts_list(&store, &entity, prefix.as_deref())
+            }
+            FactsCommands::History { entity, key } => cmd_facts_history(&store, &entity, &key),
+            FactsCommands::Forget { entity, key } => cmd_facts_forget(&store, &entity, &key),
+            FactsCommands::Stats => cmd_facts_stats(&store),
+        },
         Commands::Feedback { command } => match command {
             FeedbackCommands::Record {
                 topic,
@@ -3517,6 +3586,117 @@ fn cmd_stats(store: &SqliteStore) -> Result<()> {
     }
     if let Some(newest) = stats.newest_memory {
         println!("Newest:    {}", format_local(&newest, "%Y-%m-%d %H:%M"));
+    }
+    Ok(())
+}
+
+fn cmd_facts_set(
+    store: &SqliteStore,
+    entity: &str,
+    key: &str,
+    value: &str,
+    source: &str,
+) -> Result<()> {
+    use icm_core::FactsStore;
+    let prev = store.get_fact(entity, key)?;
+    let id = store.set_fact(entity, key, value, source)?;
+    match prev {
+        Some(p) if p.value == value => {
+            println!("unchanged: {entity}.{key} = {value} (id={id})");
+        }
+        Some(p) => {
+            println!(
+                "superseded: {entity}.{key}: \"{old}\" -> \"{new}\" (id={id})",
+                old = p.value,
+                new = value,
+            );
+        }
+        None => {
+            println!("set: {entity}.{key} = {value} (id={id})");
+        }
+    }
+    Ok(())
+}
+
+fn cmd_facts_get(store: &SqliteStore, entity: &str, key: &str) -> Result<()> {
+    use icm_core::FactsStore;
+    match store.get_fact(entity, key)? {
+        Some(f) => {
+            println!("{}", f.value);
+            eprintln!(
+                "  source: {} | created: {} | id: {}",
+                f.source,
+                format_local(&f.created_at, "%Y-%m-%d %H:%M"),
+                f.id,
+            );
+            Ok(())
+        }
+        None => {
+            eprintln!("no active fact for {entity}.{key}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn cmd_facts_list(store: &SqliteStore, entity: &str, prefix: Option<&str>) -> Result<()> {
+    use icm_core::FactsStore;
+    let facts = store.list_facts(entity, prefix)?;
+    if facts.is_empty() {
+        println!("no facts for {entity}");
+        return Ok(());
+    }
+    println!("{:<32} value", "key");
+    println!("{}", "-".repeat(60));
+    for f in &facts {
+        println!("{:<32} {}", f.key, f.value);
+    }
+    Ok(())
+}
+
+fn cmd_facts_history(store: &SqliteStore, entity: &str, key: &str) -> Result<()> {
+    use icm_core::FactsStore;
+    let rows = store.history(entity, key)?;
+    if rows.is_empty() {
+        println!("no history for {entity}.{key}");
+        return Ok(());
+    }
+    println!("history of {entity}.{key} (newest first):");
+    for f in &rows {
+        let status = match f.superseded_at {
+            None => "ACTIVE".to_string(),
+            Some(ts) => format!("superseded {}", format_local(&ts, "%Y-%m-%d %H:%M")),
+        };
+        println!(
+            "  {} | {} | {} | from {} | {}",
+            f.id,
+            format_local(&f.created_at, "%Y-%m-%d %H:%M"),
+            status,
+            f.source,
+            f.value,
+        );
+    }
+    Ok(())
+}
+
+fn cmd_facts_forget(store: &SqliteStore, entity: &str, key: &str) -> Result<()> {
+    use icm_core::FactsStore;
+    let n = store.forget_fact(entity, key)?;
+    println!("forgot {n} row(s) under {entity}.{key}");
+    Ok(())
+}
+
+fn cmd_facts_stats(store: &SqliteStore) -> Result<()> {
+    use icm_core::FactsStore;
+    let s = store.facts_stats()?;
+    println!("Active facts:    {}", s.active_count);
+    println!("Total rows:      {} (history kept)", s.total_count);
+    println!("Distinct entities: {}", s.distinct_entities);
+    if !s.top_entities.is_empty() {
+        println!();
+        println!("Top entities:");
+        for (entity, n) in &s.top_entities {
+            println!("  {entity:<30} {n}");
+        }
     }
     Ok(())
 }

--- a/crates/icm-core/src/facts.rs
+++ b/crates/icm-core/src/facts.rs
@@ -1,0 +1,83 @@
+//! Structured facts layer (issue #273).
+//!
+//! Flat `(entity, key, value)` tuples for **exact** lookup, distinct
+//! from the curated `Memory` (semantic recall) and the verbatim
+//! `Transcript` (archived conversation) layers.
+//!
+//! Why a third layer:
+//! - Semantic recall is probabilistic — vector + BM25 ranking can
+//!   miss or down-rank the right answer when the query is sharp
+//!   ("which GCP secret for X", "what host is Z on").
+//! - `facts` answers those questions with a primary-key lookup,
+//!   under 1ms even at 10k+ rows.
+//!
+//! Supersession: each fact carries `superseded_at`. An update
+//! marks the previous row superseded and inserts a new active row
+//! under the same `(entity, key)`. This gives ICM a first-class
+//! place for "fact changed" (vs. dedup, which is "same fact stated
+//! twice") — the issue calls this out as a bonus motivator.
+//!
+//! Scope (per issue): this PR ships schema + CRUD + CLI. Auto-
+//! population from extraction and entity-resolution heuristics are
+//! deferred to follow-up RFCs.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A single structured fact.
+///
+/// The composite identity is `(entity, key)` — `id` is just a row
+/// handle for the CLI / API to reference. Active facts have
+/// `superseded_at = None`; supersession-history rows carry the
+/// timestamp of the override.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Fact {
+    pub id: String,
+    pub entity: String,
+    pub key: String,
+    pub value: String,
+    /// Free-form provenance label (e.g. "user", "extraction:hook",
+    /// "import:foo.yaml"). Surfaces in `icm facts get` so the user
+    /// can see where a value came from.
+    pub source: String,
+    pub created_at: DateTime<Utc>,
+    /// `None` while active; set to the override timestamp when a
+    /// newer fact takes over the same `(entity, key)`.
+    pub superseded_at: Option<DateTime<Utc>>,
+}
+
+impl Fact {
+    /// Construct an active fact (`superseded_at = None`).
+    #[must_use]
+    pub fn new(entity: String, key: String, value: String, source: String) -> Self {
+        Self {
+            id: ulid::Ulid::new().to_string(),
+            entity,
+            key,
+            value,
+            source,
+            created_at: Utc::now(),
+            superseded_at: None,
+        }
+    }
+
+    /// True iff the fact is currently the active value for its
+    /// `(entity, key)` slot.
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        self.superseded_at.is_none()
+    }
+}
+
+/// Aggregate stats for the facts store.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FactsStats {
+    /// Distinct `(entity, key)` pairs with an active row.
+    pub active_count: usize,
+    /// Total rows including superseded history.
+    pub total_count: usize,
+    /// Distinct entities with at least one active fact.
+    pub distinct_entities: usize,
+    /// Top entities by active fact count, descending.
+    pub top_entities: Vec<(String, usize)>,
+}

--- a/crates/icm-core/src/facts_store.rs
+++ b/crates/icm-core/src/facts_store.rs
@@ -1,0 +1,41 @@
+//! Storage trait for the structured-facts layer.
+
+use crate::error::IcmResult;
+use crate::facts::{Fact, FactsStats};
+
+/// Read/write API for the `facts` table.
+///
+/// Implementations enforce one **active** row per `(entity, key)` slot:
+/// [`set_fact`] either inserts a new row or supersedes any existing
+/// active one. [`get_fact`] returns the active row only;
+/// [`history`] returns the full chain of supersessions for an audit
+/// trail.
+pub trait FactsStore {
+    /// Insert or supersede: if an active row exists for the same
+    /// `(entity, key)` and its `value` differs, mark it superseded
+    /// now and insert a new active row carrying the new value.
+    /// If `value` is unchanged, the call is a no-op (returns the
+    /// existing row's id). Returns the active row's id after the
+    /// operation.
+    fn set_fact(&self, entity: &str, key: &str, value: &str, source: &str) -> IcmResult<String>;
+
+    /// Return the active fact for `(entity, key)`, or `None` if no
+    /// row matches or the most-recent row was forgotten.
+    fn get_fact(&self, entity: &str, key: &str) -> IcmResult<Option<Fact>>;
+
+    /// List **active** facts for an entity, optionally filtered to
+    /// keys with the given prefix. Keys are returned alphabetically
+    /// so output is stable across runs.
+    fn list_facts(&self, entity: &str, key_prefix: Option<&str>) -> IcmResult<Vec<Fact>>;
+
+    /// List the full supersession history for `(entity, key)`,
+    /// newest first. Useful for "when did the value change?"
+    /// audits.
+    fn history(&self, entity: &str, key: &str) -> IcmResult<Vec<Fact>>;
+
+    /// Hard-delete every row (active + history) for `(entity, key)`.
+    fn forget_fact(&self, entity: &str, key: &str) -> IcmResult<usize>;
+
+    /// Aggregate stats for the `icm facts stats` command.
+    fn facts_stats(&self) -> IcmResult<FactsStats>;
+}

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -2,6 +2,8 @@ pub mod auto_link;
 pub mod context_snapshot;
 pub mod embedder;
 pub mod error;
+pub mod facts;
+pub mod facts_store;
 #[cfg(feature = "embeddings")]
 pub mod fastembed_embedder;
 pub mod feedback;
@@ -25,6 +27,8 @@ pub use context_snapshot::{
 };
 pub use embedder::Embedder;
 pub use error::{IcmError, IcmResult};
+pub use facts::{Fact, FactsStats};
+pub use facts_store::FactsStore;
 #[cfg(feature = "embeddings")]
 pub use fastembed_embedder::FastEmbedder;
 pub use feedback::{Feedback, FeedbackStats};

--- a/crates/icm-store/src/schema.rs
+++ b/crates/icm-store/src/schema.rs
@@ -269,6 +269,30 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
         .map_err(db_err)?;
     }
 
+    // Structured facts (issue #273): one row per `(entity, key,
+    // created_at)`. The unique index keyed on `(entity, key)` filtered
+    // by `superseded_at IS NULL` enforces "at most one active row
+    // per slot" at the DB layer — supersession is handled by the
+    // app via `UPDATE … SET superseded_at = …` followed by `INSERT`.
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS facts (
+            id TEXT PRIMARY KEY,
+            entity TEXT NOT NULL,
+            key TEXT NOT NULL,
+            value TEXT NOT NULL,
+            source TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL,
+            superseded_at TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_facts_entity ON facts(entity);
+        CREATE INDEX IF NOT EXISTS idx_facts_entity_key ON facts(entity, key);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_facts_active_unique
+            ON facts(entity, key) WHERE superseded_at IS NULL;
+        ",
+    )
+    .map_err(db_err)?;
+
     // Transcripts (verbatim sessions + messages)
     conn.execute_batch(
         "

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -10,10 +10,10 @@ use sha2::{Digest, Sha256};
 use zerocopy::IntoBytes;
 
 use icm_core::{
-    Concept, ConceptLink, Embedder, Feedback, FeedbackStats, FeedbackStore, IcmError, IcmResult,
-    Importance, Label, Memoir, MemoirStats, MemoirStore, Memory, MemorySource, MemoryStore,
-    Message, PatternCluster, Relation, Role, Session, StoreStats, TopicHealth, TranscriptHit,
-    TranscriptStats, TranscriptStore,
+    Concept, ConceptLink, Embedder, Fact, FactsStats, FactsStore, Feedback, FeedbackStats,
+    FeedbackStore, IcmError, IcmResult, Importance, Label, Memoir, MemoirStats, MemoirStore,
+    Memory, MemorySource, MemoryStore, Message, PatternCluster, Relation, Role, Session,
+    StoreStats, TopicHealth, TranscriptHit, TranscriptStats, TranscriptStore,
 };
 
 use crate::schema::init_db_with_dims;
@@ -2394,6 +2394,215 @@ impl FeedbackStore for SqliteStore {
             total,
             by_topic,
             most_applied,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Structured facts (issue #273)
+// ---------------------------------------------------------------------------
+
+fn row_to_fact(row: &rusqlite::Row<'_>) -> rusqlite::Result<Fact> {
+    let created_at: String = row.get("created_at")?;
+    let superseded_at: Option<String> = row.get("superseded_at")?;
+    Ok(Fact {
+        id: row.get("id")?,
+        entity: row.get("entity")?,
+        key: row.get("key")?,
+        value: row.get("value")?,
+        source: row.get("source")?,
+        created_at: chrono::DateTime::parse_from_rfc3339(&created_at)
+            .map(|d| d.with_timezone(&chrono::Utc))
+            .unwrap_or_else(|_| chrono::Utc::now()),
+        superseded_at: superseded_at.and_then(|s| {
+            chrono::DateTime::parse_from_rfc3339(&s)
+                .ok()
+                .map(|d| d.with_timezone(&chrono::Utc))
+        }),
+    })
+}
+
+impl FactsStore for SqliteStore {
+    fn set_fact(&self, entity: &str, key: &str, value: &str, source: &str) -> IcmResult<String> {
+        if entity.is_empty() || key.is_empty() {
+            return Err(IcmError::InvalidInput(
+                "entity and key must be non-empty".into(),
+            ));
+        }
+        let conn = &self.conn;
+        // Active row lookup
+        let existing: Option<(String, String)> = conn
+            .query_row(
+                "SELECT id, value FROM facts
+                 WHERE entity = ?1 AND key = ?2 AND superseded_at IS NULL",
+                params![entity, key],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()
+            .map_err(db_err)?;
+
+        if let Some((id, current_value)) = existing {
+            if current_value == value {
+                // No-op: same value re-asserted.
+                return Ok(id);
+            }
+            let now = chrono::Utc::now().to_rfc3339();
+            conn.execute(
+                "UPDATE facts SET superseded_at = ?1 WHERE id = ?2",
+                params![now, id],
+            )
+            .map_err(db_err)?;
+        }
+
+        let new = Fact::new(
+            entity.to_string(),
+            key.to_string(),
+            value.to_string(),
+            source.to_string(),
+        );
+        conn.execute(
+            "INSERT INTO facts (id, entity, key, value, source, created_at, superseded_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL)",
+            params![
+                new.id,
+                new.entity,
+                new.key,
+                new.value,
+                new.source,
+                new.created_at.to_rfc3339(),
+            ],
+        )
+        .map_err(db_err)?;
+        Ok(new.id)
+    }
+
+    fn get_fact(&self, entity: &str, key: &str) -> IcmResult<Option<Fact>> {
+        let conn = &self.conn;
+        let row = conn
+            .query_row(
+                "SELECT id, entity, key, value, source, created_at, superseded_at
+                 FROM facts
+                 WHERE entity = ?1 AND key = ?2 AND superseded_at IS NULL",
+                params![entity, key],
+                row_to_fact,
+            )
+            .map(Some)
+            .or_else(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                other => Err(db_err(other)),
+            })?;
+        Ok(row)
+    }
+
+    fn list_facts(&self, entity: &str, key_prefix: Option<&str>) -> IcmResult<Vec<Fact>> {
+        let conn = &self.conn;
+        let rows = match key_prefix {
+            Some(prefix) if !prefix.is_empty() => {
+                let mut stmt = conn
+                    .prepare(
+                        "SELECT id, entity, key, value, source, created_at, superseded_at
+                         FROM facts
+                         WHERE entity = ?1 AND key LIKE ?2 AND superseded_at IS NULL
+                         ORDER BY key ASC",
+                    )
+                    .map_err(db_err)?;
+                let pattern = format!("{prefix}%");
+                let rows = stmt
+                    .query_map(params![entity, pattern], row_to_fact)
+                    .map_err(db_err)?;
+                rows.collect::<Result<Vec<_>, _>>().map_err(db_err)?
+            }
+            _ => {
+                let mut stmt = conn
+                    .prepare(
+                        "SELECT id, entity, key, value, source, created_at, superseded_at
+                         FROM facts
+                         WHERE entity = ?1 AND superseded_at IS NULL
+                         ORDER BY key ASC",
+                    )
+                    .map_err(db_err)?;
+                let rows = stmt
+                    .query_map(params![entity], row_to_fact)
+                    .map_err(db_err)?;
+                rows.collect::<Result<Vec<_>, _>>().map_err(db_err)?
+            }
+        };
+        Ok(rows)
+    }
+
+    fn history(&self, entity: &str, key: &str) -> IcmResult<Vec<Fact>> {
+        let conn = &self.conn;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, entity, key, value, source, created_at, superseded_at
+                 FROM facts
+                 WHERE entity = ?1 AND key = ?2
+                 ORDER BY created_at DESC",
+            )
+            .map_err(db_err)?;
+        let rows = stmt
+            .query_map(params![entity, key], row_to_fact)
+            .map_err(db_err)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(db_err)
+    }
+
+    fn forget_fact(&self, entity: &str, key: &str) -> IcmResult<usize> {
+        let conn = &self.conn;
+        let n = conn
+            .execute(
+                "DELETE FROM facts WHERE entity = ?1 AND key = ?2",
+                params![entity, key],
+            )
+            .map_err(db_err)?;
+        Ok(n)
+    }
+
+    fn facts_stats(&self) -> IcmResult<FactsStats> {
+        let conn = &self.conn;
+        let active_count: usize = conn
+            .query_row(
+                "SELECT COUNT(*) FROM facts WHERE superseded_at IS NULL",
+                [],
+                |r| r.get::<_, i64>(0).map(|v| v as usize),
+            )
+            .map_err(db_err)?;
+        let total_count: usize = conn
+            .query_row("SELECT COUNT(*) FROM facts", [], |r| {
+                r.get::<_, i64>(0).map(|v| v as usize)
+            })
+            .map_err(db_err)?;
+        let distinct_entities: usize = conn
+            .query_row(
+                "SELECT COUNT(DISTINCT entity) FROM facts WHERE superseded_at IS NULL",
+                [],
+                |r| r.get::<_, i64>(0).map(|v| v as usize),
+            )
+            .map_err(db_err)?;
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT entity, COUNT(*) as n FROM facts
+                 WHERE superseded_at IS NULL
+                 GROUP BY entity
+                 ORDER BY n DESC
+                 LIMIT 10",
+            )
+            .map_err(db_err)?;
+        let rows = stmt
+            .query_map([], |row| {
+                let entity: String = row.get(0)?;
+                let n: i64 = row.get(1)?;
+                Ok((entity, n as usize))
+            })
+            .map_err(db_err)?;
+        let top_entities: Vec<(String, usize)> =
+            rows.collect::<Result<Vec<_>, _>>().map_err(db_err)?;
+
+        Ok(FactsStats {
+            active_count,
+            total_count,
+            distinct_entities,
+            top_entities,
         })
     }
 }
@@ -6131,6 +6340,167 @@ mod tests {
             elapsed.as_millis() < 1500,
             "search across 2k archived messages took {}ms (budget 1500ms)",
             elapsed.as_millis(),
+        );
+    }
+
+    // === FactsStore tests (issue #273) ===
+
+    #[test]
+    fn test_facts_set_and_get_roundtrip() {
+        let store = test_store();
+        let id = store
+            .set_fact("project:icm", "gcp.project", "rtk-ai-labs-01", "cli")
+            .unwrap();
+        assert!(!id.is_empty());
+
+        let f = store
+            .get_fact("project:icm", "gcp.project")
+            .unwrap()
+            .expect("active fact must exist");
+        assert_eq!(f.value, "rtk-ai-labs-01");
+        assert_eq!(f.source, "cli");
+        assert!(f.is_active());
+    }
+
+    #[test]
+    fn test_facts_set_same_value_is_noop() {
+        let store = test_store();
+        let id1 = store.set_fact("e", "k", "v", "src").unwrap();
+        let id2 = store.set_fact("e", "k", "v", "src2").unwrap();
+        assert_eq!(id1, id2, "same value re-asserted must NOT create a new row");
+        let history = store.history("e", "k").unwrap();
+        assert_eq!(history.len(), 1);
+        // Source is NOT updated by the no-op (intentional: avoids
+        // creating noise just because the same fact was re-asserted
+        // from a different surface).
+        assert_eq!(history[0].source, "src");
+    }
+
+    #[test]
+    fn test_facts_supersede_keeps_history() {
+        let store = test_store();
+        let id1 = store
+            .set_fact("project:icm", "version", "0.10.51", "release-please")
+            .unwrap();
+        let id2 = store
+            .set_fact("project:icm", "version", "0.10.52", "release-please")
+            .unwrap();
+        assert_ne!(id1, id2);
+
+        let active = store
+            .get_fact("project:icm", "version")
+            .unwrap()
+            .expect("active fact must exist after supersession");
+        assert_eq!(active.value, "0.10.52");
+        assert!(active.is_active());
+
+        let history = store.history("project:icm", "version").unwrap();
+        assert_eq!(history.len(), 2);
+        // History returned newest-first.
+        assert_eq!(history[0].value, "0.10.52");
+        assert!(history[0].is_active());
+        assert_eq!(history[1].value, "0.10.51");
+        assert!(!history[1].is_active(), "older row must be superseded");
+    }
+
+    #[test]
+    fn test_facts_list_by_entity_alpha_sorted() {
+        let store = test_store();
+        store
+            .set_fact("host:db", "owner", "ops-team", "cli")
+            .unwrap();
+        store
+            .set_fact("host:db", "deploy.region", "europe-west1", "cli")
+            .unwrap();
+        store.set_fact("host:db", "cpu.cores", "16", "cli").unwrap();
+        store
+            .set_fact("host:web", "owner", "ui-team", "cli")
+            .unwrap();
+
+        let all = store.list_facts("host:db", None).unwrap();
+        let keys: Vec<&str> = all.iter().map(|f| f.key.as_str()).collect();
+        assert_eq!(keys, vec!["cpu.cores", "deploy.region", "owner"]);
+        // Other entity NOT included.
+        assert!(all.iter().all(|f| f.entity == "host:db"));
+    }
+
+    #[test]
+    fn test_facts_list_prefix_filter() {
+        let store = test_store();
+        store
+            .set_fact("svc:api", "deploy.region", "europe-west1", "cli")
+            .unwrap();
+        store
+            .set_fact("svc:api", "deploy.replicas", "3", "cli")
+            .unwrap();
+        store
+            .set_fact("svc:api", "owner", "platform-team", "cli")
+            .unwrap();
+
+        let deploys = store.list_facts("svc:api", Some("deploy.")).unwrap();
+        assert_eq!(deploys.len(), 2);
+        assert!(deploys.iter().all(|f| f.key.starts_with("deploy.")));
+    }
+
+    #[test]
+    fn test_facts_forget_drops_history_too() {
+        let store = test_store();
+        store.set_fact("e", "k", "v1", "cli").unwrap();
+        store.set_fact("e", "k", "v2", "cli").unwrap();
+        let n = store.forget_fact("e", "k").unwrap();
+        assert_eq!(n, 2, "must delete both active and superseded rows");
+        assert!(store.get_fact("e", "k").unwrap().is_none());
+        assert!(store.history("e", "k").unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_facts_stats_breakdown() {
+        let store = test_store();
+        store.set_fact("e1", "a", "1", "cli").unwrap();
+        store.set_fact("e1", "b", "2", "cli").unwrap();
+        store.set_fact("e2", "a", "3", "cli").unwrap();
+        // Supersede e1.a — history grows, active stays the same.
+        store.set_fact("e1", "a", "1-bis", "cli").unwrap();
+
+        let stats = store.facts_stats().unwrap();
+        assert_eq!(stats.active_count, 3, "3 active slots");
+        assert_eq!(stats.total_count, 4, "4 rows including superseded");
+        assert_eq!(stats.distinct_entities, 2);
+        let top: Vec<&str> = stats.top_entities.iter().map(|(e, _)| e.as_str()).collect();
+        assert!(top.contains(&"e1") && top.contains(&"e2"));
+    }
+
+    #[test]
+    fn test_facts_rejects_empty_entity_or_key() {
+        let store = test_store();
+        assert!(store.set_fact("", "k", "v", "cli").is_err());
+        assert!(store.set_fact("e", "", "v", "cli").is_err());
+    }
+
+    /// Issue #273 perf invariant: primary-key lookup must stay
+    /// sub-millisecond even at 10k facts. Loose budget so CI runners
+    /// don't flake.
+    #[test]
+    fn perf_facts_get_at_10k_under_5ms() {
+        let store = test_store();
+        for i in 0..10_000 {
+            let entity = format!("entity:{}", i % 100);
+            let key = format!("key.{i}");
+            store
+                .set_fact(&entity, &key, &format!("val-{i}"), "bench")
+                .unwrap();
+        }
+        let start = std::time::Instant::now();
+        for _ in 0..1_000 {
+            let _ = store.get_fact("entity:42", "key.42").unwrap();
+        }
+        let elapsed = start.elapsed();
+        let per_lookup_us = elapsed.as_micros() / 1_000;
+        // 5ms / lookup in debug mode — generous; release is well
+        // under 1ms.
+        assert!(
+            per_lookup_us < 5_000,
+            "facts.get averaged {per_lookup_us}us / lookup over 1k iters (budget 5000us)",
         );
     }
 


### PR DESCRIPTION
## Summary
- New `facts` table keyed by `(entity, key)` — primary-key lookup for exact factual questions ("which GCP project for X", "what host is Z on"), distinct from semantic recall (probabilistic) and the transcript archive (lossless/unranked).
- Supersession as a first-class concept: updating a fact marks the previous row `superseded_at = now` and inserts a new active row. `icm facts history` shows the full chain. This gives ICM a home for "fact changed" — orthogonal to dedup ("same fact stated twice").
- `icm_core::FactsStore` trait with set / get / list / history / forget / stats.
- `icm facts {set,get,list,history,forget,stats}` CLI surface.
- SQLite schema with `UNIQUE INDEX … WHERE superseded_at IS NULL` so the "one active row per slot" invariant is enforced at the DB layer.

## Scope (per issue)
This is the MVP. The issue flagged the full direction as RFC + phased. Landing now:
- Schema + CRUD + CLI.

Deferred to follow-up RFCs (will reference back):
- Auto-population from extraction (hook pipeline).
- Entity-resolution heuristics / normalization.
- Trust/confidence scoring.
- FTS5 index over `value` (the lookup path is keyed; FTS over values is a search-experience add-on, not blocking).

## Test plan
- [x] 9 unit tests in icm-store covering set/get/list/history/forget/stats + the empty-input rejection branch + supersession.
- [x] `perf_facts_get_at_10k_under_5ms`: debug budget 5ms/lookup; release: well under 1ms.
- [x] End-to-end smoke (release binary, fake HOME): `set` creates, second `set` with different value emits "superseded: old -> new", third with identical value emits "unchanged"; `history` shows the chain with timestamps + ACTIVE / superseded status; `get` returns the active value with provenance on stderr; `stats` breaks down active vs total + top entities.
- [x] Process-level `icm facts get` averaged ~5ms/call over 100 reps (process spawn + DB open dominate; in-process lookup is sub-ms per the bench).
- [x] `cargo test --workspace` green (546 tests).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)