### PR TITLE
fix(install): robust CPU detection on Windows PowerShell (closes #289)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -20,10 +20,46 @@ $Repo = "rtk-ai/icm"
 $BinaryName = "icm"
 
 function Get-Arch {
-    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-    switch ($arch) {
+    # Resolution order:
+    #   1. $env:PROCESSOR_ARCHITECTURE  — set on every Windows since
+    #      forever; cheapest and survives the PowerShell-5 +
+    #      old-.NET-Framework path where `RuntimeInformation`
+    #      sometimes stringifies to "" inside switch comparisons
+    #      (issue #289 report).
+    #   2. RuntimeInformation.OSArchitecture, explicitly ToString()'d
+    #      so the switch comparison sees a string, not an enum value
+    #      that needs implicit conversion.
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    if (-not $arch) {
+        try {
+            $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+        } catch {
+            $arch = ""
+        }
+    }
+    # WOW64: 32-bit PowerShell on 64-bit Windows exposes
+    # PROCESSOR_ARCHITECTURE=x86 plus PROCESSOR_ARCHITEW6432=AMD64.
+    # Honor the latter so the user still installs the native binary.
+    if ($arch -eq "x86" -and $env:PROCESSOR_ARCHITEW6432) {
+        $arch = $env:PROCESSOR_ARCHITEW6432
+    }
+    switch ($arch.ToUpperInvariant()) {
+        "AMD64" { return "x86_64" }
         "X64"   { return "x86_64" }
-        default { throw "Unsupported architecture: $arch. Only x86_64 is supported on Windows." }
+        "ARM64" {
+            throw ("ARM64 Windows isn't pre-built yet. Build from source: " +
+                   "https://github.com/$Repo#install (cargo install --path crates/icm-cli).")
+        }
+        ""      {
+            throw ("Could not detect CPU architecture (PROCESSOR_ARCHITECTURE and " +
+                   "RuntimeInformation.OSArchitecture both empty). Open an issue at " +
+                   "https://github.com/$Repo/issues with the output of `$PSVersionTable` " +
+                   "so we can investigate.")
+        }
+        default {
+            throw ("Unsupported architecture: '$arch'. Only x86_64 is pre-built on Windows. " +
+                   "Build from source: cargo install --path crates/icm-cli.")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- The Windows installer rejected every host with `Unsupported architecture: . Only x86_64 is supported on Windows.` — the trailing dot after the colon is the giveaway: `\$arch` was empty when the switch ran.
- Root cause: `Get-Arch` switched on the raw `RuntimeInformation.OSArchitecture` enum value, expecting the string `"X64"`. On Windows PowerShell 5.x with older .NET Framework, that enum doesn't implicitly stringify the way the PS-7 path does, so the switch falls through default with an empty `\$arch`.
- Fix: resolve from `\$env:PROCESSOR_ARCHITECTURE` first (set on every Windows since forever, reliable across PS 5/7 and any .NET), then fall back to `RuntimeInformation.OSArchitecture.ToString()` with explicit conversion. Honor `PROCESSOR_ARCHITEW6432` so 32-bit PowerShell on 64-bit hosts (WOW64) still installs the native AMD64 binary. Detect ARM64 with a clear "not pre-built yet, build from source" error instead of the generic message.

## Why
Closes #289. The user (`ohelleu`) hit this on Windows Pro and tried the install via `irm | iex` then via `cargo install --path` from PowerShell, then again from MinGW64 bash — only the first failure was on our side; the other two are environment-side (Schannel cert chain, MinGW link.exe). This PR fixes the only thing we control.

## Public behavior change
None for the install path itself — same binary, same checksum verification. Only the detection branch ahead of it.

## Test plan
- [x] Reviewed switch semantics across PowerShell 5.1 (Windows-bundled) and 7.x (cross-platform): `\$env:PROCESSOR_ARCHITECTURE` is set on every Windows and stringifies natively; `ToUpperInvariant` is available on every .NET Framework / .NET 5+ string.
- [x] WOW64 case handled: 32-bit PS on 64-bit host sees `PROCESSOR_ARCHITECTURE=x86` but `PROCESSOR_ARCHITEW6432=AMD64`; we honor the latter so the user gets the native binary.
- [ ] CI Windows job pre-merge confirms the script parses (no syntax regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)