### PR TITLE
fix(init): Codex PostToolUse is opt-in to avoid 14k-event-per-day noise (closes #288)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Configures **18 tools** in one command ([full integration guide](docs/integratio
 | Claude Code | `~/.claude.json` | 5 hooks | `CLAUDE.md` | `/recall` `/remember` |
 | Claude Desktop | JSON | — | — | — |
 | Gemini CLI | `~/.gemini/settings.json` | 5 hooks | `GEMINI.md` | — |
-| Codex CLI | `~/.codex/config.toml` | 4 hooks | `AGENTS.md` | — |
+| Codex CLI | `~/.codex/config.toml` | 3 hooks (PostToolUse opt-in, see #288) | `AGENTS.md` | — |
 | Copilot CLI | `~/.copilot/mcp-config.json` | 4 hooks | `.github/copilot-instructions.md` | — |
 | Cursor | `~/.cursor/mcp.json` | — | — | `.mdc` rule |
 | Windsurf | JSON | — | `.windsurfrules` | — |
@@ -191,7 +191,7 @@ Installs auto-extraction and auto-recall hooks for all supported tools:
 |------|:-----------:|:-------:|:--------:|:-------:|:------------:|--------|
 | Claude Code | `icm hook start` | `icm hook pre` | `icm hook post` | `icm hook compact` | `icm hook prompt` | `~/.claude/settings.json` |
 | Gemini CLI | `icm hook start` | `icm hook pre` | `icm hook post` | `icm hook compact` | `icm hook prompt` | `~/.gemini/settings.json` |
-| Codex CLI | `icm hook start` | `icm hook pre` | `icm hook post` | — | `icm hook prompt` | `~/.codex/hooks.json` |
+| Codex CLI | `icm hook start` | `icm hook pre` | `icm hook post`¹ | — | `icm hook prompt` | `~/.codex/hooks.json` |
 | Copilot CLI | `icm hook start` | `icm hook pre` | `icm hook post` | — | `icm hook prompt` | `.github/hooks/icm.json` |
 | OpenCode | session start | — | tool extract | compaction | — | `~/.config/opencode/plugins/icm.ts` |
 
@@ -204,6 +204,8 @@ Installs auto-extraction and auto-recall hooks for all supported tools:
 | `icm hook post` | Extract facts from tool output every N calls (auto-extraction) |
 | `icm hook compact` | Extract memories from transcript before context compression |
 | `icm hook prompt` | Inject recalled context at the start of each user prompt |
+
+¹ **Codex CLI PostToolUse is off by default.** Codex fires PostToolUse on every shell command — a session generates ~14k events / 24h, which floods the store with tool-output bloat (issue #288). Opt in with `icm init --with-codex-post-hook` if you want it; tune `[extraction]` first (`extract_every`, `min_score`, `store_raw = false`). MCP + `AGENTS.md` alone still let Codex save via the `icm_memory_store` tool.
 
 ## CLI vs MCP
 

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -375,6 +375,18 @@ enum Commands {
         /// doesn't pollute every project tree.
         #[arg(long)]
         per_project: bool,
+
+        /// Install the Codex CLI PostToolUse hook (`icm hook post`).
+        /// Off by default since Codex fires PostToolUse on every shell
+        /// command — a reasonable session generates ~14k events / 24h
+        /// (issue #288) and the auto-extracted memories are mostly
+        /// tool-output bloat (paths, patch snippets, help text). With
+        /// MCP + AGENTS.md alone, Codex still stores via the
+        /// `icm_memory_store` MCP tool. Opt in if you want PostToolUse
+        /// extraction on Codex anyway; tune `[extraction]` first
+        /// (`extract_every`, `min_score`, `store_raw=false`).
+        #[arg(long)]
+        with_codex_post_hook: bool,
     },
 
     /// Diagnose ICM integration: check hook binary paths in Claude Code settings
@@ -669,7 +681,8 @@ enum Commands {
         token: Option<String>,
     },
 
-    /// Claude Code hook handlers (read JSON from stdin, output hook response)
+    /// Hook handlers shared across Claude Code, Codex, Gemini, and
+    /// Copilot (read JSON from stdin, output hook response).
     Hook {
         #[command(subcommand)]
         command: HookCommands,
@@ -1774,7 +1787,8 @@ fn main() -> Result<()> {
             mode,
             force,
             per_project,
-        } => cmd_init(mode, force, per_project),
+            with_codex_post_hook,
+        } => cmd_init(mode, force, per_project, with_codex_post_hook),
         Commands::Doctor => cmd_doctor(),
         Commands::Uninstall(_) => unreachable!("dispatched before open_store"),
         Commands::CodeAreas {
@@ -4175,7 +4189,12 @@ pub(crate) fn cmd_matches_icm_pattern(cmd: &str, pattern: &str) -> bool {
     cmd.contains(&format!("{pattern}.exe"))
 }
 
-fn cmd_init(mode: InitMode, force: bool, per_project: bool) -> Result<()> {
+fn cmd_init(
+    mode: InitMode,
+    force: bool,
+    per_project: bool,
+    with_codex_post_hook: bool,
+) -> Result<()> {
     let icm_bin = std::env::current_exe().context("cannot determine icm binary path")?;
     let icm_bin_str = portable_command_path(&icm_bin);
     let home = home_dir_str()?;
@@ -4937,14 +4956,28 @@ Do this BEFORE responding to the user. Not optional.
             )?;
             println!("[hook] Codex CLI PreToolUse (auto-allow): {status}");
 
-            let status = inject_codex_hook(
-                &codex_hooks_path,
-                "PostToolUse",
-                &format!("{} hook post", icm_bin_str),
-                None,
-                detect,
-            )?;
-            println!("[hook] Codex CLI PostToolUse (auto-extract): {status}");
+            // Codex CLI PostToolUse is opt-in (issue #288): Codex
+            // fires this on every shell command, so the default
+            // install used to flood the store with ~14k events/24h
+            // of tool-output bloat. MCP + AGENTS.md alone is enough
+            // for `icm_memory_store` to land curated facts via the
+            // model. Users who want the extraction-on-every-tool
+            // behavior can pass `--with-codex-post-hook`.
+            if with_codex_post_hook {
+                let status = inject_codex_hook(
+                    &codex_hooks_path,
+                    "PostToolUse",
+                    &format!("{} hook post", icm_bin_str),
+                    None,
+                    detect,
+                )?;
+                println!("[hook] Codex CLI PostToolUse (auto-extract): {status}");
+            } else {
+                println!(
+                    "[hook] Codex CLI PostToolUse: skipped (off by default; \
+                     pass --with-codex-post-hook to opt in — see issue #288)"
+                );
+            }
 
             let status = inject_codex_hook(
                 &codex_hooks_path,

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -146,6 +146,8 @@ icm init --mode mcp
 ```bash
 icm init --mode mcp     # TOML config
 icm init --mode cli     # Injects into AGENTS.md
+icm init --mode hook    # SessionStart + PreToolUse + UserPromptSubmit
+                        # (PostToolUse opt-in, see below)
 ```
 
 **Config:** `~/.codex/config.toml`
@@ -155,6 +157,24 @@ icm init --mode cli     # Injects into AGENTS.md
 command = "/path/to/icm"
 args = ["serve"]
 ```
+
+**Hooks:** `~/.codex/hooks.json` — the `hook` mode installs three hooks
+by default: SessionStart, PreToolUse (auto-allow `icm` commands),
+and UserPromptSubmit (recall injection).
+
+**PostToolUse is opt-in** (issue #288): Codex fires PostToolUse on
+every shell command, which generates ~14k events / 24h and floods
+the store with tool-output bloat (paths, patch fragments, help
+text, generic `note` entries). MCP + `AGENTS.md` alone are enough
+for `icm_memory_store` to land curated facts via the model. If
+you want PostToolUse extraction on Codex anyway, opt in with:
+
+```bash
+icm init --mode hook --with-codex-post-hook
+```
+
+…and tune `[extraction]` first (`extract_every`, `min_score`,
+`store_raw = false`) so the auto-extracted memories stay useful.
 
 **Instructions:** `AGENTS.md` in project root.
 
@@ -234,7 +254,7 @@ icm init --mode mcp
 | `mcp` | Configures MCP server in each tool's config | All 14 tools |
 | `cli` | Injects ICM instructions into instruction files | Claude Code, Codex, Gemini, Copilot, Windsurf |
 | `skill` | Creates slash commands and rule files | Claude Code, Cursor, Roo Code, Amp |
-| `hook` | Installs hooks/plugins for automatic extraction | Claude Code (4 hooks), OpenCode (JS plugin) |
+| `hook` | Installs hooks/plugins for automatic extraction | Claude Code (5 hooks), Gemini CLI (5 hooks), Codex CLI (3 hooks; PostToolUse opt-in, #288), Copilot CLI (4 hooks), OpenCode (TS plugin) |
 
 ## Manual Setup
 


### PR DESCRIPTION
## Summary
- New \`--with-codex-post-hook\` flag on \`icm init\`. Default OFF. The Codex PostToolUse hook (\`icm hook post\`) is no longer installed by default — it fires on every shell command and a normal session generates ~14k events / 24h (issue #288), flooding the store with low-value extracted memories (paths, patch fragments, help text, generic \`note\` entries) even with \`store_raw = false\` and a tight \`extract_every\`.
- Codex still gets SessionStart + PreToolUse + UserPromptSubmit plus the MCP server + AGENTS.md, so \`icm_memory_store\` continues to work via the model.
- The skip prints a one-liner pointing to the flag and the issue, so users who actually want PostToolUse extraction know the path to opt in.
- Docs aligned: README integration table notes "3 hooks (PostToolUse opt-in)", README hook-actions table gets a footnote about the noise + tuning knobs, \`docs/integrations.md\` Codex section now shows the \`hook\` mode with the opt-in flag and the callout, integration-modes summary lists Codex (3 hooks; PostToolUse opt-in).
- \`icm hook --help\` description rewritten — no longer Claude-only ("Hook handlers shared across Claude Code, Codex, Gemini, and Copilot").

## Why
Closes #288. The issue explicitly asked for one of:
1. Codex defaults to MCP + AGENTS.md, \`icm hook post\` not installed unless explicit opt-in.
2. Codex hook stays default, docs warn + provide filters.

I went with **(1)** — option (2) keeps the noise problem in everyone's default install and asks users to find tuning flags after they've already seen 14k bogus memories. Option (1) flips the default and gives the explicit opt-in for users who want it (with tuning hints in the help text and docs).

## Public behavior change
- \`icm init --mode hook\` (or \`--mode all\`) for users with Codex installed: now installs 3 Codex hooks instead of 4. The previously-installed PostToolUse hook will continue to work on machines where it was already injected — this PR only changes new installs. Users who want to remove it can either run \`icm uninstall\` and re-init, or hand-edit \`~/.codex/hooks.json\`.

## Test plan
- [x] Smoke (debug binary, fake HOME):
  - Default: \`Codex CLI PostToolUse: skipped (off by default; pass --with-codex-post-hook to opt in — see issue #288)\`
  - Opt-in: all 4 Codex hooks configured.
- [x] \`icm init --help\` shows the new flag with the rationale.
- [x] \`cargo test --workspace\` green (perf_fts_search_100 flake on shared runner under load — passes in isolation; unrelated to this change).
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)