### PR TITLE
chore: sync release icm-v0.10.54 into develop

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "crates/icm-cli": "0.10.53"
+  "crates/icm-cli": "0.10.54"
 }

--- a/crates/icm-cli/CHANGELOG.md
+++ b/crates/icm-cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.10.54](https://github.com/rtk-ai/icm/compare/icm-v0.10.53...icm-v0.10.54) (2026-06-21)
+
+
+### Features
+
+* **init:** Add `icm forget` and `icm list` to `icm_block` ([#252](https://github.com/rtk-ai/icm/issues/252)) ([b698ee6](https://github.com/rtk-ai/icm/commit/b698ee6517c17fae51d2c88902bfe22596ac3958))
+
+
+### Bug Fixes
+
+* **project:** resolve worktree directory name as main repo project ([#235](https://github.com/rtk-ai/icm/issues/235)) ([01e0c91](https://github.com/rtk-ai/icm/commit/01e0c91ca23d94434f615944603c23f31eb2a740))
+
 ## [0.10.53](https://github.com/rtk-ai/icm/compare/icm-v0.10.52...icm-v0.10.53) (2026-06-21)
 
 

--- a/crates/icm-cli/Cargo.toml
+++ b/crates/icm-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icm-cli"
-version = "0.10.53"
+version = "0.10.54"
 edition = "2021"
 description = "Permanent memory for AI agents"
 license = "Apache-2.0"


### PR DESCRIPTION
Automated back-merge of release-please commits from `main` into `develop` so the next `develop -> main` PR stays free of release-commit drift.

Manually completed: the CD `back-merge-develop` job pushed this branch but failed at `gh pr create` because the `automated` label does not exist in the repo (fixed separately in cd.yml). The branch is a clean fast-forward of develop to main HEAD (release metadata only: manifest + CHANGELOG + Cargo.toml).