### PR TITLE
fix(cd): create 'automated' label before back-merge PR to avoid failure

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -209,6 +209,14 @@ jobs:
 
           git push origin "$BRANCH"
 
+          # Ensure the 'automated' label exists before referencing it: a missing
+          # label makes `gh pr create --label` fail and aborts the back-merge PR
+          # ("could not add label: 'automated' not found"). Idempotent.
+          gh label create automated \
+            --color ededed \
+            --description "Automated PR (back-merge / release tooling)" \
+            2>/dev/null || true
+
           gh pr create \
             --base develop \
             --head "$BRANCH" \


### PR DESCRIPTION
## Problem

The post-release `back-merge-develop` job in `cd.yml` runs `gh pr create … --label automated`, but the `automated` label does not exist in this repo. `gh pr create` validates labels **before** creating the PR, so the step fails with:

```
could not add label: 'automated' not found
```

This happened on **every** release: the back-merge branch was pushed but no PR was opened, so `develop` silently fell behind on release-version metadata (manifest + CHANGELOG + Cargo.toml). Observed and recovered manually on **icm-v0.10.54** (back-merge completed via #298).

## Fix

Create the `automated` label idempotently right before `gh pr create`:

```bash
gh label create automated --color ededed --description "Automated PR (back-merge / release tooling)" 2>/dev/null || true
```

- Keeps the `automated` label semantics (useful for filtering tooling PRs).
- Removes the failure mode without masking real `gh pr create` errors.

## Test

YAML validated. Functional validation happens on the next release: the back-merge PR should open automatically with the `automated` label and no failure.