### PR TITLE
feat(store): opt-in pluggable PostgreSQL backend (#301)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+.git/
+.github/
+web/node_modules/
+**/*.db
+**/*.db-shm
+**/*.db-wal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +313,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +400,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +463,12 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "color_quant"
@@ -488,6 +525,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +570,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -604,6 +656,24 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -721,8 +791,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -843,6 +925,12 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -984,6 +1072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1055,7 +1144,7 @@ checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1079,6 +1168,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1178,13 +1268,22 @@ dependencies = [
  "libc",
  "log",
  "native-tls",
- "rand",
+ "rand 0.9.2",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror",
  "ureq",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1231,6 +1330,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1338,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.52"
+version = "0.10.54"
 dependencies = [
  "anyhow",
  "axum",
@@ -1360,7 +1468,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_lenient",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "tempfile",
  "tokio",
@@ -1409,9 +1517,11 @@ dependencies = [
  "chrono",
  "icm-core",
  "lru 0.18.0",
+ "pgvector",
+ "postgres",
  "rusqlite",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlite-vec",
  "tempfile",
  "tracing",
@@ -1866,6 +1976,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,7 +2031,7 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -2085,6 +2205,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2197,7 +2335,7 @@ checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
 dependencies = [
  "flate2",
  "pkg-config",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "ureq",
 ]
@@ -2242,6 +2380,35 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pgvector"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
+dependencies = [
+ "bytes",
+ "postgres-types",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2293,6 +2460,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postgres"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ad20e0aa0b24f5a394eab4f78c781d248982b22b25cecc7e3aa46a681605bd"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "bytes",
+ "chrono",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
 ]
 
 [[package]]
@@ -2400,7 +2611,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2410,7 +2632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2421,6 +2643,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -2470,7 +2698,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand",
+ "rand 0.9.2",
  "rand_chacha",
  "simd_helpers",
  "thiserror",
@@ -2668,7 +2896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
 dependencies = [
  "bitflags",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
@@ -2705,7 +2933,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -2931,8 +3159,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2995,6 +3234,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3061,6 +3306,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -3226,6 +3482,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokenizers"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3244,7 +3515,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand",
+ "rand 0.9.2",
  "rayon",
  "rayon-cond",
  "regex",
@@ -3292,6 +3563,32 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.1",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -3485,7 +3782,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand",
+ "rand 0.9.2",
  "web-time",
 ]
 
@@ -3496,10 +3793,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"
@@ -3509,6 +3821,12 @@ checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3656,6 +3974,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3671,6 +3998,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3822,6 +4158,19 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "whoami"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
+]
 
 [[package]]
 name = "winapi"

--- a/crates/icm-cli/Cargo.toml
+++ b/crates/icm-cli/Cargo.toml
@@ -13,9 +13,16 @@ name = "icm"
 path = "src/main.rs"
 
 [features]
-default = ["embeddings", "tui", "http-api"]
+default = ["embeddings", "tui", "http-api", "backend-sqlite"]
 embeddings = ["icm-core/embeddings", "icm-mcp/embeddings"]
 tui = ["dep:ratatui", "dep:crossterm"]
+# Storage backend selection (issue #301). Exactly one must be active.
+# Default = in-process SQLite (single binary, zero external services).
+# The opt-in PostgreSQL backend lets several `icm` processes / Kubernetes
+# replicas share one memory store; build it with
+# `--no-default-features --features "postgres,embeddings,tui,http-api"`.
+backend-sqlite = ["icm-store/backend-sqlite", "icm-mcp/backend-sqlite"]
+postgres = ["icm-store/postgres", "icm-mcp/postgres"]
 # Persistent local HTTP server (`icm serve --http`) reusing the warm
 # store + embedder. Lightweight: just axum + tokio. Issue #290.
 http-api = ["dep:axum", "dep:tokio"]
@@ -35,8 +42,8 @@ vendored-openssl = ["openssl/vendored"]
 
 [dependencies]
 icm-core = { path = "../icm-core" }
-icm-store = { path = "../icm-store" }
-icm-mcp = { path = "../icm-mcp" }
+icm-store = { path = "../icm-store", default-features = false }
+icm-mcp = { path = "../icm-mcp", default-features = false }
 anyhow = { workspace = true }
 clap = { workspace = true }
 chrono = { workspace = true }

--- a/crates/icm-cli/src/archive.rs
+++ b/crates/icm-cli/src/archive.rs
@@ -11,7 +11,7 @@
 
 use icm_core::transcript::Role;
 use icm_core::TranscriptStore;
-use icm_store::SqliteStore;
+use icm_store::Store;
 use serde_json::Value;
 
 use crate::config::ArchiveConfig;
@@ -75,7 +75,7 @@ pub fn agent_label_from_env() -> String {
 /// never breaks the hook chain — the curated `Memory` path is the
 /// agent's source of truth; the archive is fallback fidelity.
 pub fn record_event(
-    store: &SqliteStore,
+    store: &Store,
     cfg: &ArchiveConfig,
     json: &Value,
     role: Role,
@@ -154,7 +154,7 @@ mod tests {
 
     #[test]
     fn record_event_is_noop_when_disabled() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         let cfg = ArchiveConfig::default(); // enabled = false
         let v: Value = serde_json::from_str(r#"{"session_id":"s1","cwd":"/tmp"}"#).unwrap();
         record_event(&store, &cfg, &v, Role::User, "hello", None);
@@ -165,7 +165,7 @@ mod tests {
 
     #[test]
     fn record_event_skips_when_no_session_id() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         let cfg = ArchiveConfig {
             enabled: true,
             max_bytes_per_event: 0,
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn record_event_persists_under_external_id() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         let cfg = ArchiveConfig {
             enabled: true,
             max_bytes_per_event: 0,
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn record_event_truncates_at_byte_cap() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         let cfg = ArchiveConfig {
             enabled: true,
             max_bytes_per_event: 16,

--- a/crates/icm-cli/src/extract.rs
+++ b/crates/icm-cli/src/extract.rs
@@ -10,7 +10,7 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 use icm_core::{is_preference_topic, project_matches, Embedder, Importance, Memory, MemoryStore};
-use icm_store::SqliteStore;
+use icm_store::Store;
 
 use crate::extract_semantic::{AnchorKind, SemanticScorer};
 
@@ -21,7 +21,7 @@ type ScoredFact = (String, String, Importance, Option<AnchorKind>);
 
 /// Extract key facts from text and store them in ICM.
 /// Returns the number of facts stored.
-pub fn extract_and_store(store: &SqliteStore, text: &str, project: &str) -> Result<usize> {
+pub fn extract_and_store(store: &Store, text: &str, project: &str) -> Result<usize> {
     extract_and_store_with_opts(store, text, project, false, Importance::Critical)
 }
 
@@ -39,7 +39,7 @@ pub fn extract_and_store(store: &SqliteStore, text: &str, project: &str) -> Resu
 /// This variant uses the English-only keyword scorer. For multilingual
 /// content prefer [`extract_and_store_with_embedder`].
 pub fn extract_and_store_with_opts(
-    store: &SqliteStore,
+    store: &Store,
     text: &str,
     project: &str,
     store_raw: bool,
@@ -63,7 +63,7 @@ pub fn extract_and_store_with_opts(
 /// scorer's anchor-build call fails — better to extract English facts
 /// only than to extract nothing at all.
 pub fn extract_and_store_with_embedder(
-    store: &SqliteStore,
+    store: &Store,
     text: &str,
     project: &str,
     store_raw: bool,
@@ -191,7 +191,7 @@ fn cap_importance(value: Importance, cap: Importance) -> Importance {
 /// other projects bleed into the recalled context. The hard filter here
 /// prevents cross-project leakage.
 pub fn recall_context(
-    store: &SqliteStore,
+    store: &Store,
     query: &str,
     project: Option<&str>,
     limit: usize,
@@ -1484,7 +1484,7 @@ mod tests {
 
     #[test]
     fn test_store_raw_fallback() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         let text = "Just some random conversation text that has no particular keywords but is still somewhat meaningful context about the ongoing work session";
         let stored =
             extract_and_store_with_opts(&store, text, "test", true, Importance::Critical).unwrap();
@@ -1493,14 +1493,14 @@ mod tests {
 
     #[test]
     fn test_recall_context_empty_store() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         let ctx = recall_context(&store, "anything", None, 5).unwrap();
         assert!(ctx.is_empty());
     }
 
     #[test]
     fn test_extract_and_recall_roundtrip() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         let text = "The project uses Pratt precedence climbing algorithm for parsing expressions. \
                      Welford's online algorithm provides streaming mean and variance computation. \
                      The matrix determinant uses recursive cofactor expansion along the first row.";
@@ -1516,7 +1516,7 @@ mod tests {
     fn test_recall_context_filters_other_projects() {
         // Two projects' memories share search terms; the project filter must
         // strip the cross-project hits from FTS results.
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
 
         let mem_a = Memory::new(
             "context-projecta".to_string(),
@@ -1541,7 +1541,7 @@ mod tests {
 
     #[test]
     fn test_recall_context_keeps_preferences_when_filtering() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
 
         let project_mem = Memory::new(
             "context-myapp".to_string(),
@@ -1579,7 +1579,7 @@ mod tests {
         // pure word-order shuffles and minor filler additions
         // (intersection ≥ 7/9 ≈ 0.78 between any pair) to keep
         // the test deterministic across platforms.
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         let paraphrases = [
             "Patrick prefers Rust over Go for systems work",
             "Patrick really prefers Rust over Go for systems work",
@@ -1617,7 +1617,7 @@ mod tests {
         // different project — those are cross-project lessons. The
         // pre-fix project filter stripped the memory and the
         // weight-sorted fallback returned other irrelevant memories.
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         store
             .store(Memory::new(
                 "context-projecta".to_string(),
@@ -1653,7 +1653,7 @@ mod tests {
         // out `context-projecta` memories sorted by weight. The
         // pre-fix code returned the top-5 by weight regardless of
         // query relevance, polluting every irrelevant prompt.
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         for i in 0..5 {
             store
                 .store(Memory::new(
@@ -1683,7 +1683,7 @@ mod tests {
         // the always-on identity layer and the last-ditch fallback
         // surfaces them by weight. Without this, every irrelevant
         // prompt would lose the user's coding rules.
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         store
             .store(Memory::new(
                 "context-projecta".to_string(),
@@ -1720,7 +1720,7 @@ mod tests {
     fn test_recall_context_no_project_keeps_all() {
         // When no project is specified, behavior matches the pre-filter API:
         // every matching memory is returned regardless of topic.
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
 
         store
             .store(Memory::new(

--- a/crates/icm-cli/src/extract_semantic.rs
+++ b/crates/icm-cli/src/extract_semantic.rs
@@ -636,9 +636,9 @@ mod tests {
     fn french_transcript_extracts_facts_end_to_end() {
         use crate::extract::extract_and_store_with_embedder;
         use icm_core::{FastEmbedder, Importance, MemoryStore};
-        use icm_store::SqliteStore;
+        use icm_store::Store;
 
-        let store = SqliteStore::in_memory().expect("store");
+        let store = Store::in_memory().expect("store");
         let embedder = FastEmbedder::new();
 
         let text = "Session 2026-05-04. \

--- a/crates/icm-cli/src/http_api.rs
+++ b/crates/icm-cli/src/http_api.rs
@@ -7,7 +7,7 @@
 //! awkward to call from non-MCP clients.
 //!
 //! This module adds an axum HTTP server (`icm serve --http
-//! 127.0.0.1:11435`) that shares ONE warm [`SqliteStore`] and ONE
+//! 127.0.0.1:11435`) that shares ONE warm [`Store`] and ONE
 //! embedder across all requests via [`Arc`]. The endpoints mirror the
 //! existing MCP tools and route through the SAME store methods so
 //! behavior stays consistent.
@@ -41,7 +41,7 @@ use icm_core::{
     is_preference_topic, keyword_matches, project_matches, topic_matches, Embedder, Importance,
     Memory, MemoryStore, MSG_NO_MEMORIES,
 };
-use icm_store::SqliteStore;
+use icm_store::Store;
 
 use crate::recall_format::{self, RecallFormat};
 
@@ -50,14 +50,14 @@ use crate::recall_format::{self, RecallFormat};
 // ---------------------------------------------------------------------------
 
 /// Arc-shared so every axum handler reads the SAME warm store + embedder.
-/// `SqliteStore` wraps a `rusqlite::Connection`, which is `Send` but
+/// `Store` wraps a `rusqlite::Connection`, which is `Send` but
 /// not `Sync`, so the same `Arc<Mutex<…>>` pattern as the web
 /// dashboard (see `web.rs`) serializes DB access. Embedders are
 /// already `Send + Sync` (see `icm-core::embedder::Embedder`).
 /// `None` skips semantic recall — the `--no-embeddings` path.
 #[derive(Clone)]
 pub struct AppState {
-    store: Arc<Mutex<SqliteStore>>,
+    store: Arc<Mutex<Store>>,
     embedder: Option<Arc<dyn Embedder + Send + Sync>>,
     /// When set, every request must carry `Authorization: Bearer <token>`.
     token: Option<String>,
@@ -165,7 +165,7 @@ pub struct ConsolidateReq {
 /// are pre-built by `cmd_serve` and handed to us as `Arc`s.
 #[tokio::main]
 pub async fn run_http_server(
-    store: SqliteStore,
+    store: Store,
     embedder: Option<Box<dyn Embedder + Send + Sync>>,
     addr: SocketAddr,
     token: Option<String>,
@@ -308,7 +308,7 @@ fn run_recall(state: &AppState, req: &RecallReq) -> Result<Vec<(Memory, Option<f
 }
 
 fn fts_fallback<F>(
-    store: &SqliteStore,
+    store: &Store,
     req: &RecallReq,
     project_filter: &F,
     limit: usize,

--- a/crates/icm-cli/src/import.rs
+++ b/crates/icm-cli/src/import.rs
@@ -15,7 +15,7 @@ use anyhow::{bail, Context, Result};
 use chrono::{DateTime, Utc};
 
 use icm_core::{Memory, MemorySource, MemoryStore};
-use icm_store::SqliteStore;
+use icm_store::Store;
 
 use crate::extract;
 
@@ -430,7 +430,7 @@ fn exchanges_to_text(exchanges: &[Exchange]) -> String {
 // ── Main import command ──────────────────────────────────────────────────
 
 pub fn cmd_import(
-    store: &SqliteStore,
+    store: &Store,
     path: PathBuf,
     format: Option<ImportFormat>,
     project: String,
@@ -708,14 +708,14 @@ mod tests {
         let path = dir.path().join("session.jsonl");
         std::fs::write(&path, line).unwrap();
 
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         // Pre-fix this panicked with "byte index 500 is not a char boundary".
         cmd_import(&store, path, None, "test".into(), false).unwrap();
     }
 
     #[test]
     fn test_import_roundtrip() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         let jsonl = concat!(
             r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"We decided to use SQLite instead of Postgres because we need zero external dependencies. Sarah agreed with the decision."}]}}"#,
             "\n",

--- a/crates/icm-cli/src/learn_tests.rs
+++ b/crates/icm-cli/src/learn_tests.rs
@@ -2,14 +2,14 @@
 mod tests {
     use icm_core::learn::learn_project;
     use icm_core::MemoirStore;
-    use icm_store::SqliteStore;
+    use icm_store::Store;
     use std::fs;
     use tempfile::TempDir;
 
-    fn test_store() -> (TempDir, SqliteStore) {
+    fn test_store() -> (TempDir, Store) {
         let tmp = TempDir::new().expect("failed to create temp dir");
         let db_path = tmp.path().join("test.db");
-        let store = SqliteStore::with_dims(&db_path, 384).expect("failed to create store");
+        let store = Store::with_dims(&db_path, 384).expect("failed to create store");
         (tmp, store)
     }
 

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1412,8 +1412,35 @@ fn init_embedder(model: &str) -> Option<icm_core::FastEmbedder> {
     Some(icm_core::FastEmbedder::with_model(model))
 }
 
+/// Placeholder embedder for builds without the `embeddings` feature.
+///
+/// It is never instantiated (`init_embedder` always returns `None` and the
+/// runtime guards on `embeddings_enabled`), but giving the no-embeddings
+/// build a concrete `Embedder` type lets the many
+/// `embedder.as_ref().map(|e| e as &dyn Embedder)` call sites compile
+/// without per-site `#[cfg]` gates.
 #[cfg(not(feature = "embeddings"))]
-fn init_embedder(_model: &str) -> Option<()> {
+struct DisabledEmbedder;
+
+#[cfg(not(feature = "embeddings"))]
+impl icm_core::Embedder for DisabledEmbedder {
+    fn embed(&self, _text: &str) -> icm_core::IcmResult<Vec<f32>> {
+        Err(icm_core::IcmError::Embedding(
+            "this build was compiled without the `embeddings` feature".into(),
+        ))
+    }
+    fn embed_batch(&self, _texts: &[&str]) -> icm_core::IcmResult<Vec<Vec<f32>>> {
+        Err(icm_core::IcmError::Embedding(
+            "this build was compiled without the `embeddings` feature".into(),
+        ))
+    }
+    fn dimensions(&self) -> usize {
+        icm_core::DEFAULT_EMBEDDING_DIMS
+    }
+}
+
+#[cfg(not(feature = "embeddings"))]
+fn init_embedder(_model: &str) -> Option<DisabledEmbedder> {
     None
 }
 
@@ -1468,6 +1495,8 @@ fn main() -> Result<()> {
         }
     }
     let cli_db: Option<PathBuf> = cli.db.into_iter().next();
+    // `db_path` is consumed only by embeddings-gated commands (e.g. `embed`).
+    #[cfg_attr(not(feature = "embeddings"), allow(unused_variables))]
     let db_path = cli_db.clone().unwrap_or_else(default_db_path);
 
     // `icm uninstall` must NOT open the SQLite store: a default

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -35,7 +35,7 @@ use icm_core::{
     Label, Memoir, MemoirStore, Memory, MemoryStore, Relation, WakeUpFormat, WakeUpOptions,
     DEDUP_SIMILARITY_THRESHOLD, MSG_NO_MEMORIES,
 };
-use icm_store::SqliteStore;
+use icm_store::Store;
 
 #[derive(Parser)]
 #[command(
@@ -1334,18 +1334,18 @@ fn default_db_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("memories.db"))
 }
 
-fn open_store(db: Option<PathBuf>, embedding_dims: usize) -> Result<SqliteStore> {
+fn open_store(db: Option<PathBuf>, embedding_dims: usize) -> Result<Store> {
     let path = db.unwrap_or_else(default_db_path);
-    SqliteStore::with_dims(&path, embedding_dims).context("failed to open database")
+    Store::with_dims(&path, embedding_dims).context("failed to open database")
 }
 
 /// Open the store in read-only mode (issue #263). Resolves the path
 /// the same way as [`open_store`] and rejects with a helpful message
 /// if the DB doesn't exist yet — read-only mode cannot bootstrap a
 /// fresh DB.
-fn open_store_readonly(db: Option<PathBuf>) -> Result<SqliteStore> {
+fn open_store_readonly(db: Option<PathBuf>) -> Result<Store> {
     let path = db.unwrap_or_else(default_db_path);
-    SqliteStore::open_readonly(&path).with_context(|| {
+    Store::open_readonly(&path).with_context(|| {
         format!(
             "failed to open database read-only at {} \
              (--read-only requires the DB to already exist)",
@@ -1387,7 +1387,7 @@ fn resolve_embedding_dims(
         return e.dimensions();
     }
     let path = cli_db.cloned().unwrap_or_else(default_db_path);
-    match SqliteStore::read_stored_embedding_dims(&path) {
+    match Store::read_stored_embedding_dims(&path) {
         Ok(Some(dims)) => dims,
         // No DB or no metadata row → fresh install path; default is safe.
         Ok(None) => icm_core::DEFAULT_EMBEDDING_DIMS,
@@ -2038,7 +2038,7 @@ fn main() -> Result<()> {
 /// every write path stays consistent. Errors are logged and swallowed
 /// — consolidation is a maintenance op, not on the critical path.
 fn maybe_auto_consolidate(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     topic: &str,
     cfg: &crate::config::MemoryConfig,
@@ -2058,7 +2058,7 @@ fn maybe_auto_consolidate(
 
 #[allow(clippy::too_many_arguments)]
 fn cmd_store(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
     topic: String,
@@ -2162,7 +2162,7 @@ fn cmd_store(
 /// topic when `--topic` is omitted.
 #[allow(clippy::too_many_arguments)]
 fn cmd_remember(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
     content: String,
@@ -2192,7 +2192,7 @@ fn cmd_remember(
 
 #[allow(clippy::too_many_arguments)]
 fn cmd_recall(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     query: &str,
     topic: Option<&str>,
@@ -2302,7 +2302,7 @@ fn cmd_recall(
 }
 
 fn cmd_list(
-    store: &SqliteStore,
+    store: &Store,
     topic: Option<&str>,
     all: bool,
     sort: SortField,
@@ -2368,7 +2368,7 @@ fn cmd_list(
     Ok(())
 }
 
-fn cmd_forget(store: &SqliteStore, id: Option<&str>, topic: Option<&str>) -> Result<()> {
+fn cmd_forget(store: &Store, id: Option<&str>, topic: Option<&str>) -> Result<()> {
     match (id, topic) {
         (Some(_), Some(_)) => {
             // Audit #185 medium: previously the topic path silently
@@ -2406,7 +2406,7 @@ fn cmd_forget(store: &SqliteStore, id: Option<&str>, topic: Option<&str>) -> Res
 }
 
 fn cmd_update(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     id: &str,
     content: String,
@@ -2442,7 +2442,7 @@ fn cmd_update(
     Ok(())
 }
 
-fn cmd_health(store: &SqliteStore, topic_filter: Option<&str>) -> Result<()> {
+fn cmd_health(store: &Store, topic_filter: Option<&str>) -> Result<()> {
     let topics = if let Some(t) = topic_filter {
         vec![(t.to_string(), 0usize)]
     } else {
@@ -2502,7 +2502,7 @@ fn cmd_health(store: &SqliteStore, topic_filter: Option<&str>) -> Result<()> {
 }
 
 fn cmd_feedback_record(
-    store: &SqliteStore,
+    store: &Store,
     topic: String,
     context: String,
     predicted: String,
@@ -2527,7 +2527,7 @@ fn cmd_feedback_record(
 }
 
 fn cmd_feedback_search(
-    store: &SqliteStore,
+    store: &Store,
     query: &str,
     topic: Option<&str>,
     limit: usize,
@@ -2556,7 +2556,7 @@ fn cmd_feedback_search(
     Ok(())
 }
 
-fn cmd_feedback_list(store: &SqliteStore, topic: Option<&str>, limit: usize) -> Result<()> {
+fn cmd_feedback_list(store: &Store, topic: Option<&str>, limit: usize) -> Result<()> {
     let results = store.list_feedback(topic, limit)?;
     if results.is_empty() {
         match topic {
@@ -2584,7 +2584,7 @@ fn cmd_feedback_list(store: &SqliteStore, topic: Option<&str>, limit: usize) -> 
     Ok(())
 }
 
-fn cmd_feedback_stats(store: &SqliteStore) -> Result<()> {
+fn cmd_feedback_stats(store: &Store) -> Result<()> {
     let stats = store.feedback_stats()?;
     println!("Feedback total: {}", stats.total);
 
@@ -2609,7 +2609,7 @@ fn cmd_feedback_stats(store: &SqliteStore) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 fn cmd_transcript_start_session(
-    store: &SqliteStore,
+    store: &Store,
     agent: &str,
     project: Option<&str>,
     metadata: Option<&str>,
@@ -2621,7 +2621,7 @@ fn cmd_transcript_start_session(
 }
 
 fn cmd_transcript_record(
-    store: &SqliteStore,
+    store: &Store,
     session: &str,
     role: &str,
     content: &str,
@@ -2638,7 +2638,7 @@ fn cmd_transcript_record(
 }
 
 fn cmd_transcript_search(
-    store: &SqliteStore,
+    store: &Store,
     query: &str,
     session: Option<&str>,
     project: Option<&str>,
@@ -2677,11 +2677,7 @@ fn cmd_transcript_search(
     Ok(())
 }
 
-fn cmd_transcript_list_sessions(
-    store: &SqliteStore,
-    project: Option<&str>,
-    limit: usize,
-) -> Result<()> {
+fn cmd_transcript_list_sessions(store: &Store, project: Option<&str>, limit: usize) -> Result<()> {
     use icm_core::TranscriptStore;
     let sessions = store.list_sessions(project, limit)?;
     if sessions.is_empty() {
@@ -2708,7 +2704,7 @@ fn cmd_transcript_list_sessions(
     Ok(())
 }
 
-fn cmd_transcript_show(store: &SqliteStore, session: &str, limit: usize) -> Result<()> {
+fn cmd_transcript_show(store: &Store, session: &str, limit: usize) -> Result<()> {
     use icm_core::TranscriptStore;
     let meta = store.get_session(session)?;
     let meta = match meta {
@@ -2746,7 +2742,7 @@ fn cmd_transcript_show(store: &SqliteStore, session: &str, limit: usize) -> Resu
     Ok(())
 }
 
-fn cmd_transcript_stats(store: &SqliteStore) -> Result<()> {
+fn cmd_transcript_stats(store: &Store) -> Result<()> {
     use icm_core::TranscriptStore;
     let s = store.transcript_stats()?;
     println!("Sessions:      {}", s.total_sessions);
@@ -2790,7 +2786,7 @@ fn cmd_transcript_stats(store: &SqliteStore) -> Result<()> {
     Ok(())
 }
 
-fn cmd_transcript_forget(store: &SqliteStore, session: &str) -> Result<()> {
+fn cmd_transcript_forget(store: &Store, session: &str) -> Result<()> {
     use icm_core::TranscriptStore;
     store.forget_session(session)?;
     println!("Deleted session {session}");
@@ -3097,7 +3093,7 @@ fn extract_tool_input_file_path(json: &Value) -> Option<String> {
 ///    fastembed semantic-scoring extractor — multilingual, but pays
 ///    a ~3.7s model-load cost per process.
 fn cmd_hook_post(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
     extract_every: usize,
@@ -3236,7 +3232,7 @@ fn cmd_hook_post(
 
 /// PreCompact hook (Layer 1): extract memories from transcript before context compression.
 fn cmd_hook_compact(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
 ) -> Result<()> {
@@ -3250,7 +3246,7 @@ fn cmd_hook_compact(
 /// (Claude Code does not log SessionEnd attachments in its session
 /// JSONL, so this DB-side log is the source of truth).
 fn cmd_hook_log(
-    store: &SqliteStore,
+    store: &Store,
     limit: usize,
     event: Option<&str>,
     prune_older_than: Option<&str>,
@@ -3290,7 +3286,7 @@ fn cmd_hook_log(
 /// `icm hook-stats` — aggregate `hook_events` over a lookback window.
 /// Reports per-event count, error rate, and latency p50/p99 so users can
 /// confirm the async path stays under its budget.
-fn cmd_hook_stats(store: &SqliteStore, since_hours: u64) -> Result<()> {
+fn cmd_hook_stats(store: &Store, since_hours: u64) -> Result<()> {
     let cutoff = chrono::Utc::now() - chrono::Duration::hours(since_hours as i64);
     let rows = store.hook_stats(&cutoff.to_rfc3339())?;
     if rows.is_empty() {
@@ -3321,10 +3317,10 @@ fn cmd_hook_stats(store: &SqliteStore, since_hours: u64) -> Result<()> {
 /// that PreCompact misses (compaction does not fire on `/clear`).
 ///
 /// Same transcript-parsing logic as PreCompact — the only difference is the
-/// log prefix. SqliteStore handles its own dedup so a session that triggers
+/// log prefix. Store handles its own dedup so a session that triggers
 /// both PreCompact and SessionEnd back-to-back will not double-store facts.
 fn cmd_hook_end(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
     extraction_summarizer: &crate::config::SummarizerConfig,
@@ -3389,7 +3385,7 @@ fn cmd_hook_end(
 /// Reads JSON from stdin with `transcript_path`, reads the JSONL transcript,
 /// and extracts facts from assistant messages.
 fn extract_from_hook_transcript(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
     source: &str,
@@ -3578,7 +3574,7 @@ pub(crate) fn truncate_tail_at_char_boundary(s: &str, max_bytes: usize) -> &str 
 /// UserPromptSubmit hook (Layer 2): inject recalled context at the start of each prompt.
 /// Reads JSON from stdin with `user_message`, recalls relevant memories,
 /// and prints context to stdout (Claude Code appends it as system-reminder).
-fn cmd_hook_prompt(store: &SqliteStore, archive_cfg: &crate::config::ArchiveConfig) -> Result<()> {
+fn cmd_hook_prompt(store: &Store, archive_cfg: &crate::config::ArchiveConfig) -> Result<()> {
     let Some(input) = read_stdin_utf8_lossy() else {
         return Ok(());
     };
@@ -3717,7 +3713,7 @@ fn format_hook_context(ctx: &str, fmt: HookOutputFormat) -> String {
 ///
 /// Set `ICM_HOOK_DEBUG=1` in the environment to get stderr diagnostics when
 /// the hook decides to suppress output (empty store, no matching memories).
-fn cmd_hook_start(store: &SqliteStore, max_tokens: usize) -> Result<()> {
+fn cmd_hook_start(store: &Store, max_tokens: usize) -> Result<()> {
     let input = read_stdin_utf8_lossy().unwrap_or_default();
 
     let pack = build_hook_start_pack(store, &input, max_tokens)?;
@@ -3736,11 +3732,7 @@ fn cmd_hook_start(store: &SqliteStore, max_tokens: usize) -> Result<()> {
 ///
 /// Returns the pack as a String, or an empty string if there is nothing
 /// meaningful to inject (empty store, or placeholder output).
-fn build_hook_start_pack(
-    store: &SqliteStore,
-    stdin_json: &str,
-    max_tokens: usize,
-) -> Result<String> {
+fn build_hook_start_pack(store: &Store, stdin_json: &str, max_tokens: usize) -> Result<String> {
     // Tolerate missing/malformed stdin — fall back to PWD-based detection.
     let cwd: Option<String> = serde_json::from_str::<Value>(stdin_json)
         .ok()
@@ -3889,7 +3881,7 @@ fn project_from_cwd_json(json: &Value) -> Option<String> {
 /// `icm code-areas`: list files auto-recorded by the PostToolUse hook
 /// when the agent edited them. See issue #196 for the design discussion.
 fn cmd_code_areas(
-    store: &SqliteStore,
+    store: &Store,
     in_file: Option<&str>,
     project: Option<&str>,
     since: Option<&str>,
@@ -3959,7 +3951,7 @@ fn cmd_code_areas(
     Ok(())
 }
 
-fn cmd_topics(store: &SqliteStore) -> Result<()> {
+fn cmd_topics(store: &Store) -> Result<()> {
     let topics = store.list_topics()?;
     if topics.is_empty() {
         println!("No topics yet.");
@@ -3974,7 +3966,7 @@ fn cmd_topics(store: &SqliteStore) -> Result<()> {
     Ok(())
 }
 
-fn cmd_stats(store: &SqliteStore) -> Result<()> {
+fn cmd_stats(store: &Store) -> Result<()> {
     let stats = store.stats()?;
     println!("Memories:  {}", stats.total_memories);
     println!("Topics:    {}", stats.total_topics);
@@ -3988,13 +3980,7 @@ fn cmd_stats(store: &SqliteStore) -> Result<()> {
     Ok(())
 }
 
-fn cmd_facts_set(
-    store: &SqliteStore,
-    entity: &str,
-    key: &str,
-    value: &str,
-    source: &str,
-) -> Result<()> {
+fn cmd_facts_set(store: &Store, entity: &str, key: &str, value: &str, source: &str) -> Result<()> {
     use icm_core::FactsStore;
     let prev = store.get_fact(entity, key)?;
     let id = store.set_fact(entity, key, value, source)?;
@@ -4016,7 +4002,7 @@ fn cmd_facts_set(
     Ok(())
 }
 
-fn cmd_facts_get(store: &SqliteStore, entity: &str, key: &str) -> Result<()> {
+fn cmd_facts_get(store: &Store, entity: &str, key: &str) -> Result<()> {
     use icm_core::FactsStore;
     match store.get_fact(entity, key)? {
         Some(f) => {
@@ -4036,7 +4022,7 @@ fn cmd_facts_get(store: &SqliteStore, entity: &str, key: &str) -> Result<()> {
     }
 }
 
-fn cmd_facts_list(store: &SqliteStore, entity: &str, prefix: Option<&str>) -> Result<()> {
+fn cmd_facts_list(store: &Store, entity: &str, prefix: Option<&str>) -> Result<()> {
     use icm_core::FactsStore;
     let facts = store.list_facts(entity, prefix)?;
     if facts.is_empty() {
@@ -4051,7 +4037,7 @@ fn cmd_facts_list(store: &SqliteStore, entity: &str, prefix: Option<&str>) -> Re
     Ok(())
 }
 
-fn cmd_facts_history(store: &SqliteStore, entity: &str, key: &str) -> Result<()> {
+fn cmd_facts_history(store: &Store, entity: &str, key: &str) -> Result<()> {
     use icm_core::FactsStore;
     let rows = store.history(entity, key)?;
     if rows.is_empty() {
@@ -4076,14 +4062,14 @@ fn cmd_facts_history(store: &SqliteStore, entity: &str, key: &str) -> Result<()>
     Ok(())
 }
 
-fn cmd_facts_forget(store: &SqliteStore, entity: &str, key: &str) -> Result<()> {
+fn cmd_facts_forget(store: &Store, entity: &str, key: &str) -> Result<()> {
     use icm_core::FactsStore;
     let n = store.forget_fact(entity, key)?;
     println!("forgot {n} row(s) under {entity}.{key}");
     Ok(())
 }
 
-fn cmd_facts_stats(store: &SqliteStore) -> Result<()> {
+fn cmd_facts_stats(store: &Store) -> Result<()> {
     use icm_core::FactsStore;
     let s = store.facts_stats()?;
     println!("Active facts:    {}", s.active_count);
@@ -4099,7 +4085,7 @@ fn cmd_facts_stats(store: &SqliteStore) -> Result<()> {
     Ok(())
 }
 
-fn cmd_decay(store: &SqliteStore, factor: f32) -> Result<()> {
+fn cmd_decay(store: &Store, factor: f32) -> Result<()> {
     // Audit #185 H9: `apply_decay` multiplies each memory's weight by
     // `factor`, so values >= 1 *amplify* weight instead of decaying it
     // — the opposite of the user's intent and an instant footgun.
@@ -4116,9 +4102,9 @@ fn cmd_decay(store: &SqliteStore, factor: f32) -> Result<()> {
     Ok(())
 }
 
-fn cmd_prune(store: &SqliteStore, threshold: f32, dry_run: bool) -> Result<()> {
+fn cmd_prune(store: &Store, threshold: f32, dry_run: bool) -> Result<()> {
     if dry_run {
-        // The dry-run filter MUST mirror what `SqliteStore::prune` actually
+        // The dry-run filter MUST mirror what `Store::prune` actually
         // does, otherwise `--dry-run` lies. Audit R16 caught this: the
         // store hard-protects both Critical AND High (see
         // `crates/icm-store/src/store.rs:700-718`), but the dry-run was
@@ -4148,7 +4134,7 @@ fn cmd_prune(store: &SqliteStore, threshold: f32, dry_run: bool) -> Result<()> {
 }
 
 fn cmd_extract_patterns(
-    store: &SqliteStore,
+    store: &Store,
     topic: &str,
     memoir: Option<&str>,
     min_cluster_size: usize,
@@ -6215,7 +6201,7 @@ fn cli_on_path(name: &str) -> bool {
 /// content doesn't loop forever).
 #[allow(clippy::too_many_arguments)]
 fn cmd_extract_pending(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     cfg: &config::SummarizerConfig,
     limit: usize,
@@ -6430,7 +6416,7 @@ fn health_consolidate_tip() -> String {
 
 #[allow(clippy::too_many_arguments)]
 fn cmd_consolidate(
-    store: &SqliteStore,
+    store: &Store,
     topic: &str,
     keep_originals: bool,
     cfg: &config::SummarizerConfig,
@@ -6533,7 +6519,7 @@ fn cmd_consolidate(
 }
 
 fn cmd_extract(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     project: &str,
     text: Option<String>,
@@ -6592,7 +6578,7 @@ fn cmd_extract(
 /// CPU/RAM spikes reported in issue #239. Enqueuing instead costs ~50ms
 /// and never loads the model; `icm extract-pending` drains the queue
 /// later, loading the model once for the whole batch.
-fn cmd_extract_enqueue(store: &SqliteStore, project: &str, text: Option<String>) -> Result<()> {
+fn cmd_extract_enqueue(store: &Store, project: &str, text: Option<String>) -> Result<()> {
     let input = match text {
         Some(t) => t,
         None => {
@@ -6620,7 +6606,7 @@ fn cmd_extract_enqueue(store: &SqliteStore, project: &str, text: Option<String>)
     Ok(())
 }
 
-fn cmd_recall_context(store: &SqliteStore, query: &str, limit: usize) -> Result<()> {
+fn cmd_recall_context(store: &Store, query: &str, limit: usize) -> Result<()> {
     // Explicit `recall-context` CLI invocation: no implicit project filter,
     // the user passed the query they want.
     let ctx = extract::recall_context(store, query, None, limit)?;
@@ -6643,7 +6629,7 @@ fn detect_project() -> String {
     project_from_path(&path_str).unwrap_or_else(|| "unknown".to_string())
 }
 
-fn cmd_recall_project(store: &SqliteStore, limit: usize) -> Result<()> {
+fn cmd_recall_project(store: &Store, limit: usize) -> Result<()> {
     let project = detect_project();
     eprintln!("Project: {project}");
 
@@ -6666,7 +6652,7 @@ fn cmd_recall_project(store: &SqliteStore, limit: usize) -> Result<()> {
 /// project, ranks by importance × recency × weight, and truncates to fit the
 /// token budget.
 fn cmd_wake_up(
-    store: &SqliteStore,
+    store: &Store,
     project: Option<String>,
     max_tokens: usize,
     format: CliWakeUpFormat,
@@ -6708,7 +6694,7 @@ fn cmd_wake_up(
 /// full `ContextSnapshot` struct is emitted so downstream tools can react
 /// to `over_budget` / `dropped` programmatically.
 fn cmd_context(
-    store: &SqliteStore,
+    store: &Store,
     project: Option<String>,
     max_tokens: usize,
     format: CliSnapshotFormat,
@@ -6756,7 +6742,7 @@ fn cmd_context(
 }
 
 fn cmd_save_project(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
     content: &str,
@@ -6782,7 +6768,7 @@ fn cmd_save_project(
 
 #[cfg(feature = "embeddings")]
 fn cmd_embed(
-    store: &SqliteStore,
+    store: &Store,
     embedder: &dyn icm_core::Embedder,
     topic: Option<&str>,
     force: bool,
@@ -6896,7 +6882,7 @@ fn cmd_bench(count: usize) -> Result<()> {
     ];
 
     // --- Seed without embeddings ---
-    let store_plain = SqliteStore::in_memory()?;
+    let store_plain = Store::in_memory()?;
     let t0 = Instant::now();
     for i in 0..count {
         let topic = topics[i % topics.len()].to_string();
@@ -6916,7 +6902,7 @@ fn cmd_bench(count: usize) -> Result<()> {
     let store_plain_ms = t0.elapsed().as_secs_f64() * 1000.0;
 
     // --- Seed with embeddings ---
-    let store_vec = SqliteStore::in_memory()?;
+    let store_vec = Store::in_memory()?;
     let t0 = Instant::now();
     for i in 0..count {
         let topic = topics[i % topics.len()].to_string();
@@ -7081,7 +7067,7 @@ fn cmd_bench_recall(model: &str, runs: usize, verbose: bool) -> Result<()> {
         });
         std::fs::write(&mcp_config_path, serde_json::to_string_pretty(&mcp_config)?)?;
         {
-            let _ = SqliteStore::new(&icm_db)?;
+            let _ = Store::new(&icm_db)?;
         }
 
         // === WITHOUT ICM ===
@@ -7125,7 +7111,7 @@ fn cmd_bench_recall(model: &str, runs: usize, verbose: bool) -> Result<()> {
         eprintln!(" done ({:.1}s)", s1_icm.duration_ms as f64 / 1000.0);
 
         {
-            let store = SqliteStore::new(&icm_db)?;
+            let store = Store::new(&icm_db)?;
             let ext1 =
                 extract::extract_and_store(&store, bench_knowledge::SOURCE_DOCUMENT, "meridian")?;
             let ext2 = extract::extract_and_store(&store, &s1_icm.response, "meridian")?;
@@ -7143,7 +7129,7 @@ fn cmd_bench_recall(model: &str, runs: usize, verbose: bool) -> Result<()> {
         let mut scores_with: Vec<(usize, usize, f64)> = Vec::new();
         let mut responses_with: Vec<String> = Vec::new();
         for (i, q) in questions.iter().enumerate() {
-            let store = SqliteStore::new(&icm_db)?;
+            let store = Store::new(&icm_db)?;
             let ctx = extract::recall_context(&store, q.prompt, None, 15)?;
             if verbose && !ctx.is_empty() {
                 eprintln!("  [verbose] Context injected for Q{}:", i + 1);
@@ -7166,7 +7152,7 @@ fn cmd_bench_recall(model: &str, runs: usize, verbose: bool) -> Result<()> {
                         eprintln!("    Response: {}", truncate_words(&result.response, 200));
                     }
                     {
-                        let store = SqliteStore::new(&icm_db)?;
+                        let store = Store::new(&icm_db)?;
                         let _ = extract::extract_and_store(&store, &result.response, "meridian");
                     }
                     scores_with.push(score);
@@ -7361,13 +7347,13 @@ fn cmd_bench_agent(sessions: usize, model: &str, runs: usize, verbose: bool) -> 
         });
         std::fs::write(&mcp_config_path, serde_json::to_string_pretty(&mcp_config)?)?;
         {
-            let _ = SqliteStore::new(&icm_db)?;
+            let _ = Store::new(&icm_db)?;
         }
 
         let mut results_with: Vec<SessionResult> = Vec::new();
         for (i, prompt) in prompts.iter().enumerate() {
             let effective_prompt = if i > 0 {
-                let store = SqliteStore::new(&icm_db)?;
+                let store = Store::new(&icm_db)?;
                 let ctx = extract::recall_context(&store, prompt, None, 15)?;
                 if verbose && !ctx.is_empty() {
                     eprintln!("  [verbose] Context injected for session {}:", i + 1);
@@ -7389,7 +7375,7 @@ fn cmd_bench_agent(sessions: usize, model: &str, runs: usize, verbose: bool) -> 
                 Ok(result) => {
                     eprintln!(" done ({:.1}s)", result.duration_ms as f64 / 1000.0);
                     {
-                        let store = SqliteStore::new(&icm_db)?;
+                        let store = Store::new(&icm_db)?;
                         let extracted =
                             extract::extract_and_store(&store, &result.response, "mathlib")?;
                         if extracted > 0 {
@@ -7924,20 +7910,20 @@ fn truncate_words(s: &str, max_chars: usize) -> String {
 // Memoir commands
 // ---------------------------------------------------------------------------
 
-fn resolve_memoir(store: &SqliteStore, name: &str) -> Result<Memoir> {
+fn resolve_memoir(store: &Store, name: &str) -> Result<Memoir> {
     store
         .get_memoir_by_name(name)?
         .ok_or_else(|| anyhow::anyhow!("memoir not found: {name}"))
 }
 
-fn cmd_memoir_create(store: &SqliteStore, name: String, description: String) -> Result<()> {
+fn cmd_memoir_create(store: &Store, name: String, description: String) -> Result<()> {
     let memoir = Memoir::new(name, description);
     let id = store.create_memoir(memoir)?;
     println!("Created memoir: {id}");
     Ok(())
 }
 
-fn cmd_memoir_list(store: &SqliteStore) -> Result<()> {
+fn cmd_memoir_list(store: &Store) -> Result<()> {
     let memoirs = store.list_memoirs()?;
     if memoirs.is_empty() {
         println!("No memoirs yet.");
@@ -7959,7 +7945,7 @@ fn cmd_memoir_list(store: &SqliteStore) -> Result<()> {
     Ok(())
 }
 
-fn cmd_memoir_show(store: &SqliteStore, name: &str) -> Result<()> {
+fn cmd_memoir_show(store: &Store, name: &str) -> Result<()> {
     let memoir = resolve_memoir(store, name)?;
     let stats = store.memoir_stats(&memoir.id)?;
 
@@ -8008,7 +7994,7 @@ fn cmd_memoir_show(store: &SqliteStore, name: &str) -> Result<()> {
     Ok(())
 }
 
-fn cmd_memoir_delete(store: &SqliteStore, name: &str) -> Result<()> {
+fn cmd_memoir_delete(store: &Store, name: &str) -> Result<()> {
     let memoir = resolve_memoir(store, name)?;
     store.delete_memoir(&memoir.id)?;
     println!("Deleted memoir: {name}");
@@ -8016,7 +8002,7 @@ fn cmd_memoir_delete(store: &SqliteStore, name: &str) -> Result<()> {
 }
 
 fn cmd_memoir_add_concept(
-    store: &SqliteStore,
+    store: &Store,
     memoir_name: &str,
     name: String,
     definition: String,
@@ -8039,7 +8025,7 @@ fn cmd_memoir_add_concept(
 }
 
 fn cmd_memoir_refine(
-    store: &SqliteStore,
+    store: &Store,
     memoir_name: &str,
     concept_name: &str,
     new_definition: &str,
@@ -8060,7 +8046,7 @@ fn cmd_memoir_refine(
 }
 
 fn cmd_memoir_search(
-    store: &SqliteStore,
+    store: &Store,
     memoir_name: &str,
     query: &str,
     label: Option<&str>,
@@ -8093,7 +8079,7 @@ fn cmd_memoir_search(
     Ok(())
 }
 
-fn cmd_memoir_search_all(store: &SqliteStore, query: &str, limit: usize) -> Result<()> {
+fn cmd_memoir_search_all(store: &Store, query: &str, limit: usize) -> Result<()> {
     let results = store.search_all_concepts_fts(query, limit)?;
 
     if results.is_empty() {
@@ -8124,7 +8110,7 @@ fn cmd_memoir_search_all(store: &SqliteStore, query: &str, limit: usize) -> Resu
 }
 
 fn cmd_memoir_link(
-    store: &SqliteStore,
+    store: &Store,
     memoir_name: &str,
     from_name: &str,
     to_name: &str,
@@ -8146,7 +8132,7 @@ fn cmd_memoir_link(
 }
 
 fn cmd_memoir_inspect(
-    store: &SqliteStore,
+    store: &Store,
     memoir_name: &str,
     concept_name: &str,
     depth: usize,
@@ -8185,7 +8171,7 @@ fn cmd_memoir_inspect(
 
 // confidence_color and confidence_bar are now methods on Concept in icm-core
 
-fn cmd_memoir_export(store: &SqliteStore, memoir_name: &str, format: &str) -> Result<()> {
+fn cmd_memoir_export(store: &Store, memoir_name: &str, format: &str) -> Result<()> {
     let memoir = resolve_memoir(store, memoir_name)?;
     let concepts = store.list_concepts(&memoir.id)?;
 
@@ -8361,7 +8347,7 @@ fn cmd_memoir_export(store: &SqliteStore, memoir_name: &str, format: &str) -> Re
     Ok(())
 }
 
-fn cmd_memoir_distill(store: &SqliteStore, from_topic: &str, into_name: &str) -> Result<()> {
+fn cmd_memoir_distill(store: &Store, from_topic: &str, into_name: &str) -> Result<()> {
     let memoir = resolve_memoir(store, into_name)?;
     let memories = store.get_by_topic(from_topic)?;
 
@@ -8447,7 +8433,7 @@ fn truncate(s: &str, max: usize) -> String {
 // Cloud commands
 // ---------------------------------------------------------------------------
 
-fn cmd_cloud(command: CloudCommands, store: &SqliteStore) -> Result<()> {
+fn cmd_cloud(command: CloudCommands, store: &Store) -> Result<()> {
     use icm_core::Scope;
 
     match command {
@@ -8623,8 +8609,8 @@ mod hook_start_tests {
     use super::*;
     use icm_core::Importance;
 
-    fn seed_store() -> SqliteStore {
-        let store = SqliteStore::in_memory().unwrap();
+    fn seed_store() -> Store {
+        let store = Store::in_memory().unwrap();
         store
             .store(Memory::new(
                 "decisions-icm".into(),
@@ -8787,7 +8773,7 @@ mod hook_start_tests {
 
     #[test]
     fn hook_start_pack_empty_on_empty_store() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         let stdin_json = r#"{"cwd":"/Users/patrick/dev/rtk-ai/icm"}"#;
         let pack = build_hook_start_pack(&store, stdin_json, 200).unwrap();
         assert!(
@@ -8831,7 +8817,7 @@ mod hook_start_tests {
 
     #[test]
     fn hook_start_pack_respects_token_budget() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         for i in 0..50 {
             store
                 .store(Memory::new(
@@ -8855,7 +8841,7 @@ mod hook_start_tests {
 
     #[test]
     fn hook_start_pack_skips_placeholder_output() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         // Only low-importance noise — wake-up would return the "(no critical
         // memories yet ...)" placeholder, which cmd_hook_start should suppress.
         store
@@ -8930,7 +8916,7 @@ mod hook_start_tests {
     /// emitted.
     #[test]
     fn hook_start_pack_skips_snapshot_when_only_decisions() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         store
             .store(Memory::new(
                 "decisions-icm".into(),
@@ -9497,14 +9483,14 @@ mod is_icm_command_tests {
 mod cmd_forget_tests {
     use super::*;
     use icm_core::{Importance, Memory};
-    use icm_store::SqliteStore;
+    use icm_store::Store;
 
     /// Audit #185 medium: `forget <ID> -t TOPIC` used to silently nuke
     /// the whole topic and discard the id. Now we reject the
     /// ambiguous combo.
     #[test]
     fn rejects_id_and_topic_together() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         let id = store
             .store(Memory::new(
                 "topic".into(),
@@ -9528,7 +9514,7 @@ mod cmd_forget_tests {
     /// with legacy empty topics can't be wiped by typo.
     #[test]
     fn rejects_empty_topic() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         let err = cmd_forget(&store, None, Some("")).unwrap_err();
         assert!(
             err.to_string().contains("--topic cannot be empty"),
@@ -9538,7 +9524,7 @@ mod cmd_forget_tests {
 
     #[test]
     fn rejects_whitespace_only_topic() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         let err = cmd_forget(&store, None, Some("   \t  ")).unwrap_err();
         assert!(
             err.to_string().contains("--topic cannot be empty"),
@@ -9548,7 +9534,7 @@ mod cmd_forget_tests {
 
     #[test]
     fn rejects_neither_id_nor_topic() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         let err = cmd_forget(&store, None, None).unwrap_err();
         assert!(
             err.to_string().contains("required"),
@@ -9560,14 +9546,14 @@ mod cmd_forget_tests {
 #[cfg(test)]
 mod cli_contracts_tests {
     use super::*;
-    use icm_store::SqliteStore;
+    use icm_store::Store;
 
     /// Audit #185 H9: `apply_decay` multiplies weight by `factor`,
     /// so values >= 1 amplify instead of decaying. Reject at the CLI
     /// boundary so users can't shoot themselves in the foot.
     #[test]
     fn cmd_decay_rejects_factor_one_or_greater() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         for &bad in &[1.0_f32, 1.5, 2.0, 100.0, f32::INFINITY] {
             let err = cmd_decay(&store, bad).unwrap_err();
             assert!(
@@ -9579,7 +9565,7 @@ mod cli_contracts_tests {
 
     #[test]
     fn cmd_decay_rejects_negative_or_nan_factor() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         for &bad in &[-0.1_f32, -1.0, f32::NAN, f32::NEG_INFINITY] {
             let err = cmd_decay(&store, bad).unwrap_err();
             assert!(
@@ -9591,7 +9577,7 @@ mod cli_contracts_tests {
 
     #[test]
     fn cmd_decay_accepts_valid_factor() {
-        let store = SqliteStore::in_memory().unwrap();
+        let store = Store::in_memory().unwrap();
         for &good in &[0.0_f32, 0.5, 0.95, 0.999_999] {
             cmd_decay(&store, good).unwrap_or_else(|e| panic!("factor={good} rejected: {e}"));
         }
@@ -10216,8 +10202,8 @@ mod cmd_remember_tests {
     #[test]
     fn remember_appends_status_update_to_existing_memories() {
         use icm_core::{Importance, MemoryStore};
-        use icm_store::SqliteStore;
-        let store = SqliteStore::in_memory().unwrap();
+        use icm_store::Store;
+        let store = Store::in_memory().unwrap();
         let cfg = crate::config::MemoryConfig::default();
 
         cmd_store(
@@ -10255,25 +10241,25 @@ mod cmd_remember_tests {
 #[cfg(test)]
 mod cmd_memoir_tests {
     use super::*;
-    use icm_store::SqliteStore;
+    use icm_store::Store;
 
     #[track_caller]
-    fn store() -> SqliteStore {
-        SqliteStore::in_memory().unwrap()
+    fn store() -> Store {
+        Store::in_memory().unwrap()
     }
 
     #[track_caller]
-    fn make_memoir(store: &SqliteStore, name: &str) {
+    fn make_memoir(store: &Store, name: &str) {
         cmd_memoir_create(store, name.into(), "test memoir".into()).unwrap();
     }
 
     #[track_caller]
-    fn add_concept(store: &SqliteStore, memoir: &str, name: &str, def: &str) {
+    fn add_concept(store: &Store, memoir: &str, name: &str, def: &str) {
         cmd_memoir_add_concept(store, memoir, name.into(), def.into(), None).unwrap();
     }
 
     #[track_caller]
-    fn memoir_id(store: &SqliteStore, name: &str) -> String {
+    fn memoir_id(store: &Store, name: &str) -> String {
         store.get_memoir_by_name(name).unwrap().unwrap().id
     }
 

--- a/crates/icm-cli/src/tui.rs
+++ b/crates/icm-cli/src/tui.rs
@@ -30,7 +30,7 @@ use icm_core::{
     format_local, FeedbackStore, Importance, MemoirStore, Memory, MemoryStore, StoreStats,
     TopicHealth,
 };
-use icm_store::SqliteStore;
+use icm_store::Store;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -92,7 +92,7 @@ struct App {
 }
 
 impl App {
-    fn new(store: &SqliteStore, db_path: Option<&str>) -> Result<Self> {
+    fn new(store: &Store, db_path: Option<&str>) -> Result<Self> {
         let stats = store.stats()?;
         let topics = store.list_topics()?;
         let health = Self::load_health(store, &topics)?;
@@ -139,7 +139,7 @@ impl App {
         Ok(app)
     }
 
-    fn load_health(store: &SqliteStore, topics: &[(String, usize)]) -> Result<Vec<TopicHealth>> {
+    fn load_health(store: &Store, topics: &[(String, usize)]) -> Result<Vec<TopicHealth>> {
         let mut health = Vec::new();
         for (topic, _) in topics {
             if let Ok(h) = store.topic_health(topic) {
@@ -149,7 +149,7 @@ impl App {
         Ok(health)
     }
 
-    fn load_memoirs(store: &SqliteStore) -> Result<Vec<(String, String, usize, usize)>> {
+    fn load_memoirs(store: &Store) -> Result<Vec<(String, String, usize, usize)>> {
         let memoirs = store.list_memoirs()?;
         let mut result = Vec::new();
         for m in memoirs {
@@ -164,7 +164,7 @@ impl App {
         Ok(result)
     }
 
-    fn refresh(&mut self, store: &SqliteStore, db_path: Option<&str>) {
+    fn refresh(&mut self, store: &Store, db_path: Option<&str>) {
         if let Ok(s) = store.stats() {
             self.stats = s;
         }
@@ -185,7 +185,7 @@ impl App {
         self.last_refresh = Instant::now();
     }
 
-    fn load_topic_memories(&mut self, store: &SqliteStore) {
+    fn load_topic_memories(&mut self, store: &Store) {
         if let Some(idx) = self.topic_state.selected() {
             if let Some((topic, _)) = self.topics.get(idx) {
                 if let Ok(mut mems) = store.get_by_topic(topic) {
@@ -256,7 +256,7 @@ fn is_actionable_key(kind: KeyEventKind) -> bool {
     matches!(kind, KeyEventKind::Press | KeyEventKind::Repeat)
 }
 
-pub fn run_dashboard(store: &SqliteStore, db_path: Option<&str>) -> Result<()> {
+pub fn run_dashboard(store: &Store, db_path: Option<&str>) -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -281,7 +281,7 @@ pub fn run_dashboard(store: &SqliteStore, db_path: Option<&str>) -> Result<()> {
 fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut App,
-    store: &SqliteStore,
+    store: &Store,
     db_path: Option<&str>,
 ) -> Result<()> {
     loop {
@@ -528,7 +528,7 @@ fn run_loop(
 }
 
 /// Execute a confirmed action
-fn execute_confirm(app: &mut App, store: &SqliteStore, db_path: Option<&str>) {
+fn execute_confirm(app: &mut App, store: &Store, db_path: Option<&str>) {
     let confirm = app.confirm.clone();
     app.confirm = Confirm::None;
 

--- a/crates/icm-cli/src/web.rs
+++ b/crates/icm-cli/src/web.rs
@@ -16,7 +16,7 @@ use rust_embed::Embed;
 use serde::{Deserialize, Serialize};
 
 use icm_core::{FeedbackStore, MemoirStore, MemoryStore};
-use icm_store::SqliteStore;
+use icm_store::Store;
 
 use crate::config::WebConfig;
 use crate::truncate_at_char_boundary;
@@ -35,7 +35,7 @@ struct WebAssets;
 
 #[derive(Clone)]
 pub struct AppState {
-    store: Arc<Mutex<SqliteStore>>,
+    store: Arc<Mutex<Store>>,
     username: String,
     password: String,
 }
@@ -222,7 +222,7 @@ fn spa_router() -> Router<AppState> {
 
 #[tokio::main]
 pub async fn run_web_server(
-    store: SqliteStore,
+    store: Store,
     host: &str,
     port: u16,
     username: String,

--- a/crates/icm-core/src/error.rs
+++ b/crates/icm-core/src/error.rs
@@ -27,6 +27,16 @@ pub enum IcmError {
     /// the user what they tried to do.
     #[error("store is read-only; cannot perform: {0}")]
     ReadOnly(String),
+
+    /// The active storage backend does not implement this operation
+    /// (issue #301). The default SQLite backend supports everything;
+    /// opt-in remote backends (e.g. PostgreSQL) may only cover the core
+    /// memory surface and return this for the heavier subsystems
+    /// (memoir graph, transcripts, structured facts, feedback). Carries
+    /// the operation name so the caller can tell the user what is
+    /// unavailable on this backend.
+    #[error("operation not supported on this storage backend: {0}")]
+    Unsupported(String),
 }
 
 pub type IcmResult<T> = Result<T, IcmError>;

--- a/crates/icm-mcp/Cargo.toml
+++ b/crates/icm-mcp/Cargo.toml
@@ -4,12 +4,16 @@ version = "0.10.34"
 edition = "2021"
 
 [features]
-default = []
+default = ["backend-sqlite"]
 embeddings = ["icm-core/embeddings"]
+# Storage backend selection is driven by the binary crate (icm-cli); these
+# pass-through features let `cargo test -p icm-mcp` pick one directly.
+backend-sqlite = ["icm-store/backend-sqlite"]
+postgres = ["icm-store/postgres"]
 
 [dependencies]
 icm-core = { path = "../icm-core" }
-icm-store = { path = "../icm-store" }
+icm-store = { path = "../icm-store", default-features = false }
 chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/icm-mcp/src/server.rs
+++ b/crates/icm-mcp/src/server.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use tracing::{debug, error};
 
 use icm_core::Embedder;
-use icm_store::SqliteStore;
+use icm_store::Store;
 
 use crate::protocol::{JsonRpcMessage, JsonRpcResponse};
 use crate::tools;
@@ -22,7 +22,7 @@ const MAX_LINE_LEN: usize = 10 * 1024 * 1024;
 
 /// Run the MCP server on stdio. Blocks until stdin is closed.
 pub fn run_server(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn Embedder>,
     compact: bool,
 ) -> anyhow::Result<()> {
@@ -146,7 +146,7 @@ fn handle_tools_list(id: Value, has_embedder: bool) -> JsonRpcResponse {
 fn handle_tools_call(
     id: Value,
     params: &Option<Value>,
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn Embedder>,
     compact: bool,
     calls_since_store: &mut u32,

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -8,7 +8,7 @@ use icm_core::{
     MemoryStore, Relation, WakeUpFormat, WakeUpOptions, DEDUP_SIMILARITY_THRESHOLD,
     MSG_NO_MEMORIES,
 };
-use icm_store::SqliteStore;
+use icm_store::Store;
 
 use crate::protocol::ToolResult;
 
@@ -46,7 +46,7 @@ fn parse_keywords(args: &Value) -> Vec<String> {
 /// rolled-up memory had `embedding = None` and was invisible to hybrid
 /// recall until a manual `icm embed` rebuilt it).
 fn try_auto_consolidate(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn Embedder>,
     topic: &str,
     threshold: usize,
@@ -713,7 +713,7 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
 // ---------------------------------------------------------------------------
 
 pub fn call_tool(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn Embedder>,
     name: &str,
     args: &Value,
@@ -765,7 +765,7 @@ pub fn call_tool(
 // Transcript tool handlers
 // ---------------------------------------------------------------------------
 
-fn tool_transcript_start_session(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_transcript_start_session(store: &Store, args: &Value) -> ToolResult {
     use icm_core::TranscriptStore;
     let agent = args.get("agent").and_then(|v| v.as_str()).unwrap_or("mcp");
     let project = args.get("project").and_then(|v| v.as_str());
@@ -776,7 +776,7 @@ fn tool_transcript_start_session(store: &SqliteStore, args: &Value) -> ToolResul
     }
 }
 
-fn tool_transcript_record(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_transcript_record(store: &Store, args: &Value) -> ToolResult {
     use icm_core::{Role, TranscriptStore};
     let session_id = match args.get("session_id").and_then(|v| v.as_str()) {
         Some(s) => s,
@@ -807,7 +807,7 @@ fn tool_transcript_record(store: &SqliteStore, args: &Value) -> ToolResult {
     }
 }
 
-fn tool_transcript_search(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_transcript_search(store: &Store, args: &Value) -> ToolResult {
     use icm_core::TranscriptStore;
     let query = match args.get("query").and_then(|v| v.as_str()) {
         Some(s) => s,
@@ -829,7 +829,7 @@ fn tool_transcript_search(store: &SqliteStore, args: &Value) -> ToolResult {
     }
 }
 
-fn tool_transcript_show(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_transcript_show(store: &Store, args: &Value) -> ToolResult {
     use icm_core::TranscriptStore;
     let session_id = match args.get("session_id").and_then(|v| v.as_str()) {
         Some(s) => s,
@@ -853,7 +853,7 @@ fn tool_transcript_show(store: &SqliteStore, args: &Value) -> ToolResult {
     ToolResult::text(body.to_string())
 }
 
-fn tool_transcript_stats(store: &SqliteStore) -> ToolResult {
+fn tool_transcript_stats(store: &Store) -> ToolResult {
     use icm_core::TranscriptStore;
     match store.transcript_stats() {
         Ok(s) => ToolResult::text(serde_json::to_string(&s).unwrap_or_else(|_| "{}".into())),
@@ -865,7 +865,7 @@ fn tool_transcript_stats(store: &SqliteStore) -> ToolResult {
 // Wake-up tool handler
 // ---------------------------------------------------------------------------
 
-fn tool_wake_up(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_wake_up(store: &Store, args: &Value) -> ToolResult {
     // Normalize the project filter: empty string or "-" both mean "disabled",
     // mirroring the CLI convention.
     let project = match get_str(args, "project") {
@@ -908,7 +908,7 @@ fn get_i64(args: &Value, key: &str, default: i64) -> i64 {
     args.get(key).and_then(|v| v.as_i64()).unwrap_or(default)
 }
 
-fn resolve_memoir(store: &SqliteStore, name: &str) -> Result<Memoir, ToolResult> {
+fn resolve_memoir(store: &Store, name: &str) -> Result<Memoir, ToolResult> {
     store
         .get_memoir_by_name(name)
         .map_err(|e| ToolResult::error(format!("db error: {e}")))?
@@ -920,7 +920,7 @@ fn resolve_memoir(store: &SqliteStore, name: &str) -> Result<Memoir, ToolResult>
 // ---------------------------------------------------------------------------
 
 fn tool_store(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn Embedder>,
     args: &Value,
     compact: bool,
@@ -1146,7 +1146,7 @@ fn format_memory_output(memories: &[(Memory, f32)], compact: bool) -> String {
 }
 
 fn tool_recall(
-    store: &SqliteStore,
+    store: &Store,
     embedder: Option<&dyn Embedder>,
     args: &Value,
     compact: bool,
@@ -1289,7 +1289,7 @@ fn tool_recall(
     ToolResult::text(format_memory_output(&for_display, compact))
 }
 
-fn tool_forget(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_forget(store: &Store, args: &Value) -> ToolResult {
     let id = match get_str(args, "id") {
         Some(id) => id,
         None => return ToolResult::error("missing required field: id".into()),
@@ -1301,7 +1301,7 @@ fn tool_forget(store: &SqliteStore, args: &Value) -> ToolResult {
     }
 }
 
-fn tool_forget_topic(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_forget_topic(store: &Store, args: &Value) -> ToolResult {
     let topic = match get_str(args, "topic") {
         Some(t) => t,
         None => return ToolResult::error("missing required field: topic".into()),
@@ -1322,7 +1322,7 @@ fn tool_forget_topic(store: &SqliteStore, args: &Value) -> ToolResult {
     ToolResult::text(format!("Deleted {count} memories from topic: {topic}"))
 }
 
-fn tool_learn(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_learn(store: &Store, args: &Value) -> ToolResult {
     let dir_str = get_str(args, "directory").unwrap_or(".");
     let dir = std::path::PathBuf::from(dir_str);
 
@@ -1338,7 +1338,7 @@ fn tool_learn(store: &SqliteStore, args: &Value) -> ToolResult {
     }
 }
 
-fn tool_consolidate(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_consolidate(store: &Store, args: &Value) -> ToolResult {
     let topic = match get_str(args, "topic") {
         Some(t) => t,
         None => return ToolResult::error("missing required field: topic".into()),
@@ -1356,7 +1356,7 @@ fn tool_consolidate(store: &SqliteStore, args: &Value) -> ToolResult {
     }
 }
 
-fn tool_list_topics(store: &SqliteStore) -> ToolResult {
+fn tool_list_topics(store: &Store) -> ToolResult {
     match store.list_topics() {
         Ok(topics) => {
             if topics.is_empty() {
@@ -1401,7 +1401,7 @@ fn tool_list_topics(store: &SqliteStore) -> ToolResult {
     }
 }
 
-fn tool_stats(store: &SqliteStore) -> ToolResult {
+fn tool_stats(store: &Store) -> ToolResult {
     match store.stats() {
         Ok(stats) => {
             let mut output = format!(
@@ -1426,7 +1426,7 @@ fn tool_stats(store: &SqliteStore) -> ToolResult {
     }
 }
 
-fn tool_update(store: &SqliteStore, embedder: Option<&dyn Embedder>, args: &Value) -> ToolResult {
+fn tool_update(store: &Store, embedder: Option<&dyn Embedder>, args: &Value) -> ToolResult {
     let id = match get_str(args, "id") {
         Some(id) => id,
         None => return ToolResult::error("missing required field: id".into()),
@@ -1470,7 +1470,7 @@ fn tool_update(store: &SqliteStore, embedder: Option<&dyn Embedder>, args: &Valu
     }
 }
 
-fn tool_health(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_health(store: &Store, args: &Value) -> ToolResult {
     let specific_topic = get_str(args, "topic");
 
     let topics = if let Some(t) = specific_topic {
@@ -1521,7 +1521,7 @@ fn tool_health(store: &SqliteStore, args: &Value) -> ToolResult {
     ToolResult::text(output)
 }
 
-fn tool_extract_patterns(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_extract_patterns(store: &Store, args: &Value) -> ToolResult {
     let topic = match get_str(args, "topic") {
         Some(t) => t,
         None => return ToolResult::error("missing required field: topic".into()),
@@ -1589,11 +1589,7 @@ fn tool_extract_patterns(store: &SqliteStore, args: &Value) -> ToolResult {
     ToolResult::text(output)
 }
 
-fn tool_embed_all(
-    store: &SqliteStore,
-    embedder: Option<&dyn Embedder>,
-    args: &Value,
-) -> ToolResult {
+fn tool_embed_all(store: &Store, embedder: Option<&dyn Embedder>, args: &Value) -> ToolResult {
     let embedder = match embedder {
         Some(e) => e,
         None => return ToolResult::error("embeddings not available".into()),
@@ -1654,7 +1650,7 @@ fn tool_embed_all(
 // Memoir tool handlers
 // ---------------------------------------------------------------------------
 
-fn tool_memoir_create(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_memoir_create(store: &Store, args: &Value) -> ToolResult {
     let name = match get_str(args, "name") {
         Some(n) => n,
         None => return ToolResult::error("missing required field: name".into()),
@@ -1677,7 +1673,7 @@ fn tool_memoir_create(store: &SqliteStore, args: &Value) -> ToolResult {
     }
 }
 
-fn tool_memoir_list(store: &SqliteStore) -> ToolResult {
+fn tool_memoir_list(store: &Store) -> ToolResult {
     let memoirs = match store.list_memoirs() {
         Ok(m) => m,
         Err(e) => return ToolResult::error(format!("failed to list memoirs: {e}")),
@@ -1699,7 +1695,7 @@ fn tool_memoir_list(store: &SqliteStore) -> ToolResult {
     ToolResult::text(output)
 }
 
-fn tool_memoir_show(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_memoir_show(store: &Store, args: &Value) -> ToolResult {
     let name = match get_str(args, "name") {
         Some(n) => n,
         None => return ToolResult::error("missing required field: name".into()),
@@ -1756,7 +1752,7 @@ fn tool_memoir_show(store: &SqliteStore, args: &Value) -> ToolResult {
     ToolResult::text(output)
 }
 
-fn tool_memoir_add_concept(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_memoir_add_concept(store: &Store, args: &Value) -> ToolResult {
     let memoir_name = match get_str(args, "memoir") {
         Some(n) => n,
         None => return ToolResult::error("missing required field: memoir".into()),
@@ -1804,7 +1800,7 @@ fn tool_memoir_add_concept(store: &SqliteStore, args: &Value) -> ToolResult {
     }
 }
 
-fn tool_memoir_refine(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_memoir_refine(store: &Store, args: &Value) -> ToolResult {
     let memoir_name = match get_str(args, "memoir") {
         Some(n) => n,
         None => return ToolResult::error("missing required field: memoir".into()),
@@ -1844,7 +1840,7 @@ fn tool_memoir_refine(store: &SqliteStore, args: &Value) -> ToolResult {
     ))
 }
 
-fn tool_memoir_search(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_memoir_search(store: &Store, args: &Value) -> ToolResult {
     let memoir_name = match get_str(args, "memoir") {
         Some(n) => n,
         None => return ToolResult::error("missing required field: memoir".into()),
@@ -1904,7 +1900,7 @@ fn tool_memoir_search(store: &SqliteStore, args: &Value) -> ToolResult {
     ToolResult::text(output)
 }
 
-fn tool_memoir_search_all(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_memoir_search_all(store: &Store, args: &Value) -> ToolResult {
     let query = match get_str(args, "query") {
         Some(q) => q,
         None => return ToolResult::error("missing required field: query".into()),
@@ -1945,7 +1941,7 @@ fn tool_memoir_search_all(store: &SqliteStore, args: &Value) -> ToolResult {
     ToolResult::text(output)
 }
 
-fn tool_memoir_link(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_memoir_link(store: &Store, args: &Value) -> ToolResult {
     let memoir_name = match get_str(args, "memoir") {
         Some(n) => n,
         None => return ToolResult::error("missing required field: memoir".into()),
@@ -1993,7 +1989,7 @@ fn tool_memoir_link(store: &SqliteStore, args: &Value) -> ToolResult {
     }
 }
 
-fn tool_memoir_inspect(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_memoir_inspect(store: &Store, args: &Value) -> ToolResult {
     let memoir_name = match get_str(args, "memoir") {
         Some(n) => n,
         None => return ToolResult::error("missing required field: memoir".into()),
@@ -2050,7 +2046,7 @@ fn tool_memoir_inspect(store: &SqliteStore, args: &Value) -> ToolResult {
 
 // confidence_color and confidence_bar are now methods on Concept in icm-core
 
-fn tool_memoir_export(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_memoir_export(store: &Store, args: &Value) -> ToolResult {
     let memoir_name = match get_str(args, "name") {
         Some(n) => n,
         None => return ToolResult::error("missing required field: name".into()),
@@ -2250,7 +2246,7 @@ fn tool_memoir_export(store: &SqliteStore, args: &Value) -> ToolResult {
     }
 }
 
-fn tool_feedback_record(store: &SqliteStore, args: &Value, compact: bool) -> ToolResult {
+fn tool_feedback_record(store: &Store, args: &Value, compact: bool) -> ToolResult {
     let topic = match get_str(args, "topic") {
         Some(t) => t,
         None => return ToolResult::error("missing required field: topic".into()),
@@ -2292,7 +2288,7 @@ fn tool_feedback_record(store: &SqliteStore, args: &Value, compact: bool) -> Too
     }
 }
 
-fn tool_feedback_search(store: &SqliteStore, args: &Value) -> ToolResult {
+fn tool_feedback_search(store: &Store, args: &Value) -> ToolResult {
     let query = match get_str(args, "query") {
         Some(q) => q,
         None => return ToolResult::error("missing required field: query".into()),
@@ -2327,7 +2323,7 @@ fn tool_feedback_search(store: &SqliteStore, args: &Value) -> ToolResult {
     }
 }
 
-fn tool_feedback_stats(store: &SqliteStore) -> ToolResult {
+fn tool_feedback_stats(store: &Store) -> ToolResult {
     match store.feedback_stats() {
         Ok(stats) => {
             let mut output = format!("Feedback total: {}\n", stats.total);
@@ -2353,8 +2349,8 @@ fn tool_feedback_stats(store: &SqliteStore) -> ToolResult {
 mod tests {
     use super::*;
 
-    fn test_store() -> SqliteStore {
-        SqliteStore::in_memory().unwrap()
+    fn test_store() -> Store {
+        Store::in_memory().unwrap()
     }
 
     #[test]

--- a/crates/icm-store/Cargo.toml
+++ b/crates/icm-store/Cargo.toml
@@ -3,17 +3,44 @@ name = "icm-store"
 version = "0.10.34"
 edition = "2021"
 
+[features]
+# The default build is byte-for-byte the same as before: the in-process
+# SQLite backend, bundled, zero external services. This preserves the
+# "single binary, zero dependencies" promise (issue #301).
+default = ["backend-sqlite"]
+
+# In-process SQLite backend (rusqlite + sqlite-vec). The only built-in
+# backend; always the default.
+backend-sqlite = ["dep:rusqlite", "dep:sqlite-vec", "dep:zerocopy"]
+
+# Opt-in network-accessible PostgreSQL backend (issue #301). Lets several
+# ICM processes / Kubernetes replicas share one memory store, which a
+# node-local SQLite file cannot do. Mutually exclusive with
+# `backend-sqlite` (see the `compile_error!` guard in `lib.rs`); build
+# with `--no-default-features --features postgres`.
+postgres = ["dep:postgres", "dep:pgvector"]
+
 [dependencies]
 icm-core = { path = "../icm-core" }
-rusqlite = { workspace = true }
-sqlite-vec = { workspace = true }
-zerocopy = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }
 lru = { workspace = true }
 sha2 = { workspace = true }
 ulid = { workspace = true }
+
+# SQLite backend (default). Optional so the `postgres` backend can be
+# built without pulling in rusqlite / sqlite-vec.
+rusqlite = { workspace = true, optional = true }
+sqlite-vec = { workspace = true, optional = true }
+zerocopy = { workspace = true, optional = true }
+
+# PostgreSQL backend (opt-in). The blocking `postgres` client matches the
+# store's synchronous trait surface exactly, so no async runtime or
+# sync-over-async bridge is needed. `pgvector` adds the `vector` column
+# type binding used for embedding KNN search.
+postgres = { version = "0.19", features = ["with-chrono-0_4"], optional = true }
+pgvector = { version = "0.4", features = ["postgres"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/icm-store/src/lib.rs
+++ b/crates/icm-store/src/lib.rs
@@ -1,4 +1,50 @@
+//! Storage backends for ICM.
+//!
+//! The store is pluggable (issue #301). Exactly one backend is selected
+//! at build time via a Cargo feature, and both expose the same public
+//! surface through the [`Store`] type alias so `icm-cli` / `icm-mcp` are
+//! backend-agnostic:
+//!
+//! - **`backend-sqlite`** (default) — in-process SQLite via `rusqlite` +
+//!   `sqlite-vec`. Single binary, zero external services. This is the
+//!   only built-in backend and is byte-for-byte unchanged from before.
+//! - **`postgres`** (opt-in) — a network-accessible PostgreSQL backend so
+//!   multiple ICM processes / Kubernetes replicas can share one memory
+//!   store, which a node-local SQLite file cannot do. Build with
+//!   `--no-default-features --features postgres`.
+
+// Exactly one backend must be active.
+#[cfg(all(feature = "backend-sqlite", feature = "postgres"))]
+compile_error!(
+    "features `backend-sqlite` and `postgres` are mutually exclusive; \
+     build the postgres backend with `--no-default-features --features postgres`"
+);
+#[cfg(not(any(feature = "backend-sqlite", feature = "postgres")))]
+compile_error!(
+    "a storage backend must be selected: enable `backend-sqlite` (default) or `postgres`"
+);
+
+#[cfg(feature = "backend-sqlite")]
 mod schema;
+#[cfg(feature = "backend-sqlite")]
 mod store;
 
+#[cfg(feature = "postgres")]
+mod postgres;
+
+#[cfg(feature = "backend-sqlite")]
 pub use store::{HookEvent, HookEventInsert, HookStatsRow, PendingRow, SqliteStore};
+
+/// The active storage backend. `icm-cli` and `icm-mcp` use this alias
+/// everywhere instead of a concrete type, so swapping backends is a
+/// build-feature change with no call-site churn.
+#[cfg(feature = "backend-sqlite")]
+pub type Store = SqliteStore;
+
+#[cfg(feature = "postgres")]
+pub use postgres::{HookEvent, HookEventInsert, HookStatsRow, PendingRow, PostgresStore};
+
+/// The active storage backend (PostgreSQL build). See the `backend-sqlite`
+/// variant above.
+#[cfg(feature = "postgres")]
+pub type Store = PostgresStore;

--- a/crates/icm-store/src/postgres.rs
+++ b/crates/icm-store/src/postgres.rs
@@ -1,0 +1,1802 @@
+//! PostgreSQL storage backend (issue #301, opt-in via `--features postgres`).
+//!
+//! A node-local SQLite file cannot be shared between several ICM
+//! processes or Kubernetes replicas. This backend runs the same memory
+//! model over a network-accessible PostgreSQL database so every instance
+//! reads and writes one shared store. PostgreSQL serialises concurrent
+//! writers, so N replicas can `icm store` into the same memory safely.
+//!
+//! Design notes:
+//!
+//! - **Blocking client.** The store traits are synchronous
+//!   (`fn store(&self, ...) -> IcmResult<...>`), so we use the blocking
+//!   `postgres` crate. No async runtime, no sync-over-async bridge — the
+//!   client maps one-to-one onto the trait surface.
+//! - **`pgvector` for embeddings.** Memory embeddings live in a
+//!   `vector(N)` column; KNN search uses the `<=>` cosine-distance
+//!   operator. Similarity is reported as `1 - distance` to match the
+//!   SQLite backend.
+//! - **PostgreSQL full-text search** replaces SQLite FTS5: a generated
+//!   `tsvector` column (config `simple`, no stemming, to mirror FTS5's
+//!   unicode61 tokenizer) with a GIN index, queried via
+//!   `websearch_to_tsquery` so arbitrary user input is operator-safe.
+//! - **Connection string** comes from `ICM_POSTGRES_URL` (or
+//!   `DATABASE_URL` as a fallback). The `&Path` arguments that the CLI
+//!   passes for the SQLite file are ignored.
+//!
+//! Scope of this first cut: the full [`MemoryStore`] surface (the core
+//! shared-memory use case behind #301) plus the ancillary tables used by
+//! the normal store/recall/hook path (hook telemetry, the extraction
+//! queue, code areas, the key/value metadata). The heavier subsystems
+//! (memoir graph, transcripts, structured facts, feedback, pattern
+//! mining) return [`IcmError::Unsupported`] on this backend for now;
+//! they remain fully available on the default SQLite backend.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::sync::{Mutex, MutexGuard};
+
+use chrono::{DateTime, Utc};
+use postgres::types::ToSql;
+use postgres::{Client, GenericClient, NoTls};
+
+use icm_core::{
+    Concept, ConceptLink, Embedder, Fact, FactsStats, FactsStore, Feedback, FeedbackStats,
+    FeedbackStore, IcmError, IcmResult, Importance, Label, Memoir, MemoirStats, MemoirStore,
+    Memory, MemorySource, MemoryStore, Message, PatternCluster, Relation, Role, Session,
+    StoreStats, TopicHealth, TranscriptHit, TranscriptStats, TranscriptStore,
+};
+
+// ---------------------------------------------------------------------------
+// Shared public row types
+//
+// These mirror the structs the SQLite backend exposes (they live in
+// `store.rs` there). Both backends are mutually exclusive at build time,
+// so duplicating the definitions here — rather than sharing a module —
+// keeps `store.rs` byte-for-byte unchanged on the default build.
+// ---------------------------------------------------------------------------
+
+/// One row of the `hook_events` telemetry table.
+#[derive(Debug, Clone)]
+pub struct HookEvent {
+    pub id: i64,
+    pub ts: DateTime<Utc>,
+    pub event: String,
+    pub project: Option<String>,
+    pub session_id: Option<String>,
+    pub tool_name: Option<String>,
+    pub duration_ms: Option<i64>,
+    pub exit_code: i32,
+    pub payload_size: Option<i64>,
+    pub note: Option<String>,
+}
+
+/// Insert payload for a single `hook_events` row. `id` and `ts` are
+/// filled in by the store.
+#[derive(Debug, Clone, Default)]
+pub struct HookEventInsert {
+    pub event: String,
+    pub project: Option<String>,
+    pub session_id: Option<String>,
+    pub tool_name: Option<String>,
+    pub duration_ms: Option<i64>,
+    pub exit_code: i32,
+    pub payload_size: Option<i64>,
+    pub note: Option<String>,
+}
+
+/// One row of the `code_areas` table (auto-captured file edits, #196).
+#[derive(Debug, Clone)]
+pub struct CodeArea {
+    pub id: i64,
+    pub project: String,
+    pub file_path: String,
+    pub description: Option<String>,
+    pub session_id: Option<String>,
+    pub tool_name: Option<String>,
+    pub touch_count: i64,
+    pub first_touched_at: DateTime<Utc>,
+    pub last_touched_at: DateTime<Utc>,
+}
+
+/// Aggregate counts/percentiles for a slice of hook history.
+#[derive(Debug, Clone, Default)]
+pub struct HookStatsRow {
+    pub event: String,
+    pub count: i64,
+    pub error_count: i64,
+    pub avg_duration_ms: f64,
+    pub p50_duration_ms: i64,
+    pub p99_duration_ms: i64,
+}
+
+/// Queue row tuple shape: `(id, project, tool_name, raw_output, captured_at)`.
+/// `captured_at` is RFC3339 to match the SQLite backend's tuple.
+pub type PendingRow = (String, String, String, String, String);
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrored from the SQLite backend so behaviour matches)
+// ---------------------------------------------------------------------------
+
+fn pg_err(e: postgres::Error) -> IcmError {
+    IcmError::Database(e.to_string())
+}
+
+fn lock_err() -> IcmError {
+    IcmError::Database("postgres client mutex poisoned".into())
+}
+
+fn source_type(source: &MemorySource) -> &'static str {
+    match source {
+        MemorySource::ClaudeCode { .. } => "claude_code",
+        MemorySource::Conversation { .. } => "conversation",
+        MemorySource::Manual => "manual",
+    }
+}
+
+fn source_data(source: &MemorySource) -> Option<String> {
+    match source {
+        MemorySource::Manual => None,
+        other => serde_json::to_string(other).ok(),
+    }
+}
+
+fn parse_source(source_type_str: &str, source_data_str: Option<String>) -> MemorySource {
+    match source_type_str {
+        "manual" => MemorySource::Manual,
+        _ => source_data_str
+            .and_then(|d| serde_json::from_str(&d).ok())
+            .unwrap_or(MemorySource::Manual),
+    }
+}
+
+fn importance_rank(i: Importance) -> u8 {
+    match i {
+        Importance::Critical => 4,
+        Importance::High => 3,
+        Importance::Medium => 2,
+        Importance::Low => 1,
+    }
+}
+
+fn max_importance(a: Importance, b: Importance) -> Importance {
+    if importance_rank(a) >= importance_rank(b) {
+        a
+    } else {
+        b
+    }
+}
+
+/// SHA-256 over the normalized `(topic, summary)` pair, hex-encoded.
+/// Identical normalization to the SQLite backend so dedup hashes match.
+fn summary_hash(topic: &str, summary: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let topic_n = topic.trim().to_lowercase();
+    let summary_n: String = summary
+        .split_whitespace()
+        .collect::<Vec<&str>>()
+        .join(" ")
+        .to_lowercase();
+    let mut h = Sha256::new();
+    h.update(topic_n.as_bytes());
+    h.update(b"\0");
+    h.update(summary_n.as_bytes());
+    format!("{:x}", h.finalize())
+}
+
+const MAX_SUMMARY_BYTES: usize = 64 * 1024;
+const MAX_TOPIC_BYTES: usize = 256;
+
+/// Validate and normalize a `Memory` before insertion. Mirrors the
+/// SQLite backend's `validate_and_normalize`.
+fn validate_and_normalize(mut memory: Memory) -> IcmResult<Memory> {
+    memory.topic = memory.topic.trim().to_string();
+
+    if memory.topic.is_empty() {
+        return Err(IcmError::InvalidInput("topic cannot be empty".into()));
+    }
+    if memory.summary.trim().is_empty() {
+        return Err(IcmError::InvalidInput("summary cannot be empty".into()));
+    }
+    if memory.topic.contains('\0') {
+        return Err(IcmError::InvalidInput(
+            "topic must not contain NUL bytes".into(),
+        ));
+    }
+    if memory.summary.contains('\0') {
+        return Err(IcmError::InvalidInput(
+            "summary must not contain NUL bytes".into(),
+        ));
+    }
+    if memory.topic.contains(['\n', '\r', '\t']) {
+        return Err(IcmError::InvalidInput(
+            "topic must not contain newline / CR / tab characters".into(),
+        ));
+    }
+    if memory.topic.len() > MAX_TOPIC_BYTES {
+        return Err(IcmError::InvalidInput(format!(
+            "topic exceeds {MAX_TOPIC_BYTES} bytes"
+        )));
+    }
+    if memory.summary.len() > MAX_SUMMARY_BYTES {
+        return Err(IcmError::InvalidInput(format!(
+            "summary exceeds {MAX_SUMMARY_BYTES} bytes"
+        )));
+    }
+    Ok(memory)
+}
+
+const SELECT_COLS: &str = "id, created_at, updated_at, last_accessed, access_count, weight, \
+                           topic, summary, raw_excerpt, keywords, \
+                           importance, source_type, source_data, related_ids, embedding";
+
+/// Map a `memories` row (selected via [`SELECT_COLS`]) to a [`Memory`].
+fn row_to_memory(row: &postgres::Row) -> Memory {
+    let keywords_json: Option<String> = row.get(9);
+    let keywords: Vec<String> = keywords_json
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default();
+
+    let importance_str: String = row.get(10);
+    let importance = importance_str.parse().unwrap_or(Importance::Medium);
+
+    let source_type_str: String = row.get(11);
+    let source_data_str: Option<String> = row.get(12);
+    let source = parse_source(&source_type_str, source_data_str);
+
+    let related_json: Option<String> = row.get(13);
+    let related_ids: Vec<String> = related_json
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default();
+
+    let embedding: Option<Vec<f32>> = row
+        .get::<_, Option<pgvector::Vector>>(14)
+        .map(|v| v.as_slice().to_vec());
+
+    let access_count: i32 = row.get(4);
+
+    Memory {
+        id: row.get(0),
+        created_at: row.get(1),
+        updated_at: row.get(2),
+        last_accessed: row.get(3),
+        access_count: access_count.max(0) as u32,
+        weight: row.get(5),
+        topic: row.get(6),
+        summary: row.get(7),
+        raw_excerpt: row.get(8),
+        keywords,
+        importance,
+        source,
+        related_ids,
+        embedding,
+        scope: icm_core::Scope::User,
+    }
+}
+
+/// Insert a memory, or merge metadata into an existing duplicate.
+///
+/// Dedup contract identical to the SQLite backend: a collision on
+/// `(LOWER(topic), summary_hash)` is ignored and the existing row's id is
+/// returned, after merging the caller's importance (take max), keywords
+/// (union), and `raw_excerpt` (prefer new) into it.
+fn insert_or_merge_memory<C: GenericClient>(c: &mut C, memory: &Memory) -> IcmResult<String> {
+    let keywords_json = serde_json::to_string(&memory.keywords)?;
+    let related_json = serde_json::to_string(&memory.related_ids)?;
+    let st = source_type(&memory.source);
+    let sd = source_data(&memory.source);
+    let hash = summary_hash(&memory.topic, &memory.summary);
+    let importance = memory.importance.to_string();
+    let access = memory.access_count as i32;
+    let emb: Option<pgvector::Vector> = memory
+        .embedding
+        .as_ref()
+        .map(|e| pgvector::Vector::from(e.clone()));
+
+    let inserted = c
+        .query_opt(
+            "INSERT INTO memories
+             (id, created_at, updated_at, last_accessed, access_count, weight,
+              topic, summary, raw_excerpt, keywords, importance,
+              source_type, source_data, related_ids, summary_hash, embedding)
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+             ON CONFLICT (LOWER(topic), summary_hash) WHERE summary_hash IS NOT NULL
+             DO NOTHING
+             RETURNING id",
+            &[
+                &memory.id,
+                &memory.created_at,
+                &memory.updated_at,
+                &memory.last_accessed,
+                &access,
+                &memory.weight,
+                &memory.topic,
+                &memory.summary,
+                &memory.raw_excerpt,
+                &keywords_json,
+                &importance,
+                &st,
+                &sd,
+                &related_json,
+                &hash,
+                &emb,
+            ],
+        )
+        .map_err(pg_err)?;
+
+    if let Some(row) = inserted {
+        return Ok(row.get::<_, String>(0));
+    }
+
+    // Dedup hit: merge metadata into the existing row (mirrors SQLite).
+    let existing = c
+        .query_one(
+            "SELECT id, importance, keywords, raw_excerpt FROM memories
+             WHERE LOWER(topic) = LOWER($1) AND summary_hash = $2",
+            &[&memory.topic, &hash],
+        )
+        .map_err(pg_err)?;
+
+    let existing_id: String = existing.get(0);
+    let existing_importance_str: String = existing.get(1);
+    let existing_keywords_json: Option<String> = existing.get(2);
+    let existing_raw: Option<String> = existing.get(3);
+
+    let existing_importance: Importance = existing_importance_str
+        .parse()
+        .unwrap_or(Importance::Medium);
+    let merged_importance = max_importance(existing_importance, memory.importance);
+
+    let existing_keywords: Vec<String> = existing_keywords_json
+        .as_deref()
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or_default();
+    let mut merged_keywords = existing_keywords.clone();
+    for kw in &memory.keywords {
+        if !merged_keywords.contains(kw) {
+            merged_keywords.push(kw.clone());
+        }
+    }
+
+    let merged_raw = memory.raw_excerpt.clone().or_else(|| existing_raw.clone());
+
+    let importance_changed = merged_importance != existing_importance;
+    let keywords_changed = merged_keywords != existing_keywords;
+    let raw_changed = merged_raw != existing_raw;
+    if importance_changed || keywords_changed || raw_changed {
+        let merged_keywords_json = serde_json::to_string(&merged_keywords)?;
+        c.execute(
+            "UPDATE memories
+             SET importance = $1, keywords = $2, raw_excerpt = $3, updated_at = $4
+             WHERE id = $5",
+            &[
+                &merged_importance.to_string(),
+                &merged_keywords_json,
+                &merged_raw,
+                &Utc::now(),
+                &existing_id,
+            ],
+        )
+        .map_err(pg_err)?;
+    }
+
+    Ok(existing_id)
+}
+
+// ---------------------------------------------------------------------------
+// PostgresStore
+// ---------------------------------------------------------------------------
+
+/// PostgreSQL-backed store. See the module docs.
+pub struct PostgresStore {
+    client: Mutex<Client>,
+    embedding_dims: usize,
+    readonly: bool,
+}
+
+impl PostgresStore {
+    fn conn(&self) -> IcmResult<MutexGuard<'_, Client>> {
+        self.client.lock().map_err(|_| lock_err())
+    }
+
+    /// Resolve the connection string from the environment.
+    fn conn_string() -> IcmResult<String> {
+        std::env::var("ICM_POSTGRES_URL")
+            .or_else(|_| std::env::var("DATABASE_URL"))
+            .map_err(|_| {
+                IcmError::Config(
+                    "PostgreSQL backend: set ICM_POSTGRES_URL (or DATABASE_URL) to the \
+                     connection string, e.g. postgres://user:pass@host:5432/icm"
+                        .into(),
+                )
+            })
+    }
+
+    /// Connect and run the idempotent schema migration.
+    ///
+    /// The `&Path` the CLI passes for the SQLite file is ignored; the
+    /// connection comes from the environment. `requested_dims` is used
+    /// only when the database is fresh — an existing database's stored
+    /// `embedding_dims` is authoritative so we never try to declare a
+    /// `vector(N)` column that disagrees with the live table.
+    fn connect(requested_dims: usize, readonly: bool) -> IcmResult<Self> {
+        let url = Self::conn_string()?;
+        let mut client = Client::connect(&url, NoTls)
+            .map_err(|e| IcmError::Database(format!("cannot connect to PostgreSQL: {e}")))?;
+
+        let dims = init_schema(&mut client, requested_dims)?;
+
+        Ok(Self {
+            client: Mutex::new(client),
+            embedding_dims: dims,
+            readonly,
+        })
+    }
+
+    /// Reject an embedding whose length disagrees with the column's
+    /// declared dimension, with a clearer message than the raw PostgreSQL
+    /// "expected N dimensions, not M" error.
+    fn check_dims(&self, memory: &Memory) -> IcmResult<()> {
+        if let Some(emb) = memory.embedding.as_ref() {
+            if emb.len() != self.embedding_dims {
+                return Err(IcmError::InvalidInput(format!(
+                    "embedding has {} dimensions, but this store uses {}",
+                    emb.len(),
+                    self.embedding_dims
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Open or create a store with the default embedding dimension.
+    pub fn new(_path: &Path) -> IcmResult<Self> {
+        Self::connect(icm_core::DEFAULT_EMBEDDING_DIMS, false)
+    }
+
+    /// Open or create a store with a specific embedding dimension.
+    pub fn with_dims(_path: &Path, embedding_dims: usize) -> IcmResult<Self> {
+        Self::connect(embedding_dims, false)
+    }
+
+    /// Open the store in read-only mode (issue #263). The connection is
+    /// the same; write methods refuse, read-like side effects are skipped.
+    pub fn open_readonly(_path: &Path) -> IcmResult<Self> {
+        Self::connect(icm_core::DEFAULT_EMBEDDING_DIMS, true)
+    }
+
+    /// PostgreSQL has no in-memory mode; connect to the configured
+    /// database. Provided for API parity with the SQLite backend.
+    pub fn in_memory() -> IcmResult<Self> {
+        Self::connect(icm_core::DEFAULT_EMBEDDING_DIMS, false)
+    }
+
+    /// See [`Self::in_memory`].
+    pub fn in_memory_with_dims(embedding_dims: usize) -> IcmResult<Self> {
+        Self::connect(embedding_dims, false)
+    }
+
+    /// PostgreSQL stores `embedding_dims` in `icm_metadata`, but unlike
+    /// SQLite it never destructively recreates the vector column, so the
+    /// pre-open peek the SQLite backend needs is unnecessary here. Always
+    /// returns `Ok(None)` so callers fall through to the normal open path.
+    pub fn read_stored_embedding_dims(_path: &Path) -> IcmResult<Option<usize>> {
+        Ok(None)
+    }
+
+    #[must_use]
+    pub fn is_readonly(&self) -> bool {
+        self.readonly
+    }
+
+    /// No-op on PostgreSQL (the SQLite backend uses this to load the
+    /// `sqlite-vec` extension; `pgvector` lives server-side).
+    pub fn ensure_vec_init() {}
+
+    /// Apply decay if more than 24 hours since the last run. Mirrors the
+    /// SQLite backend's atomic check-and-claim via `icm_metadata`.
+    pub fn maybe_auto_decay(&self) -> IcmResult<()> {
+        if self.readonly {
+            return Ok(());
+        }
+        let now = Utc::now();
+        let claimed = {
+            let mut c = self.conn()?;
+            c.execute(
+                "INSERT INTO icm_metadata (key, value) VALUES ('last_decay_at', $1)
+                 ON CONFLICT (key) DO UPDATE SET value = $1
+                 WHERE icm_metadata.value IS NULL
+                    OR ($1::timestamptz - icm_metadata.value::timestamptz) >= interval '1 day'",
+                &[&now.to_rfc3339()],
+            )
+            .map_err(pg_err)?
+        };
+        if claimed > 0 {
+            self.apply_decay(0.95)?;
+        }
+        Ok(())
+    }
+
+    /// Atomically increment the hook call counter and return the new value.
+    pub fn increment_hook_counter(&self) -> IcmResult<usize> {
+        let mut c = self.conn()?;
+        let row = c
+            .query_one(
+                "INSERT INTO icm_metadata (key, value) VALUES ('hook_counter', '1')
+                 ON CONFLICT (key) DO UPDATE SET value = ((icm_metadata.value::bigint) + 1)::text
+                 RETURNING value::bigint",
+                &[],
+            )
+            .map_err(pg_err)?;
+        let n: i64 = row.get(0);
+        Ok(n.max(0) as usize)
+    }
+
+    /// Reset the hook call counter to 0.
+    pub fn reset_hook_counter(&self) -> IcmResult<()> {
+        let mut c = self.conn()?;
+        c.execute(
+            "INSERT INTO icm_metadata (key, value) VALUES ('hook_counter', '0')
+             ON CONFLICT (key) DO UPDATE SET value = '0'",
+            &[],
+        )
+        .map_err(pg_err)?;
+        Ok(())
+    }
+
+    // ── Async extraction queue ─────────────────────────────────────────
+
+    /// Enqueue raw tool output for later LLM extraction.
+    pub fn enqueue_pending_extraction(
+        &self,
+        project: &str,
+        tool_name: &str,
+        raw_output: &str,
+    ) -> IcmResult<String> {
+        let id = ulid::Ulid::new().to_string();
+        let mut c = self.conn()?;
+        c.execute(
+            "INSERT INTO pending_extractions (id, project, tool_name, raw_output, captured_at)
+             VALUES ($1, $2, $3, $4, $5)",
+            &[&id, &project, &tool_name, &raw_output, &Utc::now()],
+        )
+        .map_err(pg_err)?;
+        Ok(id)
+    }
+
+    /// Pop up to `limit` oldest pending rows (FIFO by capture time).
+    pub fn list_pending_extractions(&self, limit: usize) -> IcmResult<Vec<PendingRow>> {
+        let mut c = self.conn()?;
+        let rows = c
+            .query(
+                "SELECT id, project, tool_name, raw_output, captured_at
+                 FROM pending_extractions
+                 ORDER BY captured_at ASC
+                 LIMIT $1",
+                &[&(limit as i64)],
+            )
+            .map_err(pg_err)?;
+        Ok(rows
+            .iter()
+            .map(|row| {
+                let captured: DateTime<Utc> = row.get(4);
+                (
+                    row.get(0),
+                    row.get(1),
+                    row.get(2),
+                    row.get(3),
+                    captured.to_rfc3339(),
+                )
+            })
+            .collect())
+    }
+
+    /// Delete pending rows by id. Used after a worker has processed them.
+    pub fn delete_pending_extractions(&self, ids: &[String]) -> IcmResult<usize> {
+        if ids.is_empty() {
+            return Ok(0);
+        }
+        let ids_vec: Vec<String> = ids.to_vec();
+        let mut c = self.conn()?;
+        let n = c
+            .execute(
+                "DELETE FROM pending_extractions WHERE id = ANY($1)",
+                &[&ids_vec],
+            )
+            .map_err(pg_err)?;
+        Ok(n as usize)
+    }
+
+    /// Total rows currently waiting in the queue.
+    pub fn pending_extraction_count(&self) -> IcmResult<usize> {
+        let mut c = self.conn()?;
+        let row = c
+            .query_one("SELECT COUNT(*) FROM pending_extractions", &[])
+            .map_err(pg_err)?;
+        let n: i64 = row.get(0);
+        Ok(n.max(0) as usize)
+    }
+
+    // ── Code areas (issue #196) ────────────────────────────────────────
+
+    /// Insert or refresh a row for `(project, file_path)`.
+    pub fn upsert_code_area(
+        &self,
+        project: &str,
+        file_path: &str,
+        description: Option<&str>,
+        session_id: Option<&str>,
+        tool_name: Option<&str>,
+    ) -> IcmResult<()> {
+        let now = Utc::now();
+        let mut c = self.conn()?;
+        c.execute(
+            "INSERT INTO code_areas
+                (project, file_path, description, session_id, tool_name,
+                 touch_count, first_touched_at, last_touched_at)
+             VALUES ($1, $2, $3, $4, $5, 1, $6, $6)
+             ON CONFLICT (project, file_path) DO UPDATE SET
+                touch_count = code_areas.touch_count + 1,
+                last_touched_at = EXCLUDED.last_touched_at,
+                session_id = COALESCE(EXCLUDED.session_id, code_areas.session_id),
+                tool_name = COALESCE(EXCLUDED.tool_name, code_areas.tool_name),
+                description = COALESCE(EXCLUDED.description, code_areas.description)",
+            &[
+                &project,
+                &file_path,
+                &description,
+                &session_id,
+                &tool_name,
+                &now,
+            ],
+        )
+        .map_err(pg_err)?;
+        Ok(())
+    }
+
+    /// List code areas, optionally filtered, newest-touch first.
+    pub fn list_code_areas(
+        &self,
+        project: Option<&str>,
+        in_file: Option<&str>,
+        since: Option<DateTime<Utc>>,
+        limit: usize,
+    ) -> IcmResult<Vec<CodeArea>> {
+        let mut sql = String::from(
+            "SELECT id, project, file_path, description, session_id, tool_name,
+                    touch_count, first_touched_at, last_touched_at
+             FROM code_areas WHERE TRUE",
+        );
+        let mut owned: Vec<Box<dyn ToSql + Sync>> = Vec::new();
+        if let Some(p) = project {
+            owned.push(Box::new(p.to_string()));
+            sql.push_str(&format!(" AND project = ${}", owned.len()));
+        }
+        if let Some(f) = in_file {
+            owned.push(Box::new(f.to_string()));
+            let exact = owned.len();
+            owned.push(Box::new(format!("%/{f}")));
+            let suffix = owned.len();
+            sql.push_str(&format!(
+                " AND (file_path = ${exact} OR file_path LIKE ${suffix})"
+            ));
+        }
+        if let Some(t) = since {
+            owned.push(Box::new(t));
+            sql.push_str(&format!(" AND last_touched_at >= ${}", owned.len()));
+        }
+        owned.push(Box::new(limit as i64));
+        sql.push_str(&format!(
+            " ORDER BY last_touched_at DESC LIMIT ${}",
+            owned.len()
+        ));
+
+        let params: Vec<&(dyn ToSql + Sync)> = owned.iter().map(|b| b.as_ref()).collect();
+        let mut c = self.conn()?;
+        let rows = c.query(&sql, &params).map_err(pg_err)?;
+        Ok(rows
+            .iter()
+            .map(|row| CodeArea {
+                id: row.get(0),
+                project: row.get(1),
+                file_path: row.get(2),
+                description: row.get(3),
+                session_id: row.get(4),
+                tool_name: row.get(5),
+                touch_count: row.get(6),
+                first_touched_at: row.get(7),
+                last_touched_at: row.get(8),
+            })
+            .collect())
+    }
+
+    /// Total rows in `code_areas`.
+    pub fn code_area_count(&self) -> IcmResult<usize> {
+        let mut c = self.conn()?;
+        let row = c
+            .query_one("SELECT COUNT(*) FROM code_areas", &[])
+            .map_err(pg_err)?;
+        let n: i64 = row.get(0);
+        Ok(n.max(0) as usize)
+    }
+
+    // ── Hook telemetry ─────────────────────────────────────────────────
+
+    /// Append one hook telemetry row, returning its id.
+    pub fn record_hook_event(&self, ev: &HookEventInsert) -> IcmResult<i64> {
+        let mut c = self.conn()?;
+        let row = c
+            .query_one(
+                "INSERT INTO hook_events
+                 (ts, event, project, session_id, tool_name,
+                  duration_ms, exit_code, payload_size, note)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                 RETURNING id",
+                &[
+                    &Utc::now(),
+                    &ev.event,
+                    &ev.project,
+                    &ev.session_id,
+                    &ev.tool_name,
+                    &ev.duration_ms,
+                    &ev.exit_code,
+                    &ev.payload_size,
+                    &ev.note,
+                ],
+            )
+            .map_err(pg_err)?;
+        Ok(row.get(0))
+    }
+
+    /// Most recent `limit` hook events, newest first; optional event filter.
+    pub fn hook_events_recent(
+        &self,
+        limit: usize,
+        event_filter: Option<&str>,
+    ) -> IcmResult<Vec<HookEvent>> {
+        let mut c = self.conn()?;
+        let rows = match event_filter {
+            Some(ev) => c.query(
+                "SELECT id, ts, event, project, session_id, tool_name,
+                        duration_ms, exit_code, payload_size, note
+                 FROM hook_events WHERE event = $1 ORDER BY id DESC LIMIT $2",
+                &[&ev, &(limit as i64)],
+            ),
+            None => c.query(
+                "SELECT id, ts, event, project, session_id, tool_name,
+                        duration_ms, exit_code, payload_size, note
+                 FROM hook_events ORDER BY id DESC LIMIT $1",
+                &[&(limit as i64)],
+            ),
+        }
+        .map_err(pg_err)?;
+        Ok(rows
+            .iter()
+            .map(|row| HookEvent {
+                id: row.get(0),
+                ts: row.get(1),
+                event: row.get(2),
+                project: row.get(3),
+                session_id: row.get(4),
+                tool_name: row.get(5),
+                duration_ms: row.get(6),
+                exit_code: row.get(7),
+                payload_size: row.get(8),
+                note: row.get(9),
+            })
+            .collect())
+    }
+
+    /// Per-event aggregate stats since `since_rfc3339`.
+    pub fn hook_stats(&self, since_rfc3339: &str) -> IcmResult<Vec<HookStatsRow>> {
+        let since = DateTime::parse_from_rfc3339(since_rfc3339)
+            .map(|d| d.with_timezone(&Utc))
+            .unwrap_or_else(|_| Utc::now() - chrono::Duration::days(7));
+        let mut c = self.conn()?;
+        let rows = c
+            .query(
+                "SELECT event,
+                        COUNT(*)::bigint,
+                        COUNT(*) FILTER (WHERE exit_code <> 0)::bigint,
+                        COALESCE(AVG(duration_ms), 0)::float8,
+                        COALESCE(percentile_cont(0.5) WITHIN GROUP (ORDER BY duration_ms), 0)::float8,
+                        COALESCE(percentile_cont(0.99) WITHIN GROUP (ORDER BY duration_ms), 0)::float8
+                 FROM hook_events WHERE ts >= $1
+                 GROUP BY event ORDER BY event",
+                &[&since],
+            )
+            .map_err(pg_err)?;
+        Ok(rows
+            .iter()
+            .map(|row| {
+                let p50: f64 = row.get(4);
+                let p99: f64 = row.get(5);
+                HookStatsRow {
+                    event: row.get(0),
+                    count: row.get(1),
+                    error_count: row.get(2),
+                    avg_duration_ms: row.get(3),
+                    p50_duration_ms: p50 as i64,
+                    p99_duration_ms: p99 as i64,
+                }
+            })
+            .collect())
+    }
+
+    /// Delete hook events older than `cutoff_rfc3339`.
+    pub fn prune_hook_events(&self, cutoff_rfc3339: &str) -> IcmResult<usize> {
+        let cutoff = DateTime::parse_from_rfc3339(cutoff_rfc3339)
+            .map(|d| d.with_timezone(&Utc))
+            .map_err(|e| IcmError::InvalidInput(format!("invalid cutoff timestamp: {e}")))?;
+        let mut c = self.conn()?;
+        let n = c
+            .execute("DELETE FROM hook_events WHERE ts < $1", &[&cutoff])
+            .map_err(pg_err)?;
+        Ok(n as usize)
+    }
+
+    /// Total rows in `hook_events`.
+    pub fn hook_event_count(&self) -> IcmResult<usize> {
+        let mut c = self.conn()?;
+        let row = c
+            .query_one("SELECT COUNT(*) FROM hook_events", &[])
+            .map_err(pg_err)?;
+        let n: i64 = row.get(0);
+        Ok(n.max(0) as usize)
+    }
+
+    // ── Memory reads used by recall expansion ──────────────────────────
+
+    /// Fetch many memories by id in one round-trip, deduplicated by id.
+    pub fn get_many(&self, ids: &[&str]) -> IcmResult<HashMap<String, Memory>> {
+        if ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let id_vec: Vec<String> = ids.iter().map(|s| s.to_string()).collect();
+        let mut c = self.conn()?;
+        let rows = c
+            .query(
+                &format!("SELECT {SELECT_COLS} FROM memories WHERE id = ANY($1)"),
+                &[&id_vec],
+            )
+            .map_err(pg_err)?;
+        let mut map = HashMap::with_capacity(rows.len());
+        for row in &rows {
+            let m = row_to_memory(row);
+            map.insert(m.id.clone(), m);
+        }
+        Ok(map)
+    }
+
+    /// Expand a scored result set with one hop of related memories.
+    /// Backend-agnostic logic mirrored from the SQLite store.
+    pub fn expand_with_neighbors(
+        &self,
+        initial: &[(Memory, f32)],
+        max_neighbors: usize,
+        hop_discount: f32,
+        max_total: usize,
+    ) -> IcmResult<Vec<(Memory, f32)>> {
+        if max_neighbors == 0 || initial.is_empty() {
+            let mut out = initial.to_vec();
+            out.truncate(max_total);
+            return Ok(out);
+        }
+
+        let initial_ids: HashSet<String> = initial.iter().map(|(m, _)| m.id.clone()).collect();
+
+        let mut candidates: Vec<(String, f32)> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        'outer: for (mem, score) in initial {
+            for neighbor_id in &mem.related_ids {
+                if candidates.len() >= max_neighbors {
+                    break 'outer;
+                }
+                if initial_ids.contains(neighbor_id) || !seen.insert(neighbor_id.clone()) {
+                    continue;
+                }
+                candidates.push((neighbor_id.clone(), *score));
+            }
+        }
+
+        let mut neighbors: Vec<(Memory, f32)> = Vec::new();
+        if !candidates.is_empty() {
+            let ids: Vec<&str> = candidates.iter().map(|(id, _)| id.as_str()).collect();
+            let fetched = self.get_many(&ids)?;
+            for (id, parent_score) in candidates {
+                if let Some(m) = fetched.get(&id) {
+                    neighbors.push((m.clone(), parent_score * hop_discount));
+                }
+            }
+        }
+
+        let mut combined: Vec<(Memory, f32)> = initial.to_vec();
+        combined.extend(neighbors);
+        combined.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        combined.truncate(max_total);
+        Ok(combined)
+    }
+
+    /// Memories whose topic starts with `topic` (prefix match).
+    pub fn get_by_topic_prefix(&self, topic: &str) -> IcmResult<Vec<Memory>> {
+        let pattern = format!("{topic}%");
+        let mut c = self.conn()?;
+        let rows = c
+            .query(
+                &format!(
+                    "SELECT {SELECT_COLS} FROM memories WHERE topic LIKE $1 \
+                     ORDER BY weight DESC LIMIT 500"
+                ),
+                &[&pattern],
+            )
+            .map_err(pg_err)?;
+        Ok(rows.iter().map(row_to_memory).collect())
+    }
+
+    /// Distinct topics (optionally prefix-filtered) with their counts.
+    pub fn list_topics_with_prefix(&self, prefix: Option<&str>) -> IcmResult<Vec<(String, usize)>> {
+        let mut c = self.conn()?;
+        let rows = match prefix {
+            Some(p) => {
+                let pattern = format!("{p}%");
+                c.query(
+                    "SELECT topic, COUNT(*)::bigint FROM memories WHERE topic LIKE $1 \
+                     GROUP BY topic ORDER BY topic",
+                    &[&pattern],
+                )
+            }
+            None => c.query(
+                "SELECT topic, COUNT(*)::bigint FROM memories GROUP BY topic ORDER BY topic",
+                &[],
+            ),
+        }
+        .map_err(pg_err)?;
+        Ok(rows
+            .iter()
+            .map(|row| {
+                let n: i64 = row.get(1);
+                (row.get(0), n.max(0) as usize)
+            })
+            .collect())
+    }
+
+    // ── Consolidation / patterns ───────────────────────────────────────
+
+    /// Auto-consolidation is not yet implemented on the PostgreSQL
+    /// backend; the call is a no-op (returns "did not consolidate") so the
+    /// normal store path is unaffected.
+    pub fn auto_consolidate(&self, _topic: &str, _threshold: usize) -> IcmResult<bool> {
+        Ok(false)
+    }
+
+    /// See [`Self::auto_consolidate`].
+    pub fn auto_consolidate_with_embedder(
+        &self,
+        _topic: &str,
+        _threshold: usize,
+        _embedder: Option<&dyn Embedder>,
+    ) -> IcmResult<bool> {
+        Ok(false)
+    }
+
+    /// Pattern mining is not yet available on the PostgreSQL backend.
+    pub fn detect_patterns(
+        &self,
+        _topic: &str,
+        _min_cluster_size: usize,
+    ) -> IcmResult<Vec<PatternCluster>> {
+        Err(IcmError::Unsupported(
+            "detect_patterns (use the default SQLite backend)".into(),
+        ))
+    }
+
+    /// Pattern mining is not yet available on the PostgreSQL backend.
+    pub fn extract_pattern_as_concept(
+        &self,
+        _cluster: &PatternCluster,
+        _memoir_id: &str,
+    ) -> IcmResult<String> {
+        Err(IcmError::Unsupported(
+            "extract_pattern_as_concept (use the default SQLite backend)".into(),
+        ))
+    }
+}
+
+/// Idempotent schema creation. Returns the embedding dimension the table
+/// is actually using (the stored value wins over `requested_dims` on an
+/// existing database).
+fn init_schema(client: &mut Client, requested_dims: usize) -> IcmResult<usize> {
+    if !(64..=4096).contains(&requested_dims) {
+        return Err(IcmError::Config(format!(
+            "embedding_dims must be between 64 and 4096, got {requested_dims}"
+        )));
+    }
+
+    client
+        .batch_execute("CREATE EXTENSION IF NOT EXISTS vector")
+        .map_err(|e| {
+            IcmError::Database(format!(
+                "cannot enable the pgvector extension (need it for embeddings): {e}"
+            ))
+        })?;
+
+    client
+        .batch_execute(
+            "CREATE TABLE IF NOT EXISTS icm_metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            )",
+        )
+        .map_err(pg_err)?;
+
+    // The stored dimension is authoritative on an existing database.
+    let stored: Option<i64> = client
+        .query_opt(
+            "SELECT value::bigint FROM icm_metadata WHERE key = 'embedding_dims'",
+            &[],
+        )
+        .map_err(pg_err)?
+        .map(|row| row.get(0));
+    let dims = stored.map(|d| d as usize).unwrap_or(requested_dims);
+
+    client
+        .batch_execute(&format!(
+            "CREATE TABLE IF NOT EXISTS memories (
+                id TEXT PRIMARY KEY,
+                created_at TIMESTAMPTZ NOT NULL,
+                updated_at TIMESTAMPTZ NOT NULL,
+                last_accessed TIMESTAMPTZ NOT NULL,
+                access_count INTEGER NOT NULL DEFAULT 0,
+                weight REAL NOT NULL DEFAULT 1.0,
+                topic TEXT NOT NULL,
+                summary TEXT NOT NULL,
+                raw_excerpt TEXT,
+                keywords TEXT,
+                importance TEXT NOT NULL,
+                source_type TEXT NOT NULL,
+                source_data TEXT,
+                related_ids TEXT,
+                summary_hash TEXT,
+                embedding vector({dims}),
+                fts tsvector GENERATED ALWAYS AS (
+                    to_tsvector('simple',
+                        coalesce(topic, '') || ' ' ||
+                        coalesce(summary, '') || ' ' ||
+                        coalesce(keywords, ''))
+                ) STORED
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_memories_topic ON memories(topic);
+            CREATE INDEX IF NOT EXISTS idx_memories_weight ON memories(weight);
+            CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at);
+            CREATE INDEX IF NOT EXISTS idx_memories_fts ON memories USING GIN (fts);
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_topic_hash
+                ON memories (LOWER(topic), summary_hash) WHERE summary_hash IS NOT NULL;
+
+            CREATE TABLE IF NOT EXISTS pending_extractions (
+                id TEXT PRIMARY KEY,
+                project TEXT NOT NULL,
+                tool_name TEXT NOT NULL,
+                raw_output TEXT NOT NULL,
+                captured_at TIMESTAMPTZ NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS code_areas (
+                id BIGSERIAL PRIMARY KEY,
+                project TEXT NOT NULL,
+                file_path TEXT NOT NULL,
+                description TEXT,
+                session_id TEXT,
+                tool_name TEXT,
+                touch_count BIGINT NOT NULL DEFAULT 1,
+                first_touched_at TIMESTAMPTZ NOT NULL,
+                last_touched_at TIMESTAMPTZ NOT NULL,
+                UNIQUE (project, file_path)
+            );
+
+            CREATE TABLE IF NOT EXISTS hook_events (
+                id BIGSERIAL PRIMARY KEY,
+                ts TIMESTAMPTZ NOT NULL,
+                event TEXT NOT NULL,
+                project TEXT,
+                session_id TEXT,
+                tool_name TEXT,
+                duration_ms BIGINT,
+                exit_code INTEGER NOT NULL DEFAULT 0,
+                payload_size BIGINT,
+                note TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_hook_events_ts ON hook_events(ts);
+            CREATE INDEX IF NOT EXISTS idx_hook_events_event ON hook_events(event);"
+        ))
+        .map_err(pg_err)?;
+
+    // A vector index needs a concrete dimension; create it after the
+    // table exists. HNSW is available in pgvector >= 0.5 (the images we
+    // target ship a newer version).
+    client
+        .batch_execute(
+            "CREATE INDEX IF NOT EXISTS idx_memories_embedding
+                ON memories USING hnsw (embedding vector_cosine_ops)",
+        )
+        .map_err(pg_err)?;
+
+    client
+        .execute(
+            "INSERT INTO icm_metadata (key, value) VALUES ('embedding_dims', $1)
+             ON CONFLICT (key) DO NOTHING",
+            &[&dims.to_string()],
+        )
+        .map_err(pg_err)?;
+
+    Ok(dims)
+}
+
+// ---------------------------------------------------------------------------
+// MemoryStore
+// ---------------------------------------------------------------------------
+
+impl MemoryStore for PostgresStore {
+    fn store(&self, memory: Memory) -> IcmResult<String> {
+        if self.readonly {
+            return Err(IcmError::ReadOnly("store".into()));
+        }
+        let memory = validate_and_normalize(memory)?;
+        self.check_dims(&memory)?;
+        let mut c = self.conn()?;
+        let mut tx = c.transaction().map_err(pg_err)?;
+        let id = insert_or_merge_memory(&mut tx, &memory)?;
+        tx.commit().map_err(pg_err)?;
+        Ok(id)
+    }
+
+    fn get(&self, id: &str) -> IcmResult<Option<Memory>> {
+        let mut c = self.conn()?;
+        let row = c
+            .query_opt(
+                &format!("SELECT {SELECT_COLS} FROM memories WHERE id = $1"),
+                &[&id],
+            )
+            .map_err(pg_err)?;
+        Ok(row.as_ref().map(row_to_memory))
+    }
+
+    fn update(&self, memory: &Memory) -> IcmResult<()> {
+        if self.readonly {
+            return Err(IcmError::ReadOnly("update".into()));
+        }
+        self.check_dims(memory)?;
+        let keywords_json = serde_json::to_string(&memory.keywords)?;
+        let related_json = serde_json::to_string(&memory.related_ids)?;
+        let st = source_type(&memory.source);
+        let sd = source_data(&memory.source);
+        let hash = summary_hash(&memory.topic, &memory.summary);
+        let importance = memory.importance.to_string();
+        let access = memory.access_count as i32;
+        let emb: Option<pgvector::Vector> = memory
+            .embedding
+            .as_ref()
+            .map(|e| pgvector::Vector::from(e.clone()));
+
+        let mut c = self.conn()?;
+        let changed = c
+            .execute(
+                "UPDATE memories SET
+                    updated_at = $2, last_accessed = $3, access_count = $4, weight = $5,
+                    topic = $6, summary = $7, raw_excerpt = $8, keywords = $9,
+                    importance = $10, source_type = $11, source_data = $12, related_ids = $13,
+                    embedding = $14, summary_hash = $15
+                 WHERE id = $1",
+                &[
+                    &memory.id,
+                    &memory.updated_at,
+                    &memory.last_accessed,
+                    &access,
+                    &memory.weight,
+                    &memory.topic,
+                    &memory.summary,
+                    &memory.raw_excerpt,
+                    &keywords_json,
+                    &importance,
+                    &st,
+                    &sd,
+                    &related_json,
+                    &emb,
+                    &hash,
+                ],
+            )
+            .map_err(pg_err)?;
+        if changed == 0 {
+            return Err(IcmError::NotFound(memory.id.clone()));
+        }
+        Ok(())
+    }
+
+    fn delete(&self, id: &str) -> IcmResult<()> {
+        if self.readonly {
+            return Err(IcmError::ReadOnly("delete".into()));
+        }
+        let mut c = self.conn()?;
+        let changed = c
+            .execute("DELETE FROM memories WHERE id = $1", &[&id])
+            .map_err(pg_err)?;
+        if changed == 0 {
+            return Err(IcmError::NotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
+    fn search_by_keywords(&self, keywords: &[&str], limit: usize) -> IcmResult<Vec<Memory>> {
+        if keywords.is_empty() {
+            return Ok(Vec::new());
+        }
+        let keywords = &keywords[..keywords.len().min(50)];
+        let limit = limit.min(100);
+
+        let mut owned: Vec<Box<dyn ToSql + Sync>> = Vec::new();
+        let mut where_parts: Vec<String> = Vec::new();
+        for k in keywords {
+            owned.push(Box::new(format!("%{k}%")));
+            let p = owned.len();
+            where_parts.push(format!(
+                "(keywords ILIKE ${p} OR summary ILIKE ${p} OR topic ILIKE ${p})"
+            ));
+        }
+        owned.push(Box::new(limit as i64));
+        let sql = format!(
+            "SELECT {SELECT_COLS} FROM memories WHERE {} ORDER BY weight DESC LIMIT ${}",
+            where_parts.join(" OR "),
+            owned.len()
+        );
+        let params: Vec<&(dyn ToSql + Sync)> = owned.iter().map(|b| b.as_ref()).collect();
+        let mut c = self.conn()?;
+        let rows = c.query(&sql, &params).map_err(pg_err)?;
+        Ok(rows.iter().map(row_to_memory).collect())
+    }
+
+    fn search_fts(&self, query: &str, limit: usize) -> IcmResult<Vec<Memory>> {
+        let limit = limit.min(100);
+        if query.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut c = self.conn()?;
+        let rows = c
+            .query(
+                &format!(
+                    "SELECT {SELECT_COLS} FROM memories \
+                     WHERE fts @@ websearch_to_tsquery('simple', $1) \
+                     ORDER BY weight DESC LIMIT $2"
+                ),
+                &[&query, &(limit as i64)],
+            )
+            .map_err(pg_err)?;
+        Ok(rows.iter().map(row_to_memory).collect())
+    }
+
+    fn search_by_embedding(
+        &self,
+        embedding: &[f32],
+        limit: usize,
+    ) -> IcmResult<Vec<(Memory, f32)>> {
+        let qv = pgvector::Vector::from(embedding.to_vec());
+        let mut c = self.conn()?;
+        let rows = c
+            .query(
+                &format!(
+                    "SELECT {SELECT_COLS}, embedding <=> $1 AS distance FROM memories \
+                     WHERE embedding IS NOT NULL ORDER BY embedding <=> $1 LIMIT $2"
+                ),
+                &[&qv, &(limit as i64)],
+            )
+            .map_err(pg_err)?;
+        Ok(rows
+            .iter()
+            .map(|row| {
+                let distance: f64 = row.get(15);
+                (row_to_memory(row), 1.0 - distance as f32)
+            })
+            .collect())
+    }
+
+    fn search_hybrid(
+        &self,
+        query: &str,
+        embedding: &[f32],
+        limit: usize,
+    ) -> IcmResult<Vec<(Memory, f32)>> {
+        let limit = limit.min(1000);
+        let pool_size = limit * 4;
+
+        // 1. FTS candidates (id + rank). Lock released at scope end.
+        let fts_pairs: Vec<(String, f64)> = if query.trim().is_empty() {
+            Vec::new()
+        } else {
+            let mut c = self.conn()?;
+            let rows = c
+                .query(
+                    "SELECT id, ts_rank_cd(fts, websearch_to_tsquery('simple', $1))::float8 AS rank \
+                     FROM memories \
+                     WHERE fts @@ websearch_to_tsquery('simple', $1) \
+                     ORDER BY rank DESC LIMIT $2",
+                    &[&query, &(pool_size as i64)],
+                )
+                .map_err(pg_err)?;
+            rows.iter().map(|r| (r.get(0), r.get(1))).collect()
+        };
+
+        // 2. Vector candidates (full rows + similarity).
+        let vec_results = self.search_by_embedding(embedding, pool_size)?;
+
+        // 3. Assemble memory objects and per-source scores.
+        let mut all_memories: HashMap<String, Memory> = HashMap::new();
+        let mut vec_scores: HashMap<String, f32> = HashMap::new();
+        for (mem, sim) in vec_results {
+            vec_scores.insert(mem.id.clone(), sim);
+            all_memories.insert(mem.id.clone(), mem);
+        }
+
+        // Normalize FTS ranks into 0..1 within the pool (higher is better).
+        let max_rank = fts_pairs.iter().map(|(_, r)| *r).fold(0.0_f64, f64::max);
+        let mut fts_scores: HashMap<String, f32> = HashMap::new();
+        let missing: Vec<String> = fts_pairs
+            .iter()
+            .filter(|(id, _)| !all_memories.contains_key(id))
+            .map(|(id, _)| id.clone())
+            .collect();
+        if !missing.is_empty() {
+            let refs: Vec<&str> = missing.iter().map(|s| s.as_str()).collect();
+            let fetched = self.get_many(&refs)?;
+            for (id, m) in fetched {
+                all_memories.insert(id, m);
+            }
+        }
+        for (id, rank) in fts_pairs {
+            let score = if max_rank > 0.0 {
+                (rank / max_rank) as f32
+            } else {
+                0.0
+            };
+            fts_scores.insert(id, score);
+        }
+
+        // 4. Blend: 30% FTS + 70% vector (matches the SQLite backend).
+        let mut scored: Vec<(String, f32)> = all_memories
+            .keys()
+            .map(|id| {
+                let fts = fts_scores.get(id).copied().unwrap_or(0.0);
+                let vec = vec_scores.get(id).copied().unwrap_or(0.0);
+                (id.clone(), 0.3 * fts + 0.7 * vec)
+            })
+            .collect();
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(limit);
+
+        Ok(scored
+            .into_iter()
+            .filter_map(|(id, score)| all_memories.remove(&id).map(|m| (m, score)))
+            .collect())
+    }
+
+    fn update_access(&self, id: &str) -> IcmResult<()> {
+        if self.readonly {
+            return Ok(());
+        }
+        let mut c = self.conn()?;
+        let changed = c
+            .execute(
+                "UPDATE memories SET last_accessed = $1, access_count = access_count + 1 \
+                 WHERE id = $2",
+                &[&Utc::now(), &id],
+            )
+            .map_err(pg_err)?;
+        if changed == 0 {
+            return Err(IcmError::NotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
+    fn batch_update_access(&self, ids: &[&str]) -> IcmResult<usize> {
+        if ids.is_empty() || self.readonly {
+            return Ok(0);
+        }
+        let id_vec: Vec<String> = ids.iter().map(|s| s.to_string()).collect();
+        let mut c = self.conn()?;
+        let changed = c
+            .execute(
+                "UPDATE memories SET last_accessed = $1, access_count = access_count + 1 \
+                 WHERE id = ANY($2)",
+                &[&Utc::now(), &id_vec],
+            )
+            .map_err(pg_err)?;
+        Ok(changed as usize)
+    }
+
+    fn apply_decay(&self, decay_factor: f32) -> IcmResult<usize> {
+        if self.readonly {
+            return Err(IcmError::ReadOnly("apply_decay".into()));
+        }
+        // Access-aware decay, capped at 5 accesses (matches SQLite).
+        let mut c = self.conn()?;
+        let changed = c
+            .execute(
+                // `$1::float8` is explicit so PostgreSQL doesn't infer the
+                // parameter as `numeric`/`real` from a neighbouring operand
+                // and reject the `f64` we bind ("error serializing parameter").
+                "UPDATE memories SET weight = weight * (
+                    1.0 - (1.0 - $1::float8) *
+                    CASE importance
+                        WHEN 'high' THEN 0.5
+                        WHEN 'low' THEN 2.0
+                        ELSE 1.0
+                    END
+                    / (1.0 + LEAST(access_count, 5) * 0.1)
+                )
+                WHERE importance <> 'critical'",
+                &[&(decay_factor as f64)],
+            )
+            .map_err(pg_err)?;
+        Ok(changed as usize)
+    }
+
+    fn prune(&self, weight_threshold: f32) -> IcmResult<usize> {
+        if self.readonly {
+            return Err(IcmError::ReadOnly("prune".into()));
+        }
+        let mut c = self.conn()?;
+        let changed = c
+            .execute(
+                "DELETE FROM memories \
+                 WHERE weight < $1::float8 AND importance NOT IN ('critical', 'high')",
+                &[&(weight_threshold as f64)],
+            )
+            .map_err(pg_err)?;
+        Ok(changed as usize)
+    }
+
+    fn list_all(&self) -> IcmResult<Vec<Memory>> {
+        let mut c = self.conn()?;
+        let rows = c
+            .query(
+                &format!("SELECT {SELECT_COLS} FROM memories ORDER BY weight DESC LIMIT 10000"),
+                &[],
+            )
+            .map_err(pg_err)?;
+        Ok(rows.iter().map(row_to_memory).collect())
+    }
+
+    fn get_by_topic(&self, topic: &str) -> IcmResult<Vec<Memory>> {
+        let mut c = self.conn()?;
+        let rows = c
+            .query(
+                &format!(
+                    "SELECT {SELECT_COLS} FROM memories WHERE topic = $1 \
+                     ORDER BY weight DESC LIMIT 500"
+                ),
+                &[&topic],
+            )
+            .map_err(pg_err)?;
+        Ok(rows.iter().map(row_to_memory).collect())
+    }
+
+    fn list_topics(&self) -> IcmResult<Vec<(String, usize)>> {
+        self.list_topics_with_prefix(None)
+    }
+
+    fn consolidate_topic(&self, topic: &str, consolidated: Memory) -> IcmResult<()> {
+        if self.readonly {
+            return Err(IcmError::ReadOnly("consolidate_topic".into()));
+        }
+        let mut c = self.conn()?;
+        let mut tx = c.transaction().map_err(pg_err)?;
+        tx.execute("DELETE FROM memories WHERE topic = $1", &[&topic])
+            .map_err(pg_err)?;
+        insert_or_merge_memory(&mut tx, &consolidated)?;
+        tx.commit().map_err(pg_err)?;
+        Ok(())
+    }
+
+    fn count(&self) -> IcmResult<usize> {
+        let mut c = self.conn()?;
+        let row = c
+            .query_one("SELECT COUNT(*) FROM memories", &[])
+            .map_err(pg_err)?;
+        let n: i64 = row.get(0);
+        Ok(n.max(0) as usize)
+    }
+
+    fn count_by_topic(&self, topic: &str) -> IcmResult<usize> {
+        let mut c = self.conn()?;
+        let row = c
+            .query_one("SELECT COUNT(*) FROM memories WHERE topic = $1", &[&topic])
+            .map_err(pg_err)?;
+        let n: i64 = row.get(0);
+        Ok(n.max(0) as usize)
+    }
+
+    fn stats(&self) -> IcmResult<StoreStats> {
+        let mut c = self.conn()?;
+        let row = c
+            .query_one(
+                "SELECT COUNT(*)::bigint, COUNT(DISTINCT topic)::bigint, \
+                        COALESCE(AVG(weight), 0.0)::float8, MIN(created_at), MAX(created_at) \
+                 FROM memories",
+                &[],
+            )
+            .map_err(pg_err)?;
+        let total: i64 = row.get(0);
+        let topics: i64 = row.get(1);
+        let avg: f64 = row.get(2);
+        Ok(StoreStats {
+            total_memories: total.max(0) as usize,
+            total_topics: topics.max(0) as usize,
+            avg_weight: avg as f32,
+            oldest_memory: row.get(3),
+            newest_memory: row.get(4),
+        })
+    }
+
+    fn topic_health(&self, topic: &str) -> IcmResult<TopicHealth> {
+        let mut c = self.conn()?;
+        let row = c
+            .query_one(
+                "SELECT COUNT(*)::bigint,
+                        COALESCE(AVG(weight), 0)::float8,
+                        COALESCE(AVG(access_count::float8), 0)::float8,
+                        MIN(created_at), MAX(created_at), MAX(last_accessed),
+                        COALESCE(SUM(CASE WHEN weight < 0.5
+                              AND (now() - last_accessed) > interval '14 days'
+                              THEN 1 ELSE 0 END), 0)::bigint
+                 FROM memories WHERE topic = $1",
+                &[&topic],
+            )
+            .map_err(pg_err)?;
+
+        let entry_count: i64 = row.get(0);
+        if entry_count == 0 {
+            return Err(IcmError::NotFound(format!("topic: {topic}")));
+        }
+        let avg_weight: f64 = row.get(1);
+        let avg_access: f64 = row.get(2);
+        let stale: i64 = row.get(6);
+
+        Ok(TopicHealth {
+            topic: topic.to_string(),
+            entry_count: entry_count.max(0) as usize,
+            avg_weight: avg_weight as f32,
+            avg_access_count: avg_access as f32,
+            oldest: row.get(3),
+            newest: row.get(4),
+            last_accessed: row.get(5),
+            needs_consolidation: entry_count > 5,
+            stale_count: stale.max(0) as usize,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unsupported subsystems on this backend (first cut, issue #301).
+//
+// These return `IcmError::Unsupported` so the binary keeps working for the
+// core shared-memory use case while the heavier subsystems remain on the
+// default SQLite backend. A follow-up can port them.
+// ---------------------------------------------------------------------------
+
+fn unsupported<T>(op: &str) -> IcmResult<T> {
+    Err(IcmError::Unsupported(format!(
+        "{op} (use the default SQLite backend)"
+    )))
+}
+
+impl MemoirStore for PostgresStore {
+    fn create_memoir(&self, _memoir: Memoir) -> IcmResult<String> {
+        unsupported("memoir.create_memoir")
+    }
+    fn get_memoir(&self, _id: &str) -> IcmResult<Option<Memoir>> {
+        unsupported("memoir.get_memoir")
+    }
+    fn get_memoir_by_name(&self, _name: &str) -> IcmResult<Option<Memoir>> {
+        unsupported("memoir.get_memoir_by_name")
+    }
+    fn update_memoir(&self, _memoir: &Memoir) -> IcmResult<()> {
+        unsupported("memoir.update_memoir")
+    }
+    fn delete_memoir(&self, _id: &str) -> IcmResult<()> {
+        unsupported("memoir.delete_memoir")
+    }
+    fn list_memoirs(&self) -> IcmResult<Vec<Memoir>> {
+        unsupported("memoir.list_memoirs")
+    }
+    fn add_concept(&self, _concept: Concept) -> IcmResult<String> {
+        unsupported("memoir.add_concept")
+    }
+    fn get_concept(&self, _id: &str) -> IcmResult<Option<Concept>> {
+        unsupported("memoir.get_concept")
+    }
+    fn get_concept_by_name(&self, _memoir_id: &str, _name: &str) -> IcmResult<Option<Concept>> {
+        unsupported("memoir.get_concept_by_name")
+    }
+    fn update_concept(&self, _concept: &Concept) -> IcmResult<()> {
+        unsupported("memoir.update_concept")
+    }
+    fn delete_concept(&self, _id: &str) -> IcmResult<()> {
+        unsupported("memoir.delete_concept")
+    }
+    fn list_concepts(&self, _memoir_id: &str) -> IcmResult<Vec<Concept>> {
+        unsupported("memoir.list_concepts")
+    }
+    fn search_concepts_fts(
+        &self,
+        _memoir_id: &str,
+        _query: &str,
+        _limit: usize,
+    ) -> IcmResult<Vec<Concept>> {
+        unsupported("memoir.search_concepts_fts")
+    }
+    fn search_concepts_by_label(
+        &self,
+        _memoir_id: &str,
+        _label: &Label,
+        _limit: usize,
+    ) -> IcmResult<Vec<Concept>> {
+        unsupported("memoir.search_concepts_by_label")
+    }
+    fn search_all_concepts_fts(&self, _query: &str, _limit: usize) -> IcmResult<Vec<Concept>> {
+        unsupported("memoir.search_all_concepts_fts")
+    }
+    fn refine_concept(
+        &self,
+        _id: &str,
+        _new_definition: &str,
+        _new_source_ids: &[String],
+    ) -> IcmResult<()> {
+        unsupported("memoir.refine_concept")
+    }
+    fn add_link(&self, _link: ConceptLink) -> IcmResult<String> {
+        unsupported("memoir.add_link")
+    }
+    fn get_links_from(&self, _concept_id: &str) -> IcmResult<Vec<ConceptLink>> {
+        unsupported("memoir.get_links_from")
+    }
+    fn get_links_to(&self, _concept_id: &str) -> IcmResult<Vec<ConceptLink>> {
+        unsupported("memoir.get_links_to")
+    }
+    fn delete_link(&self, _id: &str) -> IcmResult<()> {
+        unsupported("memoir.delete_link")
+    }
+    fn get_neighbors(
+        &self,
+        _concept_id: &str,
+        _relation: Option<Relation>,
+    ) -> IcmResult<Vec<Concept>> {
+        unsupported("memoir.get_neighbors")
+    }
+    fn get_neighborhood(
+        &self,
+        _concept_id: &str,
+        _depth: usize,
+    ) -> IcmResult<(Vec<Concept>, Vec<ConceptLink>)> {
+        unsupported("memoir.get_neighborhood")
+    }
+    fn get_links_for_memoir(&self, _memoir_id: &str) -> IcmResult<Vec<ConceptLink>> {
+        unsupported("memoir.get_links_for_memoir")
+    }
+    fn memoir_stats(&self, _memoir_id: &str) -> IcmResult<MemoirStats> {
+        unsupported("memoir.memoir_stats")
+    }
+    fn batch_memoir_concept_counts(&self) -> IcmResult<HashMap<String, usize>> {
+        unsupported("memoir.batch_memoir_concept_counts")
+    }
+}
+
+impl FeedbackStore for PostgresStore {
+    fn store_feedback(&self, _feedback: Feedback) -> IcmResult<String> {
+        unsupported("feedback.store_feedback")
+    }
+    fn search_feedback(
+        &self,
+        _query: &str,
+        _topic: Option<&str>,
+        _limit: usize,
+    ) -> IcmResult<Vec<Feedback>> {
+        unsupported("feedback.search_feedback")
+    }
+    fn list_feedback(&self, _topic: Option<&str>, _limit: usize) -> IcmResult<Vec<Feedback>> {
+        unsupported("feedback.list_feedback")
+    }
+    fn increment_applied(&self, _id: &str) -> IcmResult<()> {
+        unsupported("feedback.increment_applied")
+    }
+    fn delete_feedback(&self, _id: &str) -> IcmResult<()> {
+        unsupported("feedback.delete_feedback")
+    }
+    fn feedback_stats(&self) -> IcmResult<FeedbackStats> {
+        unsupported("feedback.feedback_stats")
+    }
+}
+
+impl FactsStore for PostgresStore {
+    fn set_fact(
+        &self,
+        _entity: &str,
+        _key: &str,
+        _value: &str,
+        _source: &str,
+    ) -> IcmResult<String> {
+        unsupported("facts.set_fact")
+    }
+    fn get_fact(&self, _entity: &str, _key: &str) -> IcmResult<Option<Fact>> {
+        unsupported("facts.get_fact")
+    }
+    fn list_facts(&self, _entity: &str, _key_prefix: Option<&str>) -> IcmResult<Vec<Fact>> {
+        unsupported("facts.list_facts")
+    }
+    fn history(&self, _entity: &str, _key: &str) -> IcmResult<Vec<Fact>> {
+        unsupported("facts.history")
+    }
+    fn forget_fact(&self, _entity: &str, _key: &str) -> IcmResult<usize> {
+        unsupported("facts.forget_fact")
+    }
+    fn facts_stats(&self) -> IcmResult<FactsStats> {
+        unsupported("facts.facts_stats")
+    }
+}
+
+impl TranscriptStore for PostgresStore {
+    fn create_session(
+        &self,
+        _agent: &str,
+        _project: Option<&str>,
+        _metadata: Option<&str>,
+    ) -> IcmResult<String> {
+        unsupported("transcript.create_session")
+    }
+    fn ensure_session(
+        &self,
+        _id: &str,
+        _agent: &str,
+        _project: Option<&str>,
+        _metadata: Option<&str>,
+    ) -> IcmResult<String> {
+        unsupported("transcript.ensure_session")
+    }
+    fn get_session(&self, _id: &str) -> IcmResult<Option<Session>> {
+        unsupported("transcript.get_session")
+    }
+    fn list_sessions(&self, _project: Option<&str>, _limit: usize) -> IcmResult<Vec<Session>> {
+        unsupported("transcript.list_sessions")
+    }
+    fn record_message(
+        &self,
+        _session_id: &str,
+        _role: Role,
+        _content: &str,
+        _tool_name: Option<&str>,
+        _tokens: Option<i64>,
+        _metadata: Option<&str>,
+    ) -> IcmResult<String> {
+        unsupported("transcript.record_message")
+    }
+    fn list_session_messages(
+        &self,
+        _session_id: &str,
+        _limit: usize,
+        _offset: usize,
+    ) -> IcmResult<Vec<Message>> {
+        unsupported("transcript.list_session_messages")
+    }
+    fn search_transcripts(
+        &self,
+        _query: &str,
+        _session_id: Option<&str>,
+        _project: Option<&str>,
+        _limit: usize,
+    ) -> IcmResult<Vec<TranscriptHit>> {
+        unsupported("transcript.search_transcripts")
+    }
+    fn forget_session(&self, _id: &str) -> IcmResult<()> {
+        unsupported("transcript.forget_session")
+    }
+    fn transcript_stats(&self) -> IcmResult<TranscriptStats> {
+        unsupported("transcript.transcript_stats")
+    }
+}

--- a/crates/icm-store/tests/postgres_backend.rs
+++ b/crates/icm-store/tests/postgres_backend.rs
@@ -1,0 +1,157 @@
+//! Integration test for the opt-in PostgreSQL backend (issue #301).
+//!
+//! Only compiled under `--features postgres`. It needs a live PostgreSQL
+//! with the `pgvector` extension available; point `ICM_POSTGRES_URL` at it
+//! and run:
+//!
+//! ```sh
+//! docker run -d --name icm-pg -e POSTGRES_PASSWORD=icm -e POSTGRES_USER=icm \
+//!     -e POSTGRES_DB=icm -p 55432:5432 pgvector/pgvector:pg16
+//! ICM_POSTGRES_URL=postgres://icm:icm@127.0.0.1:55432/icm \
+//!     cargo test -p icm-store --no-default-features --features postgres
+//! ```
+//!
+//! When `ICM_POSTGRES_URL` is unset the test prints a skip notice and
+//! returns, so a backend-less CI run stays green.
+#![cfg(feature = "postgres")]
+
+use icm_core::{Importance, Memory, MemoryStore};
+use icm_store::Store;
+
+fn skip_if_no_pg() -> bool {
+    if std::env::var("ICM_POSTGRES_URL").is_err() && std::env::var("DATABASE_URL").is_err() {
+        eprintln!("skipping: ICM_POSTGRES_URL not set");
+        return true;
+    }
+    false
+}
+
+fn mem(topic: &str, summary: &str, imp: Importance) -> Memory {
+    Memory::new(topic.to_string(), summary.to_string(), imp)
+}
+
+#[test]
+fn postgres_core_memory_surface() {
+    if skip_if_no_pg() {
+        return;
+    }
+
+    // A unique topic namespace keeps this test isolated from any other
+    // data already in the target database.
+    let ns = format!("itest-{}", ulid::Ulid::new());
+    let store =
+        Store::with_dims(std::path::Path::new("ignored"), 384).expect("connect + migrate postgres");
+
+    // --- store ---
+    let mut m1 = mem(
+        &ns,
+        "PostgreSQL is a network-accessible backend",
+        Importance::High,
+    );
+    m1.keywords = vec!["postgres".into(), "backend".into()];
+    let id1 = store.store(m1.clone()).expect("store m1");
+    let _ = store
+        .store(mem(
+            &ns,
+            "SQLite remains the default backend",
+            Importance::Medium,
+        ))
+        .expect("store m2");
+
+    // --- dedup: same (topic, summary) returns the same id ---
+    let id1_again = store
+        .store(mem(
+            &ns,
+            "PostgreSQL is a network-accessible backend",
+            Importance::Low,
+        ))
+        .expect("store dup");
+    assert_eq!(id1, id1_again, "dedup must return the existing id");
+
+    // importance must NOT be downgraded by the low-priority re-store
+    let fetched = store.get(&id1).expect("get").expect("present");
+    assert_eq!(fetched.importance, Importance::High);
+
+    // --- count / topic listing ---
+    assert_eq!(store.count_by_topic(&ns).expect("count"), 2);
+    let topics = store.list_topics().expect("topics");
+    assert!(topics.iter().any(|(t, n)| t == &ns && *n == 2));
+
+    // --- keyword + FTS search ---
+    let kw = store
+        .search_by_keywords(&["postgres"], 10)
+        .expect("kw search");
+    assert!(kw.iter().any(|m| m.id == id1));
+    let fts = store
+        .search_fts("network-accessible", 10)
+        .expect("fts search");
+    assert!(fts.iter().any(|m| m.id == id1));
+
+    // --- decay lowers non-critical weight, prune removes the weak ---
+    let before = store.get(&id1).expect("get").expect("present").weight;
+    let touched = store.apply_decay(0.5).expect("decay");
+    assert!(touched >= 1);
+    let after = store.get(&id1).expect("get").expect("present").weight;
+    assert!(after < before, "weight should drop after decay");
+
+    // --- delete ---
+    store.delete(&id1).expect("delete");
+    assert!(store.get(&id1).expect("get").is_none());
+    assert_eq!(store.count_by_topic(&ns).expect("count"), 1);
+
+    // cleanup the remaining row in this namespace
+    for m in store.get_by_topic(&ns).expect("by topic") {
+        let _ = store.delete(&m.id);
+    }
+}
+
+#[test]
+fn postgres_vector_knn_ranks_semantically() {
+    if skip_if_no_pg() {
+        return;
+    }
+    let ns = format!("itest-vec-{}", ulid::Ulid::new());
+    // Use the store's configured dimension. An existing database is
+    // authoritative on its dims, so build vectors that size regardless of
+    // what we request here.
+    let store = Store::with_dims(
+        std::path::Path::new("ignored"),
+        icm_core::DEFAULT_EMBEDDING_DIMS,
+    )
+    .expect("connect + migrate postgres");
+    let dims = icm_core::DEFAULT_EMBEDDING_DIMS;
+
+    // Hand-built embeddings so the test is deterministic and needs no
+    // embedder: only the first two components vary. Query is closest to
+    // `near`, far from `far`.
+    let onehot = |a: f32, b: f32| {
+        let mut v = vec![0.0_f32; dims];
+        v[0] = a;
+        v[1] = b;
+        v
+    };
+    let mk = |summary: &str, emb: Vec<f32>| {
+        let mut m = mem(&ns, summary, Importance::Medium);
+        m.embedding = Some(emb);
+        m
+    };
+    let near_id = store
+        .store(mk("near vector", onehot(1.0, 0.0)))
+        .expect("store near");
+    let _far_id = store
+        .store(mk("far vector", onehot(0.0, 1.0)))
+        .expect("store far");
+
+    let query = onehot(0.9, 0.1);
+    let results = store.search_by_embedding(&query, 5).expect("knn");
+    assert!(!results.is_empty());
+    assert_eq!(results[0].0.id, near_id, "nearest vector must rank first");
+    assert!(
+        results[0].1 > 0.5,
+        "cosine similarity should be high for the near vector"
+    );
+
+    for m in store.get_by_topic(&ns).expect("by topic") {
+        let _ = store.delete(&m.id);
+    }
+}

--- a/deploy/Dockerfile.postgres
+++ b/deploy/Dockerfile.postgres
@@ -1,0 +1,17 @@
+# Build the `icm` CLI with the opt-in PostgreSQL backend (issue #301).
+# Embeddings are intentionally left out so the image stays small and needs
+# no model download — the shared-memory / multi-writer scenario this image
+# is built to demonstrate uses keyword + full-text search.
+FROM rust:1-bookworm AS build
+WORKDIR /src
+COPY . .
+RUN cargo build -p icm-cli --release \
+        --no-default-features \
+        --features "postgres,http-api"
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/target/release/icm /usr/local/bin/icm
+ENTRYPOINT ["icm"]

--- a/deploy/k8s/icm-writer-job.yaml
+++ b/deploy/k8s/icm-writer-job.yaml
@@ -1,0 +1,37 @@
+# Concurrent multi-writer test: 20 independent pods each store one unique
+# memory into the shared PostgreSQL store at the same time. With a
+# node-local SQLite file this is impossible; here all writes land in one
+# database with no lost rows.
+#
+# `image:` is a placeholder — substitute your pushed image, e.g.
+#   sed "s|__ICM_IMAGE__|$ACR.azurecr.io/icm-postgres:test|" icm-writer-job.yaml | kubectl apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: icm-writer
+  labels: { app: icm-writer }
+spec:
+  completions: 20
+  parallelism: 20
+  completionMode: Indexed
+  backoffLimit: 3
+  template:
+    metadata:
+      labels: { app: icm-writer }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: writer
+          image: __ICM_IMAGE__
+          envFrom:
+            - secretRef: { name: icm-pg }
+          # JOB_COMPLETION_INDEX is injected by Kubernetes for Indexed
+          # jobs and makes every pod's content unique (so dedup keeps all
+          # 20 rows rather than collapsing them).
+          command: ["/bin/sh", "-c"]
+          args:
+            - >
+              icm store --no-embeddings
+              -t concurrency
+              -c "memory #${JOB_COMPLETION_INDEX} written by an independent ICM replica on Kubernetes"
+              -i medium

--- a/deploy/k8s/postgres.yaml
+++ b/deploy/k8s/postgres.yaml
@@ -1,0 +1,57 @@
+# Ephemeral PostgreSQL (with pgvector) for validating the ICM PostgreSQL
+# backend on Kubernetes. Storage is an emptyDir — this is a test fixture,
+# not a production database.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: icm-pg
+  labels: { app: icm-postgres }
+stringData:
+  POSTGRES_USER: icm
+  POSTGRES_PASSWORD: icm
+  POSTGRES_DB: icm
+  # Connection string consumed by the icm pods.
+  ICM_POSTGRES_URL: postgres://icm:icm@icm-postgres:5432/icm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: icm-postgres
+  labels: { app: icm-postgres }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: icm-postgres }
+  template:
+    metadata:
+      labels: { app: icm-postgres }
+    spec:
+      containers:
+        - name: postgres
+          image: pgvector/pgvector:pg16
+          envFrom:
+            - secretRef: { name: icm-pg }
+          ports:
+            - containerPort: 5432
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "icm"]
+            initialDelaySeconds: 5
+            periodSeconds: 3
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: icm-postgres
+  labels: { app: icm-postgres }
+spec:
+  selector: { app: icm-postgres }
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -1,0 +1,95 @@
+# PostgreSQL backend (opt-in)
+
+By default ICM stores memory in a node-local SQLite file. That is perfect
+for a single machine, but a local file cannot be shared between several
+ICM processes or between Kubernetes replicas, so memory can't be shared
+across instances.
+
+The **PostgreSQL backend** (issue #301) runs the same memory model over a
+network-accessible PostgreSQL database. Every instance reads and writes
+one shared store, and PostgreSQL serialises concurrent writers, so N
+replicas can `icm store` into the same memory with no lost rows.
+
+It is **opt-in** and selected at build time via a Cargo feature. The
+default build is unchanged: SQLite only, single binary, zero external
+services.
+
+## What it covers
+
+This first cut implements the **core memory surface** — exactly the part
+that benefits from being shared:
+
+- `store` (with dedup + metadata merge), `get`, `update`, `forget`
+- keyword search, full-text search (PostgreSQL `tsvector` + GIN),
+  vector KNN (`pgvector`, cosine), and the hybrid blend (30% FTS / 70%
+  vector)
+- `list`, `topics`, `stats`, `health`
+- temporal `decay` (access-aware) and `prune`
+- the ancillary tables used by the normal store/recall/hook path:
+  hook telemetry, the async extraction queue, code areas, and the
+  key/value metadata.
+
+The heavier subsystems — memoir graph, verbatim transcripts, structured
+facts, feedback, and pattern mining — return a clear
+`operation not supported on this storage backend` error on PostgreSQL for
+now. They remain fully available on the default SQLite backend.
+
+## Requirements
+
+PostgreSQL with the [`pgvector`](https://github.com/pgvector/pgvector)
+extension available (the backend runs `CREATE EXTENSION IF NOT EXISTS
+vector`). The `pgvector/pgvector` images and Azure Database for
+PostgreSQL Flexible Server (with `vector` allow-listed) both work.
+
+## Build
+
+```sh
+cargo build -p icm-cli --release \
+    --no-default-features \
+    --features "postgres,embeddings,tui,http-api"
+```
+
+`postgres` and `backend-sqlite` are mutually exclusive; `--no-default-features`
+drops the default SQLite backend so only PostgreSQL is compiled in.
+
+## Configure
+
+The connection string comes from the environment:
+
+```sh
+export ICM_POSTGRES_URL="postgres://user:pass@host:5432/icm"
+# DATABASE_URL is accepted as a fallback.
+```
+
+The `--db` flag (a SQLite file path) is ignored by this backend.
+
+The schema — including the `vector(N)` embedding column whose dimension
+`N` matches your embedder — is created on first connect. The stored
+dimension is authoritative afterwards, so always initialise a database
+with the embedder you intend to use (or `--no-embeddings` for
+keyword/FTS-only).
+
+## Verify
+
+```sh
+docker run -d --name icm-pg \
+    -e POSTGRES_PASSWORD=icm -e POSTGRES_USER=icm -e POSTGRES_DB=icm \
+    -p 55432:5432 pgvector/pgvector:pg16
+
+export ICM_POSTGRES_URL="postgres://icm:icm@127.0.0.1:55432/icm"
+
+icm store -t demo -c "PostgreSQL backend shares memory across replicas" -i high
+icm recall "shared memory"
+icm stats
+
+# Integration tests (skipped automatically when the env var is unset):
+cargo test -p icm-store --no-default-features --features postgres -- --test-threads=1
+```
+
+## Kubernetes
+
+A network backend is what makes a horizontally-scaled deployment share
+memory. Point every replica's `ICM_POSTGRES_URL` at the same PostgreSQL
+service and they read/write one store. See
+[`deploy/k8s`](../deploy/k8s) for a minimal manifest set used to validate
+this on a real cluster.


### PR DESCRIPTION
## Summary

Closes #301. ICM's store was hardwired to a node-local SQLite file, which several processes / Kubernetes replicas cannot share. This adds an **opt-in, network-accessible PostgreSQL backend** so N instances read/write **one shared memory store**, with PostgreSQL serialising concurrent writers.

The **default build is unchanged**: SQLite only, single binary, zero external services.

## Design

- The active store is abstracted behind an `icm_store::Store` type alias, selected at build time by a Cargo feature:
  - `backend-sqlite` (default) — byte-for-byte the same SQLite path as before.
  - `postgres` (opt-in) — mutually exclusive (guarded by `compile_error!`). `cli`/`mcp` are now backend-agnostic (`SqliteStore` → `Store`).
- `PostgresStore` uses the **blocking `postgres` client** — the store traits are synchronous, so there is no async runtime and no sync-over-async bridge. Embeddings use **`pgvector`** cosine KNN (`<=>`); full-text search uses a generated **`tsvector` column + GIN index** queried via `websearch_to_tsquery`.
- Implements the full `MemoryStore` surface (store/dedup+metadata-merge, get/update/delete, keyword/FTS/vector/hybrid search with the 30/70 blend, decay, prune, topics, stats, health) plus the ancillary store/recall/hook tables (hook telemetry, extraction queue, code areas, metadata).
- Heavier subsystems (memoir graph, transcripts, facts, feedback, pattern mining) return `IcmError::Unsupported` on this backend for now; they stay fully available on SQLite. A follow-up can port them.
- Connection from `ICM_POSTGRES_URL` / `DATABASE_URL`.

## Build

```sh
cargo build -p icm-cli --release --no-default-features --features "postgres,embeddings,tui,http-api"
```

## Verified end-to-end (real pgvector PostgreSQL)

- `store` / dedup (same content → one row, importance not downgraded), `recall` via **FTS** and **semantic vector KNN** (ranked Paris > Tokyo > Rust for "European capital cities"), `list` / `topics` / `stats` / `forget`.
- `decay` (access-aware) and `prune` — fixed a real param-type bug (`$1::float8`) found only by running against a live DB.
- **20 concurrent independent `icm` processes wrote with zero lost rows.**
- Feature-gated integration tests (`crates/icm-store/tests/postgres_backend.rs`) pass against a live DB and skip cleanly without one.
- Default `backend-sqlite` build: `cargo build`, `cargo clippy -D warnings`, and the full test suite stay green.

## Included

- `docs/postgres-backend.md`, `deploy/Dockerfile.postgres`, and `deploy/k8s/` (pgvector Postgres + a 20-way concurrent-writer Job) — used to validate the shared-memory scenario on Kubernetes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)