### PR TITLE
refactor(store): one binary, additive backends, runtime selection (#301)

### DIFF
--- a/crates/icm-cli/Cargo.toml
+++ b/crates/icm-cli/Cargo.toml
@@ -13,14 +13,16 @@ name = "icm"
 path = "src/main.rs"
 
 [features]
-default = ["embeddings", "tui", "http-api", "backend-sqlite"]
+# The published binary carries ALL backends and picks one at runtime via
+# `ICM_DB_BACKEND` (issue #301). Backends are additive; for a lean build
+# (e.g. SQLite-only) use `--no-default-features --features
+# "embeddings,tui,http-api,backend-sqlite"`.
+default = ["embeddings", "tui", "http-api", "backend-sqlite", "postgres", "opensearch"]
 embeddings = ["icm-core/embeddings", "icm-mcp/embeddings"]
 tui = ["dep:ratatui", "dep:crossterm"]
-# Storage backend selection (issue #301). Exactly one must be active.
-# Default = in-process SQLite (single binary, zero external services).
-# The opt-in PostgreSQL backend lets several `icm` processes / Kubernetes
-# replicas share one memory store; build it with
-# `--no-default-features --features "postgres,embeddings,tui,http-api"`.
+# Storage backends (additive). SQLite is in-process; postgres / opensearch
+# are network-accessible so several `icm` processes / Kubernetes replicas
+# share one memory store. The active one is selected at runtime, not here.
 backend-sqlite = ["icm-store/backend-sqlite", "icm-mcp/backend-sqlite"]
 postgres = ["icm-store/postgres", "icm-mcp/postgres"]
 opensearch = ["icm-store/opensearch", "icm-mcp/opensearch"]

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1495,8 +1495,9 @@ fn main() -> Result<()> {
         }
     }
     let cli_db: Option<PathBuf> = cli.db.into_iter().next();
-    // `db_path` is consumed only by embeddings-gated commands (e.g. `embed`).
-    #[cfg_attr(not(feature = "embeddings"), allow(unused_variables))]
+    // `db_path` is consumed only by some feature-gated commands (e.g. the
+    // embeddings-only `embed`), so it can be unused in lean builds.
+    #[allow(unused_variables)]
     let db_path = cli_db.clone().unwrap_or_else(default_db_path);
 
     // `icm uninstall` must NOT open the SQLite store: a default

--- a/crates/icm-store/Cargo.toml
+++ b/crates/icm-store/Cargo.toml
@@ -9,8 +9,10 @@ edition = "2021"
 # "single binary, zero dependencies" promise (issue #301).
 default = ["backend-sqlite"]
 
-# In-process SQLite backend (rusqlite + sqlite-vec). The only built-in
-# backend; always the default.
+# Storage backends are ADDITIVE (issue #301): any combination can be
+# compiled into one binary, and the active one is chosen at runtime via
+# `ICM_DB_BACKEND` (see the `Store` enum). SQLite is the lightweight
+# default; the remote backends are opt-in extra deps.
 backend-sqlite = ["dep:rusqlite", "dep:sqlite-vec", "dep:zerocopy"]
 
 # Opt-in network-accessible PostgreSQL backend (issue #301). Lets several

--- a/crates/icm-store/src/backend.rs
+++ b/crates/icm-store/src/backend.rs
@@ -1,0 +1,688 @@
+//! Runtime-dispatched storage backend (issue #301).
+//!
+//! [`Store`] is an enum over the compiled-in backends. The active backend
+//! is chosen at runtime from `ICM_DB_BACKEND` (`sqlite` (default) /
+//! `postgres` / `opensearch`), mirroring SurrealDB's `Surreal<Any>`: a
+//! single binary can carry every backend and pick one without a rebuild.
+//! Cargo features only decide which variants are available.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+
+use icm_core::{
+    Concept, ConceptLink, Embedder, Fact, FactsStats, FactsStore, Feedback, FeedbackStats,
+    FeedbackStore, IcmError, IcmResult, Label, Memoir, MemoirStats, MemoirStore, Memory,
+    MemoryStore, Message, PatternCluster, Relation, Role, Session, StoreStats, TopicHealth,
+    TranscriptHit, TranscriptStats, TranscriptStore,
+};
+
+use crate::common::{CodeArea, HookEvent, HookEventInsert, HookStatsRow, PendingRow};
+
+#[cfg(feature = "backend-sqlite")]
+use crate::store::SqliteStore;
+
+#[cfg(feature = "postgres")]
+use crate::postgres::PostgresStore;
+
+#[cfg(feature = "opensearch")]
+use crate::opensearch::OpenSearchStore;
+
+/// Which storage backend is active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendKind {
+    Sqlite,
+    Postgres,
+    OpenSearch,
+}
+
+impl BackendKind {
+    /// Resolve the requested backend from `ICM_DB_BACKEND` (default
+    /// `sqlite`). Unknown values are a config error.
+    pub fn from_env() -> IcmResult<Self> {
+        match std::env::var("ICM_DB_BACKEND")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+        {
+            None | Some("") | Some("sqlite") => Ok(BackendKind::Sqlite),
+            Some("postgres") | Some("postgresql") | Some("pg") => Ok(BackendKind::Postgres),
+            Some("opensearch") | Some("os") => Ok(BackendKind::OpenSearch),
+            Some(other) => Err(IcmError::Config(format!(
+                "unknown ICM_DB_BACKEND '{other}' (expected: sqlite, postgres, opensearch)"
+            ))),
+        }
+    }
+}
+
+/// A storage backend chosen at runtime. Every method forwards to the
+/// active variant.
+pub enum Store {
+    #[cfg(feature = "backend-sqlite")]
+    Sqlite(SqliteStore),
+    #[cfg(feature = "postgres")]
+    Postgres(PostgresStore),
+    #[cfg(feature = "opensearch")]
+    OpenSearch(OpenSearchStore),
+}
+
+/// Forward a method call to the active backend variant.
+macro_rules! dispatch {
+    ($self:expr, $m:ident ( $($a:expr),* )) => {
+        match $self {
+            #[cfg(feature = "backend-sqlite")]
+            Store::Sqlite(s) => s.$m($($a),*),
+            #[cfg(feature = "postgres")]
+            Store::Postgres(s) => s.$m($($a),*),
+            #[cfg(feature = "opensearch")]
+            Store::OpenSearch(s) => s.$m($($a),*),
+        }
+    };
+}
+
+/// Error for a backend selected at runtime but not compiled into the binary.
+/// Only used in builds where some backend feature is disabled.
+#[allow(dead_code)]
+fn not_compiled(name: &str) -> IcmError {
+    IcmError::Config(format!(
+        "the '{name}' backend was requested (ICM_DB_BACKEND) but this build was \
+         not compiled with its Cargo feature"
+    ))
+}
+
+impl Store {
+    // --- Constructors (select the backend, then build that variant) ---
+
+    /// Open or create the active backend with the default embedding dim.
+    pub fn new(path: &Path) -> IcmResult<Self> {
+        Self::with_dims(path, icm_core::DEFAULT_EMBEDDING_DIMS)
+    }
+
+    /// Open or create the active backend with a specific embedding dim.
+    pub fn with_dims(path: &Path, embedding_dims: usize) -> IcmResult<Self> {
+        match BackendKind::from_env()? {
+            BackendKind::Sqlite => {
+                #[cfg(feature = "backend-sqlite")]
+                {
+                    Ok(Store::Sqlite(SqliteStore::with_dims(path, embedding_dims)?))
+                }
+                #[cfg(not(feature = "backend-sqlite"))]
+                {
+                    let _ = (path, embedding_dims);
+                    Err(not_compiled("sqlite"))
+                }
+            }
+            BackendKind::Postgres => {
+                #[cfg(feature = "postgres")]
+                {
+                    Ok(Store::Postgres(PostgresStore::with_dims(
+                        path,
+                        embedding_dims,
+                    )?))
+                }
+                #[cfg(not(feature = "postgres"))]
+                {
+                    let _ = (path, embedding_dims);
+                    Err(not_compiled("postgres"))
+                }
+            }
+            BackendKind::OpenSearch => {
+                #[cfg(feature = "opensearch")]
+                {
+                    Ok(Store::OpenSearch(OpenSearchStore::with_dims(
+                        path,
+                        embedding_dims,
+                    )?))
+                }
+                #[cfg(not(feature = "opensearch"))]
+                {
+                    let _ = (path, embedding_dims);
+                    Err(not_compiled("opensearch"))
+                }
+            }
+        }
+    }
+
+    /// Open the active backend read-only (issue #263).
+    pub fn open_readonly(path: &Path) -> IcmResult<Self> {
+        match BackendKind::from_env()? {
+            BackendKind::Sqlite => {
+                #[cfg(feature = "backend-sqlite")]
+                {
+                    Ok(Store::Sqlite(SqliteStore::open_readonly(path)?))
+                }
+                #[cfg(not(feature = "backend-sqlite"))]
+                {
+                    let _ = path;
+                    Err(not_compiled("sqlite"))
+                }
+            }
+            BackendKind::Postgres => {
+                #[cfg(feature = "postgres")]
+                {
+                    Ok(Store::Postgres(PostgresStore::open_readonly(path)?))
+                }
+                #[cfg(not(feature = "postgres"))]
+                {
+                    let _ = path;
+                    Err(not_compiled("postgres"))
+                }
+            }
+            BackendKind::OpenSearch => {
+                #[cfg(feature = "opensearch")]
+                {
+                    Ok(Store::OpenSearch(OpenSearchStore::open_readonly(path)?))
+                }
+                #[cfg(not(feature = "opensearch"))]
+                {
+                    let _ = path;
+                    Err(not_compiled("opensearch"))
+                }
+            }
+        }
+    }
+
+    /// In-memory store for the active backend (remote backends connect to
+    /// their configured endpoint).
+    pub fn in_memory() -> IcmResult<Self> {
+        Self::in_memory_with_dims(icm_core::DEFAULT_EMBEDDING_DIMS)
+    }
+
+    /// See [`Self::in_memory`].
+    pub fn in_memory_with_dims(embedding_dims: usize) -> IcmResult<Self> {
+        match BackendKind::from_env()? {
+            BackendKind::Sqlite => {
+                #[cfg(feature = "backend-sqlite")]
+                {
+                    Ok(Store::Sqlite(SqliteStore::in_memory_with_dims(
+                        embedding_dims,
+                    )?))
+                }
+                #[cfg(not(feature = "backend-sqlite"))]
+                {
+                    let _ = embedding_dims;
+                    Err(not_compiled("sqlite"))
+                }
+            }
+            BackendKind::Postgres => {
+                #[cfg(feature = "postgres")]
+                {
+                    Ok(Store::Postgres(PostgresStore::in_memory_with_dims(
+                        embedding_dims,
+                    )?))
+                }
+                #[cfg(not(feature = "postgres"))]
+                {
+                    let _ = embedding_dims;
+                    Err(not_compiled("postgres"))
+                }
+            }
+            BackendKind::OpenSearch => {
+                #[cfg(feature = "opensearch")]
+                {
+                    Ok(Store::OpenSearch(OpenSearchStore::in_memory_with_dims(
+                        embedding_dims,
+                    )?))
+                }
+                #[cfg(not(feature = "opensearch"))]
+                {
+                    let _ = embedding_dims;
+                    Err(not_compiled("opensearch"))
+                }
+            }
+        }
+    }
+
+    /// Peek the stored embedding dim for the active backend (no full open).
+    pub fn read_stored_embedding_dims(path: &Path) -> IcmResult<Option<usize>> {
+        match BackendKind::from_env()? {
+            BackendKind::Sqlite => {
+                #[cfg(feature = "backend-sqlite")]
+                {
+                    SqliteStore::read_stored_embedding_dims(path)
+                }
+                #[cfg(not(feature = "backend-sqlite"))]
+                {
+                    let _ = path;
+                    Ok(None)
+                }
+            }
+            BackendKind::Postgres => {
+                #[cfg(feature = "postgres")]
+                {
+                    PostgresStore::read_stored_embedding_dims(path)
+                }
+                #[cfg(not(feature = "postgres"))]
+                {
+                    let _ = path;
+                    Ok(None)
+                }
+            }
+            BackendKind::OpenSearch => {
+                #[cfg(feature = "opensearch")]
+                {
+                    OpenSearchStore::read_stored_embedding_dims(path)
+                }
+                #[cfg(not(feature = "opensearch"))]
+                {
+                    let _ = path;
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    /// Whether the active store was opened read-only.
+    pub fn is_readonly(&self) -> bool {
+        dispatch!(self, is_readonly())
+    }
+
+    // --- Inherent store/recall/hook surface (forwarded) ---
+
+    pub fn maybe_auto_decay(&self) -> IcmResult<()> {
+        dispatch!(self, maybe_auto_decay())
+    }
+    pub fn increment_hook_counter(&self) -> IcmResult<usize> {
+        dispatch!(self, increment_hook_counter())
+    }
+    pub fn reset_hook_counter(&self) -> IcmResult<()> {
+        dispatch!(self, reset_hook_counter())
+    }
+    pub fn enqueue_pending_extraction(
+        &self,
+        project: &str,
+        tool_name: &str,
+        raw_output: &str,
+    ) -> IcmResult<String> {
+        dispatch!(
+            self,
+            enqueue_pending_extraction(project, tool_name, raw_output)
+        )
+    }
+    pub fn list_pending_extractions(&self, limit: usize) -> IcmResult<Vec<PendingRow>> {
+        dispatch!(self, list_pending_extractions(limit))
+    }
+    pub fn delete_pending_extractions(&self, ids: &[String]) -> IcmResult<usize> {
+        dispatch!(self, delete_pending_extractions(ids))
+    }
+    pub fn pending_extraction_count(&self) -> IcmResult<usize> {
+        dispatch!(self, pending_extraction_count())
+    }
+    pub fn upsert_code_area(
+        &self,
+        project: &str,
+        file_path: &str,
+        description: Option<&str>,
+        session_id: Option<&str>,
+        tool_name: Option<&str>,
+    ) -> IcmResult<()> {
+        dispatch!(
+            self,
+            upsert_code_area(project, file_path, description, session_id, tool_name)
+        )
+    }
+    pub fn list_code_areas(
+        &self,
+        project: Option<&str>,
+        in_file: Option<&str>,
+        since: Option<DateTime<Utc>>,
+        limit: usize,
+    ) -> IcmResult<Vec<CodeArea>> {
+        dispatch!(self, list_code_areas(project, in_file, since, limit))
+    }
+    pub fn code_area_count(&self) -> IcmResult<usize> {
+        dispatch!(self, code_area_count())
+    }
+    pub fn record_hook_event(&self, ev: &HookEventInsert) -> IcmResult<i64> {
+        dispatch!(self, record_hook_event(ev))
+    }
+    pub fn hook_events_recent(
+        &self,
+        limit: usize,
+        event_filter: Option<&str>,
+    ) -> IcmResult<Vec<HookEvent>> {
+        dispatch!(self, hook_events_recent(limit, event_filter))
+    }
+    pub fn hook_stats(&self, since_rfc3339: &str) -> IcmResult<Vec<HookStatsRow>> {
+        dispatch!(self, hook_stats(since_rfc3339))
+    }
+    pub fn prune_hook_events(&self, cutoff_rfc3339: &str) -> IcmResult<usize> {
+        dispatch!(self, prune_hook_events(cutoff_rfc3339))
+    }
+    pub fn hook_event_count(&self) -> IcmResult<usize> {
+        dispatch!(self, hook_event_count())
+    }
+    pub fn auto_consolidate(&self, topic: &str, threshold: usize) -> IcmResult<bool> {
+        dispatch!(self, auto_consolidate(topic, threshold))
+    }
+    pub fn auto_consolidate_with_embedder(
+        &self,
+        topic: &str,
+        threshold: usize,
+        embedder: Option<&dyn Embedder>,
+    ) -> IcmResult<bool> {
+        dispatch!(
+            self,
+            auto_consolidate_with_embedder(topic, threshold, embedder)
+        )
+    }
+    pub fn expand_with_neighbors(
+        &self,
+        initial: &[(Memory, f32)],
+        max_neighbors: usize,
+        hop_discount: f32,
+        max_total: usize,
+    ) -> IcmResult<Vec<(Memory, f32)>> {
+        dispatch!(
+            self,
+            expand_with_neighbors(initial, max_neighbors, hop_discount, max_total)
+        )
+    }
+    pub fn get_many(&self, ids: &[&str]) -> IcmResult<HashMap<String, Memory>> {
+        dispatch!(self, get_many(ids))
+    }
+    pub fn get_by_topic_prefix(&self, topic: &str) -> IcmResult<Vec<Memory>> {
+        dispatch!(self, get_by_topic_prefix(topic))
+    }
+    pub fn list_topics_with_prefix(&self, prefix: Option<&str>) -> IcmResult<Vec<(String, usize)>> {
+        dispatch!(self, list_topics_with_prefix(prefix))
+    }
+    pub fn detect_patterns(
+        &self,
+        topic: &str,
+        min_cluster_size: usize,
+    ) -> IcmResult<Vec<PatternCluster>> {
+        dispatch!(self, detect_patterns(topic, min_cluster_size))
+    }
+    pub fn extract_pattern_as_concept(
+        &self,
+        cluster: &PatternCluster,
+        memoir_id: &str,
+    ) -> IcmResult<String> {
+        dispatch!(self, extract_pattern_as_concept(cluster, memoir_id))
+    }
+}
+
+impl MemoryStore for Store {
+    fn store(&self, memory: Memory) -> IcmResult<String> {
+        dispatch!(self, store(memory))
+    }
+    fn get(&self, id: &str) -> IcmResult<Option<Memory>> {
+        dispatch!(self, get(id))
+    }
+    fn update(&self, memory: &Memory) -> IcmResult<()> {
+        dispatch!(self, update(memory))
+    }
+    fn delete(&self, id: &str) -> IcmResult<()> {
+        dispatch!(self, delete(id))
+    }
+    fn search_by_keywords(&self, keywords: &[&str], limit: usize) -> IcmResult<Vec<Memory>> {
+        dispatch!(self, search_by_keywords(keywords, limit))
+    }
+    fn search_fts(&self, query: &str, limit: usize) -> IcmResult<Vec<Memory>> {
+        dispatch!(self, search_fts(query, limit))
+    }
+    fn search_by_embedding(
+        &self,
+        embedding: &[f32],
+        limit: usize,
+    ) -> IcmResult<Vec<(Memory, f32)>> {
+        dispatch!(self, search_by_embedding(embedding, limit))
+    }
+    fn search_hybrid(
+        &self,
+        query: &str,
+        embedding: &[f32],
+        limit: usize,
+    ) -> IcmResult<Vec<(Memory, f32)>> {
+        dispatch!(self, search_hybrid(query, embedding, limit))
+    }
+    fn update_access(&self, id: &str) -> IcmResult<()> {
+        dispatch!(self, update_access(id))
+    }
+    fn batch_update_access(&self, ids: &[&str]) -> IcmResult<usize> {
+        dispatch!(self, batch_update_access(ids))
+    }
+    fn apply_decay(&self, decay_factor: f32) -> IcmResult<usize> {
+        dispatch!(self, apply_decay(decay_factor))
+    }
+    fn prune(&self, weight_threshold: f32) -> IcmResult<usize> {
+        dispatch!(self, prune(weight_threshold))
+    }
+    fn list_all(&self) -> IcmResult<Vec<Memory>> {
+        dispatch!(self, list_all())
+    }
+    fn get_by_topic(&self, topic: &str) -> IcmResult<Vec<Memory>> {
+        dispatch!(self, get_by_topic(topic))
+    }
+    fn list_topics(&self) -> IcmResult<Vec<(String, usize)>> {
+        dispatch!(self, list_topics())
+    }
+    fn consolidate_topic(&self, topic: &str, consolidated: Memory) -> IcmResult<()> {
+        dispatch!(self, consolidate_topic(topic, consolidated))
+    }
+    fn count(&self) -> IcmResult<usize> {
+        dispatch!(self, count())
+    }
+    fn count_by_topic(&self, topic: &str) -> IcmResult<usize> {
+        dispatch!(self, count_by_topic(topic))
+    }
+    fn stats(&self) -> IcmResult<StoreStats> {
+        dispatch!(self, stats())
+    }
+    fn topic_health(&self, topic: &str) -> IcmResult<TopicHealth> {
+        dispatch!(self, topic_health(topic))
+    }
+}
+
+impl MemoirStore for Store {
+    fn create_memoir(&self, memoir: Memoir) -> IcmResult<String> {
+        dispatch!(self, create_memoir(memoir))
+    }
+    fn get_memoir(&self, id: &str) -> IcmResult<Option<Memoir>> {
+        dispatch!(self, get_memoir(id))
+    }
+    fn get_memoir_by_name(&self, name: &str) -> IcmResult<Option<Memoir>> {
+        dispatch!(self, get_memoir_by_name(name))
+    }
+    fn update_memoir(&self, memoir: &Memoir) -> IcmResult<()> {
+        dispatch!(self, update_memoir(memoir))
+    }
+    fn delete_memoir(&self, id: &str) -> IcmResult<()> {
+        dispatch!(self, delete_memoir(id))
+    }
+    fn list_memoirs(&self) -> IcmResult<Vec<Memoir>> {
+        dispatch!(self, list_memoirs())
+    }
+    fn add_concept(&self, concept: Concept) -> IcmResult<String> {
+        dispatch!(self, add_concept(concept))
+    }
+    fn get_concept(&self, id: &str) -> IcmResult<Option<Concept>> {
+        dispatch!(self, get_concept(id))
+    }
+    fn get_concept_by_name(&self, memoir_id: &str, name: &str) -> IcmResult<Option<Concept>> {
+        dispatch!(self, get_concept_by_name(memoir_id, name))
+    }
+    fn update_concept(&self, concept: &Concept) -> IcmResult<()> {
+        dispatch!(self, update_concept(concept))
+    }
+    fn delete_concept(&self, id: &str) -> IcmResult<()> {
+        dispatch!(self, delete_concept(id))
+    }
+    fn list_concepts(&self, memoir_id: &str) -> IcmResult<Vec<Concept>> {
+        dispatch!(self, list_concepts(memoir_id))
+    }
+    fn search_concepts_fts(
+        &self,
+        memoir_id: &str,
+        query: &str,
+        limit: usize,
+    ) -> IcmResult<Vec<Concept>> {
+        dispatch!(self, search_concepts_fts(memoir_id, query, limit))
+    }
+    fn search_concepts_by_label(
+        &self,
+        memoir_id: &str,
+        label: &Label,
+        limit: usize,
+    ) -> IcmResult<Vec<Concept>> {
+        dispatch!(self, search_concepts_by_label(memoir_id, label, limit))
+    }
+    fn search_all_concepts_fts(&self, query: &str, limit: usize) -> IcmResult<Vec<Concept>> {
+        dispatch!(self, search_all_concepts_fts(query, limit))
+    }
+    fn refine_concept(
+        &self,
+        id: &str,
+        new_definition: &str,
+        new_source_ids: &[String],
+    ) -> IcmResult<()> {
+        dispatch!(self, refine_concept(id, new_definition, new_source_ids))
+    }
+    fn add_link(&self, link: ConceptLink) -> IcmResult<String> {
+        dispatch!(self, add_link(link))
+    }
+    fn get_links_from(&self, concept_id: &str) -> IcmResult<Vec<ConceptLink>> {
+        dispatch!(self, get_links_from(concept_id))
+    }
+    fn get_links_to(&self, concept_id: &str) -> IcmResult<Vec<ConceptLink>> {
+        dispatch!(self, get_links_to(concept_id))
+    }
+    fn delete_link(&self, id: &str) -> IcmResult<()> {
+        dispatch!(self, delete_link(id))
+    }
+    fn get_neighbors(
+        &self,
+        concept_id: &str,
+        relation: Option<Relation>,
+    ) -> IcmResult<Vec<Concept>> {
+        dispatch!(self, get_neighbors(concept_id, relation))
+    }
+    fn get_neighborhood(
+        &self,
+        concept_id: &str,
+        depth: usize,
+    ) -> IcmResult<(Vec<Concept>, Vec<ConceptLink>)> {
+        dispatch!(self, get_neighborhood(concept_id, depth))
+    }
+    fn get_links_for_memoir(&self, memoir_id: &str) -> IcmResult<Vec<ConceptLink>> {
+        dispatch!(self, get_links_for_memoir(memoir_id))
+    }
+    fn memoir_stats(&self, memoir_id: &str) -> IcmResult<MemoirStats> {
+        dispatch!(self, memoir_stats(memoir_id))
+    }
+    fn batch_memoir_concept_counts(&self) -> IcmResult<HashMap<String, usize>> {
+        dispatch!(self, batch_memoir_concept_counts())
+    }
+}
+
+impl FeedbackStore for Store {
+    fn store_feedback(&self, feedback: Feedback) -> IcmResult<String> {
+        dispatch!(self, store_feedback(feedback))
+    }
+    fn search_feedback(
+        &self,
+        query: &str,
+        topic: Option<&str>,
+        limit: usize,
+    ) -> IcmResult<Vec<Feedback>> {
+        dispatch!(self, search_feedback(query, topic, limit))
+    }
+    fn list_feedback(&self, topic: Option<&str>, limit: usize) -> IcmResult<Vec<Feedback>> {
+        dispatch!(self, list_feedback(topic, limit))
+    }
+    fn increment_applied(&self, id: &str) -> IcmResult<()> {
+        dispatch!(self, increment_applied(id))
+    }
+    fn delete_feedback(&self, id: &str) -> IcmResult<()> {
+        dispatch!(self, delete_feedback(id))
+    }
+    fn feedback_stats(&self) -> IcmResult<FeedbackStats> {
+        dispatch!(self, feedback_stats())
+    }
+}
+
+impl FactsStore for Store {
+    fn set_fact(&self, entity: &str, key: &str, value: &str, source: &str) -> IcmResult<String> {
+        dispatch!(self, set_fact(entity, key, value, source))
+    }
+    fn get_fact(&self, entity: &str, key: &str) -> IcmResult<Option<Fact>> {
+        dispatch!(self, get_fact(entity, key))
+    }
+    fn list_facts(&self, entity: &str, key_prefix: Option<&str>) -> IcmResult<Vec<Fact>> {
+        dispatch!(self, list_facts(entity, key_prefix))
+    }
+    fn history(&self, entity: &str, key: &str) -> IcmResult<Vec<Fact>> {
+        dispatch!(self, history(entity, key))
+    }
+    fn forget_fact(&self, entity: &str, key: &str) -> IcmResult<usize> {
+        dispatch!(self, forget_fact(entity, key))
+    }
+    fn facts_stats(&self) -> IcmResult<FactsStats> {
+        dispatch!(self, facts_stats())
+    }
+}
+
+impl TranscriptStore for Store {
+    fn create_session(
+        &self,
+        agent: &str,
+        project: Option<&str>,
+        metadata: Option<&str>,
+    ) -> IcmResult<String> {
+        dispatch!(self, create_session(agent, project, metadata))
+    }
+    fn ensure_session(
+        &self,
+        id: &str,
+        agent: &str,
+        project: Option<&str>,
+        metadata: Option<&str>,
+    ) -> IcmResult<String> {
+        dispatch!(self, ensure_session(id, agent, project, metadata))
+    }
+    fn get_session(&self, id: &str) -> IcmResult<Option<Session>> {
+        dispatch!(self, get_session(id))
+    }
+    fn list_sessions(&self, project: Option<&str>, limit: usize) -> IcmResult<Vec<Session>> {
+        dispatch!(self, list_sessions(project, limit))
+    }
+    fn record_message(
+        &self,
+        session_id: &str,
+        role: Role,
+        content: &str,
+        tool_name: Option<&str>,
+        tokens: Option<i64>,
+        metadata: Option<&str>,
+    ) -> IcmResult<String> {
+        dispatch!(
+            self,
+            record_message(session_id, role, content, tool_name, tokens, metadata)
+        )
+    }
+    fn list_session_messages(
+        &self,
+        session_id: &str,
+        limit: usize,
+        offset: usize,
+    ) -> IcmResult<Vec<Message>> {
+        dispatch!(self, list_session_messages(session_id, limit, offset))
+    }
+    fn search_transcripts(
+        &self,
+        query: &str,
+        session_id: Option<&str>,
+        project: Option<&str>,
+        limit: usize,
+    ) -> IcmResult<Vec<TranscriptHit>> {
+        dispatch!(self, search_transcripts(query, session_id, project, limit))
+    }
+    fn forget_session(&self, id: &str) -> IcmResult<()> {
+        dispatch!(self, forget_session(id))
+    }
+    fn transcript_stats(&self) -> IcmResult<TranscriptStats> {
+        dispatch!(self, transcript_stats())
+    }
+}

--- a/crates/icm-store/src/common.rs
+++ b/crates/icm-store/src/common.rs
@@ -1,0 +1,70 @@
+//! Shared public types used by every storage backend.
+//!
+//! These live in one always-compiled module so that the backends
+//! (`store`/SQLite, `postgres`, `opensearch`) can be compiled together in
+//! a single binary without colliding type definitions. The runtime
+//! [`crate::Store`] enum dispatches across whichever backends are enabled.
+
+use chrono::{DateTime, Utc};
+
+/// One row of the `hook_events` telemetry table.
+#[derive(Debug, Clone)]
+pub struct HookEvent {
+    pub id: i64,
+    pub ts: DateTime<Utc>,
+    pub event: String,
+    pub project: Option<String>,
+    pub session_id: Option<String>,
+    pub tool_name: Option<String>,
+    pub duration_ms: Option<i64>,
+    pub exit_code: i32,
+    pub payload_size: Option<i64>,
+    pub note: Option<String>,
+}
+
+/// Insert payload for a single `hook_events` row. `id` and `ts` are filled
+/// in by the store.
+#[derive(Debug, Clone, Default)]
+pub struct HookEventInsert {
+    pub event: String,
+    pub project: Option<String>,
+    pub session_id: Option<String>,
+    pub tool_name: Option<String>,
+    pub duration_ms: Option<i64>,
+    pub exit_code: i32,
+    pub payload_size: Option<i64>,
+    pub note: Option<String>,
+}
+
+/// One row of the `code_areas` table. A code area is a file the agent
+/// touched during a session; the same `(project, file_path)` increments
+/// `touch_count` on each re-touch rather than producing a duplicate row.
+#[derive(Debug, Clone)]
+pub struct CodeArea {
+    pub id: i64,
+    pub project: String,
+    pub file_path: String,
+    pub description: Option<String>,
+    pub session_id: Option<String>,
+    pub tool_name: Option<String>,
+    pub touch_count: i64,
+    pub first_touched_at: DateTime<Utc>,
+    pub last_touched_at: DateTime<Utc>,
+}
+
+/// Aggregate counts/percentiles for a slice of hook history. Returned by
+/// the `hook_stats` call.
+#[derive(Debug, Clone, Default)]
+pub struct HookStatsRow {
+    pub event: String,
+    pub count: i64,
+    pub error_count: i64,
+    pub avg_duration_ms: f64,
+    pub p50_duration_ms: i64,
+    pub p99_duration_ms: i64,
+}
+
+/// One row from the async extraction queue:
+/// `(id, project, tool_name, raw_output, captured_at)` where
+/// `captured_at` is RFC3339.
+pub type PendingRow = (String, String, String, String, String);

--- a/crates/icm-store/src/lib.rs
+++ b/crates/icm-store/src/lib.rs
@@ -1,40 +1,34 @@
 //! Storage backends for ICM.
 //!
-//! The store is pluggable (issue #301). Exactly one backend is selected
-//! at build time via a Cargo feature, and all expose the same public
-//! surface through the [`Store`] type alias so `icm-cli` / `icm-mcp` are
-//! backend-agnostic:
+//! The store is pluggable (issue #301) and backends are **additive**: any
+//! combination can be compiled into one binary, and the active backend is
+//! selected at **runtime** via the `ICM_DB_BACKEND` environment variable
+//! (`sqlite` (default) / `postgres` / `opensearch`). This follows the
+//! idiomatic Rust pattern (e.g. SurrealDB's `Surreal<Any>`): features only
+//! control which backends are *available*, not which one runs.
 //!
 //! - **`backend-sqlite`** (default) — in-process SQLite via `rusqlite` +
-//!   `sqlite-vec`. Single binary, zero external services. This is the
-//!   only built-in backend and is byte-for-byte unchanged from before.
-//! - **`postgres`** (opt-in) — a network-accessible PostgreSQL backend so
-//!   multiple ICM processes / Kubernetes replicas can share one memory
-//!   store. Build with `--no-default-features --features postgres`.
-//! - **`opensearch`** (opt-in) — a search-native OpenSearch backend
-//!   (BM25 + `knn_vector` HNSW) sharing memory across replicas. Build
-//!   with `--no-default-features --features opensearch`.
+//!   `sqlite-vec`. Lightweight, no external service.
+//! - **`postgres`** — network-accessible PostgreSQL (`pgvector` + FTS) so
+//!   replicas share one memory store.
+//! - **`opensearch`** — network-accessible OpenSearch (BM25 + `knn_vector`).
+//!
+//! `icm-cli` / `icm-mcp` use the [`Store`] enum, which dispatches every
+//! call to whichever backend variant is active.
 
-// Exactly one backend must be active.
-#[cfg(any(
-    all(feature = "backend-sqlite", feature = "postgres"),
-    all(feature = "backend-sqlite", feature = "opensearch"),
-    all(feature = "postgres", feature = "opensearch"),
-))]
-compile_error!(
-    "the storage backends `backend-sqlite`, `postgres` and `opensearch` are \
-     mutually exclusive; build a remote backend with `--no-default-features \
-     --features <postgres|opensearch>`"
-);
+// At least one backend must be compiled in.
 #[cfg(not(any(
     feature = "backend-sqlite",
     feature = "postgres",
     feature = "opensearch"
 )))]
 compile_error!(
-    "a storage backend must be selected: enable `backend-sqlite` (default), \
-     `postgres`, or `opensearch`"
+    "at least one storage backend must be enabled: `backend-sqlite` (default), \
+     `postgres`, and/or `opensearch`"
 );
+
+mod backend;
+mod common;
 
 #[cfg(feature = "backend-sqlite")]
 mod schema;
@@ -47,27 +41,16 @@ mod postgres;
 #[cfg(feature = "opensearch")]
 mod opensearch;
 
-#[cfg(feature = "backend-sqlite")]
-pub use store::{HookEvent, HookEventInsert, HookStatsRow, PendingRow, SqliteStore};
+// Shared row types (backend-agnostic).
+pub use common::{CodeArea, HookEvent, HookEventInsert, HookStatsRow, PendingRow};
 
-/// The active storage backend. `icm-cli` and `icm-mcp` use this alias
-/// everywhere instead of a concrete type, so swapping backends is a
-/// build-feature change with no call-site churn.
-#[cfg(feature = "backend-sqlite")]
-pub type Store = SqliteStore;
+// The runtime-dispatched store and the backend selector.
+pub use backend::{BackendKind, Store};
 
-#[cfg(feature = "postgres")]
-pub use postgres::{HookEvent, HookEventInsert, HookStatsRow, PendingRow, PostgresStore};
-
-/// The active storage backend (PostgreSQL build). See the `backend-sqlite`
-/// variant above.
-#[cfg(feature = "postgres")]
-pub type Store = PostgresStore;
-
+// Concrete backend types, exposed for direct use / tests.
 #[cfg(feature = "opensearch")]
-pub use opensearch::{HookEvent, HookEventInsert, HookStatsRow, OpenSearchStore, PendingRow};
-
-/// The active storage backend (OpenSearch build). See the `backend-sqlite`
-/// variant above.
-#[cfg(feature = "opensearch")]
-pub type Store = OpenSearchStore;
+pub use opensearch::OpenSearchStore;
+#[cfg(feature = "postgres")]
+pub use postgres::PostgresStore;
+#[cfg(feature = "backend-sqlite")]
+pub use store::SqliteStore;

--- a/crates/icm-store/src/opensearch.rs
+++ b/crates/icm-store/src/opensearch.rs
@@ -42,68 +42,9 @@ use icm_core::{
     StoreStats, TopicHealth, TranscriptHit, TranscriptStats, TranscriptStore,
 };
 
-// ---------------------------------------------------------------------------
-// Shared public row types (mirrors the SQLite/PostgreSQL backends so the
-// `icm-cli` / `icm-mcp` re-exports resolve under any backend feature).
-// ---------------------------------------------------------------------------
-
-/// One row of the `hook_events` telemetry stream.
-#[derive(Debug, Clone)]
-pub struct HookEvent {
-    pub id: i64,
-    pub ts: DateTime<Utc>,
-    pub event: String,
-    pub project: Option<String>,
-    pub session_id: Option<String>,
-    pub tool_name: Option<String>,
-    pub duration_ms: Option<i64>,
-    pub exit_code: i32,
-    pub payload_size: Option<i64>,
-    pub note: Option<String>,
-}
-
-/// Insert payload for a single hook event; `id`/`ts` are filled in here.
-#[derive(Debug, Clone, Default)]
-pub struct HookEventInsert {
-    pub event: String,
-    pub project: Option<String>,
-    pub session_id: Option<String>,
-    pub tool_name: Option<String>,
-    pub duration_ms: Option<i64>,
-    pub exit_code: i32,
-    pub payload_size: Option<i64>,
-    pub note: Option<String>,
-}
-
-/// One aggregated row of `hook_stats`.
-#[derive(Debug, Clone)]
-pub struct HookStatsRow {
-    pub event: String,
-    pub count: i64,
-    pub error_count: i64,
-    pub avg_duration_ms: f64,
-    pub p50_duration_ms: i64,
-    pub p99_duration_ms: i64,
-}
-
-/// Row tuple from the pending-extraction queue:
-/// `(id, project, tool_name, raw_output, captured_at)`.
-pub type PendingRow = (String, String, String, String, String);
-
-/// One row of the `code_areas` collection: a file the agent touched,
-/// deduplicated on `(project, file_path)` with a `touch_count`.
-#[derive(Debug, Clone)]
-pub struct CodeArea {
-    pub id: i64,
-    pub project: String,
-    pub file_path: String,
-    pub description: Option<String>,
-    pub session_id: Option<String>,
-    pub tool_name: Option<String>,
-    pub touch_count: i64,
-    pub first_touched_at: DateTime<Utc>,
-    pub last_touched_at: DateTime<Utc>,
-}
+// Shared public row types live in `crate::common` (issue #301) so every
+// backend can be compiled into one binary without colliding definitions.
+pub use crate::common::{CodeArea, HookEvent, HookEventInsert, HookStatsRow, PendingRow};
 
 // ---------------------------------------------------------------------------
 // Index names

--- a/crates/icm-store/src/postgres.rs
+++ b/crates/icm-store/src/postgres.rs
@@ -47,72 +47,9 @@ use icm_core::{
     StoreStats, TopicHealth, TranscriptHit, TranscriptStats, TranscriptStore,
 };
 
-// ---------------------------------------------------------------------------
-// Shared public row types
-//
-// These mirror the structs the SQLite backend exposes (they live in
-// `store.rs` there). Both backends are mutually exclusive at build time,
-// so duplicating the definitions here — rather than sharing a module —
-// keeps `store.rs` byte-for-byte unchanged on the default build.
-// ---------------------------------------------------------------------------
-
-/// One row of the `hook_events` telemetry table.
-#[derive(Debug, Clone)]
-pub struct HookEvent {
-    pub id: i64,
-    pub ts: DateTime<Utc>,
-    pub event: String,
-    pub project: Option<String>,
-    pub session_id: Option<String>,
-    pub tool_name: Option<String>,
-    pub duration_ms: Option<i64>,
-    pub exit_code: i32,
-    pub payload_size: Option<i64>,
-    pub note: Option<String>,
-}
-
-/// Insert payload for a single `hook_events` row. `id` and `ts` are
-/// filled in by the store.
-#[derive(Debug, Clone, Default)]
-pub struct HookEventInsert {
-    pub event: String,
-    pub project: Option<String>,
-    pub session_id: Option<String>,
-    pub tool_name: Option<String>,
-    pub duration_ms: Option<i64>,
-    pub exit_code: i32,
-    pub payload_size: Option<i64>,
-    pub note: Option<String>,
-}
-
-/// One row of the `code_areas` table (auto-captured file edits, #196).
-#[derive(Debug, Clone)]
-pub struct CodeArea {
-    pub id: i64,
-    pub project: String,
-    pub file_path: String,
-    pub description: Option<String>,
-    pub session_id: Option<String>,
-    pub tool_name: Option<String>,
-    pub touch_count: i64,
-    pub first_touched_at: DateTime<Utc>,
-    pub last_touched_at: DateTime<Utc>,
-}
-
-/// Aggregate counts/percentiles for a slice of hook history.
-#[derive(Debug, Clone, Default)]
-pub struct HookStatsRow {
-    pub event: String,
-    pub count: i64,
-    pub error_count: i64,
-    pub avg_duration_ms: f64,
-    pub p50_duration_ms: i64,
-    pub p99_duration_ms: i64,
-}
-
-/// Queue row tuple shape: `(id, project, tool_name, raw_output, captured_at)`.
-/// `captured_at` is RFC3339 to match the SQLite backend's tuple.
-pub type PendingRow = (String, String, String, String, String);
+// Shared public row types live in `crate::common` (issue #301) so every
+// backend can be compiled into one binary without colliding definitions.
+pub use crate::common::{CodeArea, HookEvent, HookEventInsert, HookStatsRow, PendingRow};
 
 // ---------------------------------------------------------------------------
 // Helpers (mirrored from the SQLite backend so behaviour matches)

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -23,69 +23,9 @@ pub(crate) fn db_err(e: rusqlite::Error) -> IcmError {
     IcmError::Database(e.to_string())
 }
 
-/// One row from the `pending_extractions` queue, in column order:
-/// `(id, project, tool_name, raw_output, captured_at_rfc3339)`.
-pub type PendingRow = (String, String, String, String, String);
-
-/// Structured hook telemetry event written by every `icm hook <event>`
-/// invocation. Read back by `icm hook-log` / `icm hook-stats`.
-#[derive(Debug, Clone)]
-pub struct HookEvent {
-    pub id: i64,
-    pub ts: DateTime<Utc>,
-    pub event: String,
-    pub project: Option<String>,
-    pub session_id: Option<String>,
-    pub tool_name: Option<String>,
-    pub duration_ms: Option<i64>,
-    pub exit_code: i32,
-    pub payload_size: Option<i64>,
-    pub note: Option<String>,
-}
-
-/// Insert payload for a single `hook_events` row. `id` and `ts` are filled
-/// in by the store.
-#[derive(Debug, Clone, Default)]
-pub struct HookEventInsert {
-    pub event: String,
-    pub project: Option<String>,
-    pub session_id: Option<String>,
-    pub tool_name: Option<String>,
-    pub duration_ms: Option<i64>,
-    pub exit_code: i32,
-    pub payload_size: Option<i64>,
-    pub note: Option<String>,
-}
-
-/// One row of the `code_areas` table. A code area is a file the agent
-/// touched during a session; the same `(project, file_path)` increments
-/// `touch_count` on each re-touch rather than producing a duplicate row.
-/// Populated by `cmd_hook_post` whenever it sees an Edit / Write /
-/// MultiEdit / NotebookEdit tool call. See issue #196.
-#[derive(Debug, Clone)]
-pub struct CodeArea {
-    pub id: i64,
-    pub project: String,
-    pub file_path: String,
-    pub description: Option<String>,
-    pub session_id: Option<String>,
-    pub tool_name: Option<String>,
-    pub touch_count: i64,
-    pub first_touched_at: DateTime<Utc>,
-    pub last_touched_at: DateTime<Utc>,
-}
-
-/// Aggregate counts/percentiles for a slice of hook history. Returned by
-/// `SqliteStore::hook_stats`.
-#[derive(Debug, Clone, Default)]
-pub struct HookStatsRow {
-    pub event: String,
-    pub count: i64,
-    pub error_count: i64,
-    pub avg_duration_ms: f64,
-    pub p50_duration_ms: i64,
-    pub p99_duration_ms: i64,
-}
+// Shared public row types live in `crate::common` so all backends can be
+// compiled into one binary without colliding definitions (issue #301).
+pub use crate::common::{CodeArea, HookEvent, HookEventInsert, HookStatsRow, PendingRow};
 
 /// Collect mapped rows into a Vec, converting rusqlite errors.
 fn collect_rows<T>(

--- a/deploy/k8s/opensearch.yaml
+++ b/deploy/k8s/opensearch.yaml
@@ -7,7 +7,8 @@ metadata:
   name: icm-os
   labels: { app: icm-opensearch }
 stringData:
-  # Connection string consumed by the icm pods.
+  # Select the backend at runtime + give it a connection string.
+  ICM_DB_BACKEND: opensearch
   ICM_OPENSEARCH_URL: http://icm-opensearch:9200
 ---
 apiVersion: apps/v1

--- a/deploy/k8s/postgres.yaml
+++ b/deploy/k8s/postgres.yaml
@@ -10,7 +10,8 @@ stringData:
   POSTGRES_USER: icm
   POSTGRES_PASSWORD: icm
   POSTGRES_DB: icm
-  # Connection string consumed by the icm pods.
+  # Select the backend at runtime + give it a connection string.
+  ICM_DB_BACKEND: postgres
   ICM_POSTGRES_URL: postgres://icm:icm@icm-postgres:5432/icm
 ---
 apiVersion: apps/v1

--- a/docs/opensearch-backend.md
+++ b/docs/opensearch-backend.md
@@ -30,27 +30,30 @@ error for now and stay fully available on SQLite.
 
 ## Build
 
+The **default `icm` binary already includes this backend** (backends are
+additive and selected at runtime, like SurrealDB's `Surreal<Any>`). For a
+lean image without ONNX/fastembed, build keyword + BM25 only:
+
 ```sh
 cargo build -p icm-cli --release --no-default-features \
-    --features "opensearch,embeddings,tui,http-api"
+    --features "opensearch,http-api"
 ```
-
-Drop `embeddings` for a lean container image that uses keyword + BM25
-search only.
 
 ## Configure
 
-The backend talks to the OpenSearch REST API over the blocking `ureq`
-client (no async runtime). Point it at your cluster:
+Select the backend at runtime. It talks to the OpenSearch REST API over the
+blocking `ureq` client (no async runtime):
 
 ```sh
+export ICM_DB_BACKEND=opensearch
 export ICM_OPENSEARCH_URL=http://localhost:9201
 # optional basic auth (when the security plugin is enabled):
 export ICM_OPENSEARCH_USER=admin
 export ICM_OPENSEARCH_PASSWORD=...
 ```
 
-The `--db` flag is ignored by this backend.
+With `ICM_DB_BACKEND` unset (or `sqlite`) the binary uses the local SQLite
+file. The `--db` flag is ignored by this backend.
 
 ### Local OpenSearch
 

--- a/docs/postgres-backend.md
+++ b/docs/postgres-backend.md
@@ -43,25 +43,24 @@ PostgreSQL Flexible Server (with `vector` allow-listed) both work.
 
 ## Build
 
-```sh
-cargo build -p icm-cli --release \
-    --no-default-features \
-    --features "postgres,embeddings,tui,http-api"
-```
-
-`postgres` and `backend-sqlite` are mutually exclusive; `--no-default-features`
-drops the default SQLite backend so only PostgreSQL is compiled in.
+The **default `icm` binary already includes this backend** (backends are
+additive and selected at runtime, like SurrealDB's `Surreal<Any>`). Nothing
+to build — just configure it. For a lean SQLite-only binary, build with
+`--no-default-features --features "embeddings,tui,http-api,backend-sqlite"`.
 
 ## Configure
 
-The connection string comes from the environment:
+Select the backend at runtime and give it a connection string:
 
 ```sh
+export ICM_DB_BACKEND=postgres
 export ICM_POSTGRES_URL="postgres://user:pass@host:5432/icm"
-# DATABASE_URL is accepted as a fallback.
+# DATABASE_URL is accepted as a fallback for the URL.
 ```
 
-The `--db` flag (a SQLite file path) is ignored by this backend.
+With `ICM_DB_BACKEND` unset (or `sqlite`) the binary uses the local SQLite
+file as before. The `--db` flag (a SQLite file path) is ignored by this
+backend.
 
 The schema — including the `vector(N)` embedding column whose dimension
 `N` matches your embedder — is created on first connect. The stored
@@ -76,6 +75,7 @@ docker run -d --name icm-pg \
     -e POSTGRES_PASSWORD=icm -e POSTGRES_USER=icm -e POSTGRES_DB=icm \
     -p 55432:5432 pgvector/pgvector:pg16
 
+export ICM_DB_BACKEND=postgres
 export ICM_POSTGRES_URL="postgres://icm:icm@127.0.0.1:55432/icm"
 
 icm store -t demo -c "PostgreSQL backend shares memory across replicas" -i high


### PR DESCRIPTION
## Summary

Follow-up to the PostgreSQL (#302) and OpenSearch (#304) backends. Those shipped as **mutually-exclusive Cargo features** (one binary per backend) — which Cargo officially discourages (features must be additive; mutual-exclusion breaks `cargo build --all-features` / `--workspace`).

This switches to the idiomatic Rust pattern used by **SurrealDB** (`Surreal<Any>`), **sqlx** (`Any`) and **sccache**: backends are **additive**, all compiled into **one binary**, and the active one is selected at **runtime** via `ICM_DB_BACKEND` (`sqlite` default / `postgres` / `opensearch`).

## What changed

- `Store` is now an **enum** over the compiled-in backends, forwarding every trait method + inherent method to the active variant via a small `dispatch!` macro. `BackendKind::from_env()` does the runtime selection.
- Shared row types (`HookEvent`/`HookEventInsert`/`HookStatsRow`/`PendingRow`/`CodeArea`) centralized in `common.rs` so all backends coexist without colliding definitions.
- Dropped the 3-way `compile_error!`; kept only an "at least one backend" guard. The published binary enables all three by default; lean builds remain possible (`--no-default-features --features "...,backend-sqlite"`).
- Docs + K8s manifests updated to use `ICM_DB_BACKEND`.

## Size (release, x86_64-linux)

| Binary | Size |
|---|---|
| SQLite-only | 32 MB |
| **All three backends** | **33 MB** |
| OpenSearch lean (no embeddings) | 6.4 MB |

→ **+1 MB** for all three backends. The bulk (~24 MB) is ONNX/fastembed embeddings, not the DB drivers — so one all-in binary is essentially free.

## Verified

- **One binary**, `ICM_DB_BACKEND=sqlite|postgres|opensearch` — each `store` + `recall` against real local services; invalid value errors cleanly.
- Default (all-in) build + `clippy -D warnings`; lean combos (sqlite-only, opensearch-only) also build + clippy clean.
- Full default test suite green.

_(The individual backends were already validated on throwaway AKS clusters in #302/#304; this PR is the dispatch refactor, re-verified e2e locally against real PostgreSQL + OpenSearch.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)