### PR TITLE
feat(store): runtime backend selection via ICM_DB_BACKEND (#301)

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -44,7 +44,9 @@ use icm_store::Store;
     about = "Infinite Context Memory - persistent memory for LLMs"
 )]
 struct Cli {
-    /// Path to the SQLite database (overrides config and ICM_DB env var)
+    /// Path to the SQLite database (overrides config and ICM_DB env var).
+    /// Used by the default SQLite backend; ignored when ICM_DB_BACKEND
+    /// selects a remote backend (postgres / opensearch).
     #[arg(long, global = true, action = clap::ArgAction::Append)]
     db: Vec<PathBuf>,
 


### PR DESCRIPTION
Documents the `--db` flag's backend-dependent behaviour and, via the `Release-As: 0.10.57` trailer, cuts the release that ships the additive-backends / single-binary refactor (#307) — which merged as a `refactor:` commit and so did not trigger a version bump on its own.

No functional change beyond the help text; the runtime selection itself landed in #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)