### PR TITLE
Add MCP HTTP proxy mode

### DIFF
--- a/crates/icm-cli/src/http_api.rs
+++ b/crates/icm-cli/src/http_api.rs
@@ -25,6 +25,7 @@
 //! is refused at startup — otherwise the full memory store would be
 //! reachable, unauthenticated, to anyone on that interface.
 
+use std::io::{self, BufRead, Write};
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 
@@ -39,6 +40,8 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+
+use icm_mcp::protocol::{JsonRpcMessage, JsonRpcResponse};
 
 use icm_core::{
     is_preference_topic, keyword_matches, project_matches, topic_matches, Embedder, Importance,
@@ -62,6 +65,8 @@ use crate::recall_format::{self, RecallFormat};
 pub struct AppState {
     store: Arc<Mutex<Store>>,
     embedder: Option<Arc<dyn Embedder + Send + Sync>>,
+    mcp_calls_since_store: Arc<Mutex<u32>>,
+    auto_consolidate: icm_mcp::AutoConsolidate,
     /// When set, every request must carry `Authorization: Bearer <token>`.
     token: Option<String>,
 }
@@ -177,6 +182,12 @@ pub struct ConsolidateReq {
     keep_originals: bool,
 }
 
+#[derive(Debug, Deserialize, Default)]
+pub struct McpQuery {
+    #[serde(default)]
+    compact: bool,
+}
+
 // ---------------------------------------------------------------------------
 // Server entry
 // ---------------------------------------------------------------------------
@@ -202,6 +213,7 @@ pub async fn run_http_server(
     embedder: Option<Box<dyn Embedder + Send + Sync>>,
     addr: SocketAddr,
     token: Option<String>,
+    auto_consolidate: icm_mcp::AutoConsolidate,
 ) -> Result<()> {
     // A non-loopback bind with no token exposes the full memory store —
     // recall, store, consolidate — to anyone who can reach the interface,
@@ -214,10 +226,13 @@ pub async fn run_http_server(
     let state = AppState {
         store: Arc::new(Mutex::new(store)),
         embedder: embedder.map(Arc::from),
+        mcp_calls_since_store: Arc::new(Mutex::new(0)),
+        auto_consolidate,
         token,
     };
 
     let app = Router::new()
+        .route("/mcp", post(handle_mcp))
         .route("/recall", post(handle_recall))
         .route("/store", post(handle_store))
         .route("/consolidate", post(handle_consolidate))
@@ -237,6 +252,36 @@ pub async fn run_http_server(
     eprintln!("[icm http] listening on http://{local}");
 
     axum::serve(listener, app).await?;
+    Ok(())
+}
+
+pub fn run_mcp_stdio_proxy(base_url: &str, token: Option<&str>, compact: bool) -> Result<()> {
+    let endpoint = mcp_proxy_endpoint(base_url, compact)?;
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+
+    for line in stdin.lock().lines() {
+        let line = line?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        match post_mcp_json_rpc(&endpoint, token, line) {
+            Ok(Some(body)) => {
+                writeln!(stdout, "{body}")?;
+                stdout.flush()?;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                let id = json_rpc_id(line);
+                let response = JsonRpcResponse::err(id, -32000, e.to_string());
+                writeln!(stdout, "{}", serde_json::to_string(&response)?)?;
+                stdout.flush()?;
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -284,6 +329,87 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
         return false;
     }
     a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+async fn handle_mcp(
+    State(state): State<AppState>,
+    Query(q): Query<McpQuery>,
+    Json(raw): Json<Value>,
+) -> Response {
+    let msg: JsonRpcMessage = match serde_json::from_value(raw) {
+        Ok(msg) => msg,
+        Err(e) => {
+            let response = JsonRpcResponse::err(Value::Null, -32700, format!("parse error: {e}"));
+            return Json(response).into_response();
+        }
+    };
+
+    let store = lock_store(&state);
+    let mut calls_since_store = state
+        .mcp_calls_since_store
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    match icm_mcp::server::handle_json_rpc_message(
+        msg,
+        &store,
+        state.embedder_ref(),
+        q.compact,
+        state.auto_consolidate,
+        &mut calls_since_store,
+    ) {
+        Some(response) => Json(response).into_response(),
+        None => StatusCode::NO_CONTENT.into_response(),
+    }
+}
+
+fn mcp_proxy_endpoint(base_url: &str, compact: bool) -> Result<String> {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        anyhow::bail!("--http-proxy URL must not be empty");
+    }
+    let mut endpoint = if trimmed.ends_with("/mcp") || trimmed.contains("/mcp?") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}/mcp")
+    };
+    endpoint.push(if endpoint.contains('?') { '&' } else { '?' });
+    endpoint.push_str("compact=");
+    endpoint.push_str(if compact { "true" } else { "false" });
+    Ok(endpoint)
+}
+
+fn post_mcp_json_rpc(endpoint: &str, token: Option<&str>, body: &str) -> Result<Option<String>> {
+    let mut req = ureq::post(endpoint).set("content-type", "application/json");
+    if let Some(token) = token {
+        req = req.set("authorization", &format!("Bearer {token}"));
+    }
+
+    match req.send_string(body) {
+        Ok(resp) => {
+            if resp.status() == StatusCode::NO_CONTENT.as_u16() {
+                return Ok(None);
+            }
+            let body = resp.into_string()?;
+            if body.trim().is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(body))
+            }
+        }
+        Err(ureq::Error::Status(code, resp)) => {
+            let text = resp.into_string().unwrap_or_default();
+            anyhow::bail!("HTTP {code} from ICM daemon: {}", text.trim());
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn json_rpc_id(line: &str) -> Value {
+    serde_json::from_str::<Value>(line)
+        .ok()
+        .and_then(|v| v.get("id").cloned())
+        .unwrap_or(Value::Null)
 }
 
 // ---------------------------------------------------------------------------
@@ -826,6 +952,11 @@ mod tests {
         let state = AppState {
             store: Arc::new(Mutex::new(Store::in_memory().unwrap())),
             embedder: None,
+            mcp_calls_since_store: Arc::new(Mutex::new(0)),
+            auto_consolidate: icm_mcp::AutoConsolidate {
+                enabled: false,
+                threshold: 10,
+            },
             token: None,
         };
 
@@ -888,6 +1019,11 @@ mod tests {
         let state = AppState {
             store: Arc::new(Mutex::new(store)),
             embedder: Some(Arc::new(StubEmbedder)),
+            mcp_calls_since_store: Arc::new(Mutex::new(0)),
+            auto_consolidate: icm_mcp::AutoConsolidate {
+                enabled: false,
+                threshold: 10,
+            },
             token: None,
         };
 
@@ -909,6 +1045,22 @@ mod tests {
         assert!(
             memories[0].embedding.is_some(),
             "consolidated memory must have an embedding attached"
+        );
+    }
+
+    #[test]
+    fn mcp_proxy_endpoint_points_at_mcp_route_with_compact_flag() {
+        assert_eq!(
+            mcp_proxy_endpoint("http://127.0.0.1:11435", true).unwrap(),
+            "http://127.0.0.1:11435/mcp?compact=true"
+        );
+        assert_eq!(
+            mcp_proxy_endpoint("http://127.0.0.1:11435/mcp", false).unwrap(),
+            "http://127.0.0.1:11435/mcp?compact=false"
+        );
+        assert_eq!(
+            mcp_proxy_endpoint("http://127.0.0.1:11435/", false).unwrap(),
+            "http://127.0.0.1:11435/mcp?compact=false"
         );
     }
 }

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -739,7 +739,7 @@ enum Commands {
 
         /// Launch web dashboard instead of MCP stdio server
         #[cfg(feature = "web")]
-        #[arg(long)]
+        #[arg(long, conflicts_with = "http_proxy")]
         expose: bool,
 
         /// Run a persistent local HTTP API on the given address instead
@@ -753,10 +753,12 @@ enum Commands {
         #[arg(long, value_name = "ADDR")]
         http: Option<std::net::SocketAddr>,
 
-        /// Require `Authorization: Bearer <TOKEN>` on every HTTP
-        /// request (only meaningful with `--http`). Required unless
-        /// `--http` binds a loopback address (127.0.0.1/::1) — binding
-        /// any other interface without a token is refused.
+        /// Forward MCP stdio requests to an `icm serve --http` daemon.
+        #[cfg(feature = "http-api")]
+        #[arg(long = "http-proxy", value_name = "URL", conflicts_with = "http")]
+        http_proxy: Option<String>,
+
+        /// Bearer token used by the HTTP server or proxy.
         #[cfg(feature = "http-api")]
         #[arg(long, value_name = "TOKEN")]
         token: Option<String>,
@@ -1601,6 +1603,22 @@ fn main() -> Result<()> {
 
     let cli = Cli::parse();
     let cfg = config::load_config()?;
+
+    #[cfg(feature = "http-api")]
+    if let Commands::Serve {
+        compact,
+        http_proxy: Some(base_url),
+        token,
+        ..
+    } = &cli.command
+    {
+        return http_api::run_mcp_stdio_proxy(
+            base_url,
+            token.as_deref(),
+            *compact || cfg.mcp.compact,
+        );
+    }
+
     let embeddings_enabled =
         cfg.embeddings.enabled && !cli.no_embeddings && std::env::var("ICM_NO_EMBEDDINGS").is_err();
     // Load-dynamic build (issue #345): resolve the onnxruntime runtime. Activate
@@ -2168,6 +2186,8 @@ fn main() -> Result<()> {
             #[cfg(feature = "http-api")]
             http,
             #[cfg(feature = "http-api")]
+                http_proxy: _,
+            #[cfg(feature = "http-api")]
             token,
         } => {
             #[cfg(feature = "web")]
@@ -2188,7 +2208,11 @@ fn main() -> Result<()> {
             if let Some(addr) = http {
                 let boxed_emb: Option<Box<dyn icm_core::Embedder + Send + Sync>> =
                     embedder.map(|e| Box::new(e) as Box<dyn icm_core::Embedder + Send + Sync>);
-                return http_api::run_http_server(store, boxed_emb, addr, token);
+                let auto_consolidate = icm_mcp::AutoConsolidate {
+                    enabled: cfg.memory.auto_consolidate_enabled,
+                    threshold: cfg.memory.auto_consolidate_threshold,
+                };
+                return http_api::run_http_server(store, boxed_emb, addr, token, auto_consolidate);
             }
             #[cfg(feature = "embeddings")]
             let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
@@ -11346,6 +11370,34 @@ mod cli_contracts_tests {
         assert!(tip.contains("--summarizer-provider"));
         assert!(tip.contains("provider=none"));
         assert!(tip.contains("--keep-originals"));
+    }
+
+    #[cfg(feature = "http-api")]
+    #[test]
+    fn serve_accepts_http_proxy_url_for_stdio_mcp() {
+        let cli = Cli::try_parse_from([
+            "icm",
+            "serve",
+            "--http-proxy",
+            "http://127.0.0.1:11435",
+            "--token",
+            "secret",
+        ])
+        .unwrap();
+
+        let Commands::Serve {
+            compact,
+            http_proxy,
+            token,
+            ..
+        } = cli.command
+        else {
+            panic!("expected serve command");
+        };
+
+        assert!(!compact);
+        assert_eq!(http_proxy.as_deref(), Some("http://127.0.0.1:11435"));
+        assert_eq!(token.as_deref(), Some("secret"));
     }
 }
 

--- a/crates/icm-cli/tests/http_api_integration.rs
+++ b/crates/icm-cli/tests/http_api_integration.rs
@@ -20,7 +20,7 @@
 //!     (which the issue's manual smoke covers).
 #![cfg(all(target_os = "linux", feature = "http-api"))]
 
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
@@ -276,4 +276,67 @@ fn missing_required_fields_return_400() {
         }
         other => panic!("expected error, got {other:?}"),
     }
+}
+
+#[test]
+fn stdio_proxy_forwards_tools_call_to_http_daemon() {
+    let (_dir, db) = temp_db();
+    let server = spawn_server(&db, &["--token", "proxy-secret"]);
+
+    let mut proxy = Command::new(ICM)
+        .arg("--no-embeddings")
+        .arg("serve")
+        .arg("--http-proxy")
+        .arg(format!("http://{}", server.addr))
+        .arg("--token")
+        .arg("proxy-secret")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn icm serve --http-proxy");
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "icm_memory_store",
+            "arguments": {
+                "topic": "proxy-test",
+                "content": "stored through stdio proxy"
+            }
+        }
+    });
+    {
+        let mut stdin = proxy.stdin.take().expect("proxy stdin");
+        writeln!(stdin, "{request}").expect("write JSON-RPC request");
+    }
+
+    let output = proxy.wait_with_output().expect("wait for proxy");
+    assert!(
+        output.status.success(),
+        "proxy failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let response: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("proxy emitted JSON-RPC");
+    assert_eq!(response["jsonrpc"], "2.0");
+    assert_eq!(response["id"], 1);
+    assert!(response.get("result").is_some(), "response: {response}");
+
+    let recall = ureq::post(&format!("http://{}/recall?format=json", server.addr))
+        .timeout(Duration::from_secs(5))
+        .set("authorization", "Bearer proxy-secret")
+        .set("content-type", "application/json")
+        .send_string(r#"{"query":"stdio proxy","topic":"proxy-test"}"#)
+        .expect("authenticated recall");
+    let memories: serde_json::Value =
+        serde_json::from_str(&recall.into_string().unwrap()).expect("recall JSON");
+    assert!(
+        memories.as_array().is_some_and(|items| items
+            .iter()
+            .any(|item| item["summary"] == "stored through stdio proxy")),
+        "proxied store did not reach daemon DB: {memories}"
+    );
 }

--- a/crates/icm-mcp/src/server.rs
+++ b/crates/icm-mcp/src/server.rs
@@ -103,35 +103,49 @@ pub fn run_server(
             }
         };
 
-        let method = msg.method.as_deref().unwrap_or("");
-        debug!("MCP request: {method}");
-
-        // Notifications have no id — don't respond
-        let id = match msg.id {
-            Some(id) => id,
-            None => continue,
-        };
-
-        let response = match method {
-            "initialize" => handle_initialize(id),
-            "ping" => JsonRpcResponse::ok(id, json!({})),
-            "tools/list" => handle_tools_list(id, embedder.is_some()),
-            "tools/call" => handle_tools_call(
-                id,
-                &msg.params,
-                store,
-                embedder,
-                compact,
-                auto_consolidate,
-                &mut calls_since_store,
-            ),
-            other => JsonRpcResponse::method_not_found(id, other),
-        };
-
-        write_response(&mut stdout, &response)?;
+        if let Some(response) = handle_json_rpc_message(
+            msg,
+            store,
+            embedder,
+            compact,
+            auto_consolidate,
+            &mut calls_since_store,
+        ) {
+            write_response(&mut stdout, &response)?;
+        }
     }
 
     Ok(())
+}
+
+pub fn handle_json_rpc_message(
+    msg: JsonRpcMessage,
+    store: &Store,
+    embedder: Option<&dyn Embedder>,
+    compact: bool,
+    auto_consolidate: AutoConsolidate,
+    calls_since_store: &mut u32,
+) -> Option<JsonRpcResponse> {
+    let method = msg.method.as_deref().unwrap_or("");
+    debug!("MCP request: {method}");
+
+    let id = msg.id?;
+
+    Some(match method {
+        "initialize" => handle_initialize(id),
+        "ping" => JsonRpcResponse::ok(id, json!({})),
+        "tools/list" => handle_tools_list(id, embedder.is_some()),
+        "tools/call" => handle_tools_call(
+            id,
+            &msg.params,
+            store,
+            embedder,
+            compact,
+            auto_consolidate,
+            calls_since_store,
+        ),
+        other => JsonRpcResponse::method_not_found(id, other),
+    })
 }
 
 fn write_response(stdout: &mut io::Stdout, resp: &JsonRpcResponse) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary

Add a lightweight MCP stdio proxy so multiple clients can share one warm ICM HTTP daemon.

## Motivation

Each stdio client currently launches a separate `icm serve` process and may load its own embedding model. Memory use therefore scales with the number of connected clients.

## Changes

- add `icm serve --http-proxy <URL>`
- forward MCP stdio traffic to a shared local HTTP daemon
- expose `POST /mcp` on the warm daemon
- document the multi-client setup and memory tradeoff

## Compatibility and safety

Existing stdio and HTTP modes are unchanged. The proxy is opt-in and does not change the MCP request or response contract.

## Validation

```bash
cargo check -p icm-cli --no-default-features --features http-api,backend-sqlite
cargo test -p icm-cli --bin icm proxy --no-default-features --features http-api,backend-sqlite,embeddings
cargo test -p icm-mcp --no-default-features --features backend-sqlite
```