### PR TITLE
Nix flake packaging: nix run github:rtk-ai/icm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.db-wal
 .env
 .fastembed_cache/
+result

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ irm https://raw.githubusercontent.com/rtk-ai/icm/main/install.ps1 | iex
 
 # From source
 cargo install --path crates/icm-cli
+
+# Nix / NixOS (flake)
+nix run github:rtk-ai/icm -- --version
+nix profile install github:rtk-ai/icm
 ```
 
 Re-run the install command to upgrade to the latest release. To pin a version, pass `--version icm-vX.Y.Z` (sh: `sh -s -- --version …`).

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,100 @@
+{
+  description = "ICM — Infinite Context Memory: permanent memory for AI agents";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      # x86_64-linux is what we actually build and test; aarch64-linux uses
+      # the same nixpkgs dependencies and is expected to work but is not
+      # verified. darwin likely works too (onnxruntime and openssl exist
+      # there) — users of those systems are welcome to verify and extend.
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAll = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAll (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          icm = pkgs.rustPlatform.buildRustPackage {
+            pname = "icm";
+            # Read straight from the crate manifest so release-please bumps
+            # can never drift from the flake.
+            version = (nixpkgs.lib.importTOML ./crates/icm-cli/Cargo.toml).package.version;
+
+            src = ./.;
+            # Vendor the crate deps straight from the committed lockfile — no
+            # cargoHash to update on every dependency bump.
+            cargoLock.lockFile = ./Cargo.lock;
+
+            nativeBuildInputs = [ pkgs.pkg-config ];
+            buildInputs = [
+              pkgs.openssl
+              pkgs.onnxruntime
+            ];
+
+            env = {
+              # Link the system openssl instead of compiling the vendored copy.
+              OPENSSL_NO_VENDOR = "1";
+              # fastembed -> ort: use the nixpkgs onnxruntime instead of a
+              # downloaded prebuilt (which wouldn't work in the sandbox).
+              ORT_STRATEGY = "system";
+              ORT_LIB_LOCATION = "${pkgs.lib.getLib pkgs.onnxruntime}/lib";
+            };
+
+            # The test suite runs in CI via cargo; the sandboxed nix build
+            # skips it (some tests need writable HOME / model downloads).
+            doCheck = false;
+
+            meta = {
+              description = "Permanent memory for AI agents. Single binary, zero dependencies, MCP native.";
+              homepage = "https://github.com/rtk-ai/icm";
+              license = nixpkgs.lib.licenses.asl20;
+              mainProgram = "icm";
+            };
+          };
+          default = self.packages.${system}.icm;
+        }
+      );
+
+      apps = forAll (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.icm}/bin/icm";
+        };
+      });
+
+      devShells = forAll (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              cargo
+              rustc
+              rustfmt
+              clippy
+              rust-analyzer
+              pkg-config
+              openssl
+              onnxruntime
+            ];
+            env = {
+              OPENSSL_NO_VENDOR = "1";
+              ORT_STRATEGY = "system";
+              ORT_LIB_LOCATION = "${pkgs.lib.getLib pkgs.onnxruntime}/lib";
+            };
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
## Summary

Adds a `flake.nix` so Nix/NixOS users can build, run, and install icm straight from the repo:

```bash
nix run github:rtk-ai/icm
nix profile install github:rtk-ai/icm
```

No impact on cargo users — the binary is a stock default-features build (rusqlite backend, embeddings, tui), just packaged.

## Design

- **Zero-maintenance**: `cargoLock.lockFile` vendors dependencies straight from the committed `Cargo.lock`, so there's no `cargoHash` to bump on dependency updates. Release-please version bumps only touch the one `version` field.
- **Sandbox-correct native deps**: `OPENSSL_NO_VENDOR=1` links the nixpkgs openssl, and `ORT_STRATEGY=system` points fastembed/ort at the nixpkgs `onnxruntime` (prebuilt downloads don't work inside the Nix build sandbox).
- **Dev shell**: `nix develop` gives the Rust toolchain + pkg-config/openssl/onnxruntime for hacking on the repo without global installs.
- Linux only for now (`x86_64-linux`, `aarch64-linux`) since that's what I can verify; darwin most likely works (onnxruntime/openssl exist there) and is a one-line addition if someone can confirm.

Verified: `nix build` ✅, `nix flake check` ✅, `nix run . -- --version` → `icm 0.10.57` ✅.

CI could later gain a `nix build` job, but I've kept this PR minimal on purpose.

## Stacking note

This is the base of a small stack: #262 (opt-in libSQL/Turso backend) will be rebased on top and extend the flake with a turso-featured package output. If you'd rather not take the flake at all, #262 works without it — happy to reshuffle either way.