### PR TITLE
fix(recall): keyword-OR fallback when FTS AND-match misses natural-language queries

### DIFF
--- a/crates/icm-cli/src/extract.rs
+++ b/crates/icm-cli/src/extract.rs
@@ -190,6 +190,18 @@ fn content_tokens(query: &str) -> Vec<String> {
         .collect()
 }
 
+/// How many `tokens` appear (case-insensitively) in `mem`'s topic, summary,
+/// or keywords. Used to rank `search_by_keywords` candidates by relevance
+/// instead of leaving them ordered by weight alone.
+fn matched_token_count(tokens: &[String], mem: &Memory) -> usize {
+    let haystack =
+        format!("{} {} {}", mem.topic, mem.summary, mem.keywords.join(" ")).to_lowercase();
+    tokens
+        .iter()
+        .filter(|t| haystack.contains(t.as_str()))
+        .count()
+}
+
 /// Recall relevant memories and format as context preamble for prompt injection.
 ///
 /// When `project` is `Some(name)`, results are restricted to memories whose
@@ -236,6 +248,12 @@ pub fn recall_context(
         if !tokens.is_empty() {
             let refs: Vec<&str> = tokens.iter().map(String::as_str).collect();
             fts_results = store.search_by_keywords(&refs, pool)?;
+            // search_by_keywords orders by weight alone, which can bury a
+            // memory matching most of the query behind an unrelated
+            // higher-weight one that only matched a single token. Re-rank
+            // by how many content tokens actually matched; ties keep their
+            // relative (weight) order since sort_by_key is stable.
+            fts_results.sort_by_key(|m| std::cmp::Reverse(matched_token_count(&tokens, m)));
         }
     }
     let project_filtered: Vec<Memory> = fts_results
@@ -1810,6 +1828,90 @@ mod tests {
             vec!["why", "workers", "crash", "right", "after", "deploy"],
         );
         assert!(content_tokens("do a").is_empty());
+    }
+
+    #[test]
+    fn test_recall_context_keyword_fallback_ranks_by_relevance_not_weight_alone() {
+        // search_by_keywords orders candidates by weight alone. A memory
+        // that only shares one token with the query but has high weight
+        // must not bury a memory that shares every content token.
+        let store = Store::in_memory().unwrap();
+        store
+            .store(Memory::new(
+                "notes".to_string(),
+                "Onboarding checklist mentions deploy day logistics.".to_string(),
+                Importance::Critical,
+            ))
+            .unwrap();
+        store
+            .store(Memory::new(
+                "notes".to_string(),
+                "The deploy script must run migrations before restarting workers, \
+                 otherwise workers boot against the old schema and crash on startup."
+                    .to_string(),
+                Importance::Medium,
+            ))
+            .unwrap();
+
+        let ctx =
+            recall_context(&store, "why do workers crash right after a deploy", None, 5).unwrap();
+        let deploy_script_pos = ctx
+            .find("deploy script")
+            .expect("must surface both matches");
+        let onboarding_pos = ctx.find("Onboarding").expect("must surface both matches");
+        assert!(
+            deploy_script_pos < onboarding_pos,
+            "the memory matching workers/crash/deploy must rank above the one matching only \
+             deploy, despite lower weight: {ctx}"
+        );
+    }
+
+    #[test]
+    fn test_recall_context_natural_language_question_surfaces_cross_project_on_larger_store() {
+        // Reproduces the shape of #323's second report: a project-scoped
+        // store with many topics (context-<project>, errors-resolved,
+        // preferences), where a natural-language query matches a
+        // cross-project errors-resolved memory that tier 1's project
+        // filter legitimately excludes. Tier 2 (global FTS/keyword
+        // fallback, #185 H5) must still surface it.
+        let store = Store::in_memory().unwrap();
+        for i in 0..20 {
+            store
+                .store(Memory::new(
+                    "context-projecta".to_string(),
+                    format!("Project A note number {i} about routine maintenance"),
+                    Importance::High,
+                ))
+                .unwrap();
+        }
+        store
+            .store(Memory::new(
+                "errors-resolved".to_string(),
+                "Fixed a bug where the worker pool crashed on deploy because migrations ran \
+                 after the workers restarted instead of before."
+                    .to_string(),
+                Importance::Critical,
+            ))
+            .unwrap();
+        store
+            .store(Memory::new(
+                "preferences".to_string(),
+                "User prefers tabs over spaces".to_string(),
+                Importance::Critical,
+            ))
+            .unwrap();
+
+        let ctx = recall_context(
+            &store,
+            "why do workers crash right after a deploy",
+            Some("projectb"),
+            5,
+        )
+        .unwrap();
+        assert!(
+            ctx.contains("worker pool crashed"),
+            "natural-language query must surface the cross-project errors-resolved memory: {ctx}"
+        );
     }
 
     #[test]

--- a/crates/icm-cli/src/extract.rs
+++ b/crates/icm-cli/src/extract.rs
@@ -178,6 +178,18 @@ fn cap_importance(value: Importance, cap: Importance) -> Importance {
     }
 }
 
+/// Query tokens worth matching against `search_by_keywords`: alphanumeric
+/// runs of 3+ chars, lowercased. Short tokens ("a", "do", "is") are dropped
+/// because `search_by_keywords` matches via `LIKE '%token%'` — keeping them
+/// would match almost every row and defeat the point of a relevance filter.
+fn content_tokens(query: &str) -> Vec<String> {
+    query
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|w| w.chars().count() >= 3)
+        .map(|w| w.to_lowercase())
+        .collect()
+}
+
 /// Recall relevant memories and format as context preamble for prompt injection.
 ///
 /// When `project` is `Some(name)`, results are restricted to memories whose
@@ -204,8 +216,28 @@ pub fn recall_context(
         }
     };
 
-    // Oversample FTS results so that filtering still leaves enough candidates.
-    let fts_results = store.search_fts(query, limit.saturating_mul(4).max(limit))?;
+    // Oversample so that filtering still leaves enough candidates.
+    let pool = limit.saturating_mul(4).max(limit);
+
+    // #323: `search_fts` quotes every token, so FTS5 AND-joins them — a
+    // natural-language question ("why do workers crash right after a
+    // deploy") requires the memory to contain "why"/"do"/"a" too, and
+    // returns nothing even on an otherwise strong match. `recall` doesn't
+    // have this problem because it goes through `search_hybrid` (FTS +
+    // vector); `recall_context` stays FTS-only on purpose (no embedder load
+    // on the per-prompt hook path), so give it the same keyword-OR fallback
+    // `cmd_recall` already falls back to when it has no embedder either
+    // (see `search_by_keywords` call in `cmd_recall`). An off-topic query
+    // shares no content tokens with any memory, so this still yields
+    // nothing and tier 3 (preferences-by-weight, #185 H4) still applies.
+    let mut fts_results = store.search_fts(query, pool)?;
+    if fts_results.is_empty() {
+        let tokens = content_tokens(query);
+        if !tokens.is_empty() {
+            let refs: Vec<&str> = tokens.iter().map(String::as_str).collect();
+            fts_results = store.search_by_keywords(&refs, pool)?;
+        }
+    }
     let project_filtered: Vec<Memory> = fts_results
         .iter()
         .filter(|m| project_filter(m))
@@ -1740,6 +1772,44 @@ mod tests {
         let ctx = recall_context(&store, "Token", None, 5).unwrap();
         assert!(ctx.contains("refresh"));
         assert!(ctx.contains("rotation"));
+    }
+
+    #[test]
+    fn test_recall_context_natural_language_question_surfaces_memory() {
+        // #323: a natural-language question carries function words
+        // ("why"/"do"/"a") the memory never contains. `search_fts`
+        // AND-joins every token, so it returns nothing even though the
+        // memory is a clear topical match. The keyword-OR fallback must
+        // recover it.
+        let store = Store::in_memory().unwrap();
+        store
+            .store(Memory::new(
+                "notes".to_string(),
+                "The deploy script must run migrations before restarting workers, \
+                 otherwise workers boot against the old schema and crash on startup."
+                    .to_string(),
+                Importance::Critical,
+            ))
+            .unwrap();
+
+        let ctx =
+            recall_context(&store, "why do workers crash right after a deploy", None, 5).unwrap();
+        assert!(
+            ctx.contains("deploy script"),
+            "natural-language question must surface the matching memory: {ctx}"
+        );
+    }
+
+    #[test]
+    fn test_content_tokens_drops_short_words() {
+        // Short tokens ("a", "do") would match almost every row via
+        // `search_by_keywords`'s LIKE '%token%' and defeat the fallback's
+        // purpose, so they must be dropped.
+        assert_eq!(
+            content_tokens("why do workers crash right after a deploy"),
+            vec!["why", "workers", "crash", "right", "after", "deploy"],
+        );
+        assert!(content_tokens("do a").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #323. `recall_context()` — the shared engine behind `recall-context`, `recall-project`, and the `hook prompt` / `UserPromptSubmit` path — is FTS-only: it calls `store.search_fts(query, …)` and never the hybrid/vector path that plain `recall` uses.

`sanitize_fts_query()` wraps every token in quotes, so FTS5 evaluates the result as an implicit AND of single-token phrases. A natural-language question like `"why do workers crash right after a deploy"` therefore also requires the memory to literally contain `why`/`do`/`right`/`after`/`a` — none of which are in it — so FTS returns zero rows even though the memory is a strong topical match.

With FTS empty, tiers 1 and 2 of the three-tier fallback (both derived from the FTS results) are also empty, so every such query drops straight to tier 3: preference-topic memories sorted by weight, the *same set regardless of the query*. That's the "returns a static set regardless of relevance" symptom from #323's second repro (the ~90-memory project DB).

## Fix

Add a keyword-OR fallback via the existing `search_by_keywords()` when the AND-FTS query comes back empty, using the query's content tokens (alphanumeric runs of 3+ chars — short tokens are dropped because `search_by_keywords` matches via `LIKE '%token%'`, and a 1-2 char token would match almost every row).

This mirrors what `cmd_recall()` already does when it has no embedder available (same `search_by_keywords` fallback), so `recall_context` now degrades the same way `recall` does instead of jumping straight to the weight-sorted last resort.

An off-topic query still shares no content tokens with any memory, so it still yields nothing from this fallback and the #185 H4 preferences-only tier still applies — verified by the existing off-topic tests, unchanged and still passing.

Candidates from the keyword fallback are then re-ranked by how many content tokens actually matched (`search_by_keywords` itself only orders by weight, which could otherwise bury a strong multi-token match behind an unrelated memory that only matched once but has higher weight).

### Trade-off: the 3+ char token filter drops short acronyms

`content_tokens` requires 3+ alphanumeric chars, so 1-2 char tokens ("S3", "ML", "AI") are dropped from the fallback query — they'd otherwise match almost every row via `search_by_keywords`'s `LIKE '%token%'` and defeat the point of filtering. This means a query like "why does S3 access fail" falls back to matching on `access`/`fail` rather than `S3` specifically. Still strictly better than the current zero-results behavior, but worth flagging as a known limitation rather than a fully-solved case — happy to revisit the threshold or special-case short all-caps tokens if that's a real problem in practice.

### Why not give `recall_context` the same hybrid/vector path `recall` uses?

Considered it, but:
- Vector KNN has no relevance threshold — it returns the nearest-K for *any* query, which would reintroduce the #185 H4 "dumps memories on off-topic prompts" behavior that the preferences-only fallback was specifically added to prevent.
- `hook prompt` fires on every single user prompt. Loading an embedding model on that path is real per-prompt latency that the current FTS-only design avoids on purpose. A keyword-OR fallback is essentially free by comparison.

## Testing

On the current commit, from a clean `main` checkout:

- `cargo build -p icm-cli` — clean
- `cargo test --workspace` — 604 passed, 4 ignored (unrelated: opensearch/postgres backend tests that need external services), 0 failed
- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Added `test_recall_context_natural_language_question_surfaces_memory` and `test_content_tokens_drops_short_words`
- Added `test_recall_context_keyword_fallback_ranks_by_relevance_not_weight_alone` (covers the re-ranking above) and `test_recall_context_natural_language_question_surfaces_cross_project_on_larger_store`, which reproduces the shape of #323's second report — a store with many topics (20 unrelated `context-<project>` memories, an `errors-resolved` memory, a `preferences` memory) where the natural-language query must surface the cross-project `errors-resolved` memory through tier 2. Synthetic data, not the real DB from the issue — I don't have a way to pull that into a test fixture, and didn't want to hand-inspect real personal memory content for this.

Manual repro (same as issue #323's minimal repro):

```
$ icm --db repro.sqlite recall-context "why do workers crash right after a deploy" --limit 2

# before: No relevant context found.
# after:
Here is context from previous analysis of this project. Use it to answer efficiently without re-reading files.

- The deploy script must run migrations before restarting workers, otherwise workers boot against the old schema and crash on startup.

---
```

Off-topic query (`"qwerty xyzzy nonsense"`) against the same DB still correctly returns `No relevant context found.` — the H4 protection is intact.

## Note

Opened as a draft — the issue reporter (me) wants to look over the diff and description before it's marked ready for review.

---

Drafted with the help of Claude (Anthropic) — root-caused and implemented independently in a Claude Code session (before seeing the comment posted on #323), then built/tested/reviewed by me before pushing.
