### PR TITLE
fix(hooks): stop SessionEnd self-sustaining `claude -p` spawn loop (#322)

### DIFF
--- a/crates/icm-cli/src/config.rs
+++ b/crates/icm-cli/src/config.rs
@@ -275,6 +275,11 @@ impl Default for ExtractionConfig {
             // fastembed load). `extract-pending` falls back to a batched
             // fastembed drain when no CLI is found. Shipping `none` here
             // left every default install on the heavy inline path (#239).
+            // The self-sustaining spawn loop this path used to enable (#322)
+            // is now blocked three ways: the summarizer's `claude -p` runs
+            // isolated (`--setting-sources "" --strict-mcp-config`), carries
+            // `ICM_WORKER=1` so any hook it fires no-ops, and the worker
+            // holds a `flock` singleton.
             summarizer: SummarizerConfig {
                 provider: "auto".into(),
                 ..SummarizerConfig::default()

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1497,8 +1497,9 @@ fn main() -> Result<()> {
         }
     }
     let cli_db: Option<PathBuf> = cli.db.into_iter().next();
-    // `db_path` is consumed only by some feature-gated commands (e.g. the
-    // embeddings-only `embed`), so it can be unused in lean builds.
+    // `db_path` feeds the extract-pending worker lock (#322) and some
+    // feature-gated commands (e.g. the embeddings-only `embed`); it can be
+    // unused in the leanest builds.
     #[allow(unused_variables)]
     let db_path = cli_db.clone().unwrap_or_else(default_db_path);
 
@@ -1732,6 +1733,7 @@ fn main() -> Result<()> {
                 provider.as_deref(),
                 model.as_deref(),
                 dry_run,
+                &db_path,
             )
         }
         Commands::Decay { factor } => cmd_decay(&store, factor),
@@ -3357,6 +3359,17 @@ fn cmd_hook_end(
     memory_cfg: &crate::config::MemoryConfig,
     extraction_summarizer: &crate::config::SummarizerConfig,
 ) -> Result<()> {
+    // Reentrancy guard (#322): if this hook is firing inside an
+    // ICM-spawned worker subtree, do nothing. The summarizer's
+    // `claude -p` child sets `ICM_WORKER=1`, which every hook it triggers
+    // inherits. Without this guard, that child's own SessionEnd would fork
+    // another worker → another `claude -p` → an unbounded, self-sustaining
+    // spawn loop (thermal runaway). A worker session has no durable
+    // transcript worth extracting anyway.
+    if std::env::var_os("ICM_WORKER").is_some() {
+        return Ok(());
+    }
+
     // Async path: when a provider is configured, drain the
     // pending_extractions queue in a detached subprocess and return
     // immediately so Claude Code doesn't kill us with "Hook cancelled".
@@ -3369,6 +3382,9 @@ fn cmd_hook_end(
             // config so it picks up the same provider.
             let mut cmd = std::process::Command::new(&self_path);
             cmd.arg("extract-pending").arg("--limit").arg("20");
+            // Mark the worker subtree (#322) so any hook fired by an LLM
+            // CLI it spawns short-circuits instead of forking again.
+            cmd.env("ICM_WORKER", "1");
             cmd.stdin(std::process::Stdio::null())
                 .stdout(std::process::Stdio::null())
                 .stderr(std::process::Stdio::null());
@@ -6213,6 +6229,53 @@ fn cli_on_path(name: &str) -> bool {
     })
 }
 
+/// Best-effort inter-process singleton lock for the extract-pending worker
+/// (#322). Held for the lifetime of the value; the OS releases the advisory
+/// `flock` when the file descriptor closes on drop.
+struct WorkerLock {
+    #[cfg(unix)]
+    _file: std::fs::File,
+}
+
+impl WorkerLock {
+    /// Try to take the lock next to the DB. `Ok(Some(_))` = acquired,
+    /// `Ok(None)` = another process already holds it, `Err` = the lockfile
+    /// itself could not be created (caller may proceed without the guard).
+    fn acquire(db_path: &std::path::Path) -> Result<Option<Self>> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::io::AsRawFd;
+            let lock_path = db_path.with_extension("extract.lock");
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                // We only need a valid fd to flock; never write to or
+                // truncate the lockfile (state lives in the advisory lock).
+                .truncate(false)
+                .open(&lock_path)
+                .with_context(|| format!("opening worker lockfile {}", lock_path.display()))?;
+            // SAFETY: valid fd from the File above; LOCK_NB makes it
+            // non-blocking so a busy lock returns immediately.
+            let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+            if rc == 0 {
+                Ok(Some(Self { _file: file }))
+            } else {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() == Some(libc::EWOULDBLOCK) {
+                    Ok(None)
+                } else {
+                    Err(anyhow::Error::new(err).context("flock on worker lockfile"))
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = db_path;
+            Ok(Some(Self {}))
+        }
+    }
+}
+
 /// Process the async extraction queue.
 ///
 /// Reads up to `limit` oldest pending rows from `pending_extractions`.
@@ -6240,7 +6303,32 @@ fn cmd_extract_pending(
     cli_provider: Option<&str>,
     cli_model: Option<&str>,
     dry_run: bool,
+    db_path: &std::path::Path,
 ) -> Result<()> {
+    // Singleton guard (#322): only one worker drains the queue at a time.
+    // On a default install every ending Claude Code / Codex / editor session
+    // forks a worker; uncapped they pile up (the incident ran 5+ at once,
+    // each booting an LLM CLI) and hammer the same non-WAL SQLite DB, which
+    // makes the concurrent-write corruption in #313 far likelier. A dry-run
+    // only previews, so it takes no lock.
+    let _lock = if dry_run {
+        None
+    } else {
+        match WorkerLock::acquire(db_path) {
+            Ok(Some(l)) => Some(l),
+            Ok(None) => {
+                println!("Another extract-pending worker is already running; skipping.");
+                return Ok(());
+            }
+            Err(e) => {
+                eprintln!(
+                    "[extract-pending] lock unavailable ({e}); proceeding without singleton guard"
+                );
+                None
+            }
+        }
+    };
+
     let pending = store.list_pending_extractions(limit)?;
     if pending.is_empty() {
         println!("No pending extractions.");
@@ -8710,6 +8798,30 @@ mod hook_start_tests {
             project_from_path(dir.path().to_str().unwrap()),
             Some("myproject".into())
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn worker_lock_is_exclusive_and_releases_on_drop() {
+        // #322: a second worker must not run while the first holds the lock,
+        // and the lock must free up once the first finishes.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("memories.db");
+
+        let first = WorkerLock::acquire(&db).unwrap();
+        assert!(first.is_some(), "first acquire should succeed");
+
+        // Held: a concurrent acquire is refused (Ok(None)), not an error.
+        let second = WorkerLock::acquire(&db).unwrap();
+        assert!(
+            second.is_none(),
+            "second acquire must be refused while held"
+        );
+
+        // Release, then the lock is available again.
+        drop(first);
+        let third = WorkerLock::acquire(&db).unwrap();
+        assert!(third.is_some(), "acquire should succeed after release");
     }
 
     #[test]

--- a/crates/icm-cli/src/summarizer.rs
+++ b/crates/icm-cli/src/summarizer.rs
@@ -123,6 +123,13 @@ pub fn make_summarizer(kind: ProviderKind) -> Result<Box<dyn Summarizer>> {
 fn run_cli(binary: &str, args: &[&str], stdin_payload: &str, timeout: Duration) -> Result<String> {
     let mut child = Command::new(binary)
         .args(args)
+        // Reentrancy marker (#322): mark the entire subprocess subtree as an
+        // ICM-spawned worker. If the spawned CLI is itself an agent harness
+        // (e.g. `claude -p` is a full Claude Code session), any ICM hook it
+        // fires inherits this var and no-ops instead of forking yet another
+        // worker — the backstop that breaks the self-sustaining spawn loop
+        // even if the isolation flags below are ever dropped or unsupported.
+        .env("ICM_WORKER", "1")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -168,13 +175,33 @@ fn run_cli(binary: &str, args: &[&str], stdin_payload: &str, timeout: Duration) 
 
 pub struct ClaudeCliSummarizer;
 
+/// Build the `claude` CLI argv for a summarization call.
+///
+/// Isolate the child session (#322). Without these flags a summarization
+/// `claude -p` boots a *full* Claude Code session: it loads the user's
+/// global settings — including ICM's own SessionEnd hook, which forks the
+/// next worker — and every configured MCP server. `--setting-sources ""`
+/// loads no user/project/local settings (so no hooks), and
+/// `--strict-mcp-config` with no `--mcp-config` means no MCP servers. The
+/// child does nothing but answer the summarization prompt.
+fn claude_cli_args(model: &str) -> Vec<&str> {
+    vec![
+        "-p",
+        "--model",
+        model,
+        "--setting-sources",
+        "",
+        "--strict-mcp-config",
+    ]
+}
+
 impl Summarizer for ClaudeCliSummarizer {
     fn name(&self) -> &'static str {
         "claude"
     }
     fn summarize(&self, req: &SummarizeRequest<'_>) -> Result<String> {
         let model = req.model.unwrap_or("claude-haiku-4-5");
-        let args = vec!["-p", "--model", model];
+        let args = claude_cli_args(model);
         run_cli("claude", &args, req.prompt, req.timeout).map(trim_response)
     }
 }
@@ -461,6 +488,24 @@ mod tests {
         }
 
         assert_eq!(result, ProviderKind::Claude);
+    }
+
+    #[test]
+    fn claude_cli_args_isolate_the_child_session() {
+        // #322: the summarization `claude -p` must run with no user/project
+        // settings (no ICM hooks) and no MCP servers, or it self-forks.
+        let args = claude_cli_args("claude-haiku-4-5");
+        assert_eq!(args[0], "-p");
+        assert!(args.contains(&"--model"));
+        assert!(args.contains(&"claude-haiku-4-5"));
+        assert!(args.contains(&"--strict-mcp-config"));
+        // `--setting-sources` must be present and immediately followed by an
+        // empty value (load nothing) — not omitted.
+        let idx = args
+            .iter()
+            .position(|a| *a == "--setting-sources")
+            .expect("--setting-sources must be passed");
+        assert_eq!(args[idx + 1], "", "--setting-sources value must be empty");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #322.

## Problem (verified against `main` @ 65ae008)

With the default config, `extraction.summarizer.provider = "auto"` resolves to the Claude CLI whenever `claude` is on PATH. Every SessionEnd hook forks a detached `icm extract-pending` worker, which spawns a bare `claude -p`. That child is a **full Claude Code session**: it inherits the user's global settings — including the ICM hooks `icm init` installed — and boots every configured MCP server. When the child session ends, its own SessionEnd hook forks the next worker → a self-sustaining spawn chain (reported incident: load avg 46–61, >90% CPU, ~100k processes in ~3h, thermal runaway).

I re-read the code before fixing and confirmed all four root causes cited in the issue:
- `config.rs` — default `provider = "auto"`
- `summarizer.rs` — `detect_provider` picks Claude on `CLAUDECODE`, and the `Auto` fallback is Claude
- `summarizer.rs` — the `claude -p` spawn had **no** `--setting-sources` / `--strict-mcp-config`
- `main.rs` — `cmd_hook_end` forked unconditionally with no reentrancy guard, no lock, no queue check

## Fix — three independent guards

1. **Spawn isolation** (`summarizer.rs`): the summarization `claude -p` now runs `--setting-sources ""` (loads no user/project/local settings → no ICM hooks) and `--strict-mcp-config` (no MCP servers, since we pass no `--mcp-config`). Both flags verified present on `claude` 2.1.206. This alone breaks the loop *and* removes the MCP boot cost per spawn.
2. **Reentrancy guard** (`main.rs` + `summarizer.rs`): every summarizer-spawned CLI carries `ICM_WORKER=1`, and the forked worker sets it too. `cmd_hook_end` no-ops when it sees `ICM_WORKER`. Backstop that kills the loop even if the isolation flags ever change or are unsupported by the installed `claude`.
3. **Singleton `flock`** (`main.rs`): `cmd_extract_pending` takes an exclusive non-blocking `flock` on `<db>.extract.lock` before draining; a second concurrent worker prints a skip message and exits. Caps worker concurrency (the incident ran 5+ at once) and relieves the concurrent-write pressure behind #313.

**Default stays `auto`** — this preserves the ~50 ms hook-latency win from #239, and it is now safe because of the guards above. Flipping to `none` remains a one-line follow-up if maintainers prefer a conservative default.

## Tests / validation

- Unit: `worker_lock_is_exclusive_and_releases_on_drop` (lock refuses a 2nd holder, frees on drop) and `claude_cli_args_isolate_the_child_session` (isolation argv).
- Full suite: `291 passed, 2 ignored`; `cargo clippy --all-targets` clean; `cargo fmt`.
- E2E on the built binary:
  - `ICM_WORKER=1 icm hook end` → **no** worker fork (vs. fork without it).
  - `extract-pending` with the lockfile held by another process → `Another extract-pending worker is already running; skipping.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)