### PR TITLE
fix(store): read-only serve sees live writes, not a stale immutable snapshot (#319)

### DIFF
--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -120,6 +120,14 @@ fn open_readonly_connection(path: &Path) -> IcmResult<Connection> {
             return Ok(conn);
         }
     }
+    // Live open unusable (e.g. a read-only sandbox dir, #263). Fall back to an
+    // immutable snapshot — but warn, because a long-lived reader on this
+    // connection will NOT see subsequent writes (the #319 staleness tradeoff).
+    tracing::warn!(
+        path = %path.display(),
+        "read-only DB opened immutable (sandbox fallback): writes committed after \
+         this point will not be visible until the connection is reopened"
+    );
     open_readonly_uri(path, true)
 }
 
@@ -4156,29 +4164,50 @@ mod tests {
     #[test]
     fn open_readonly_falls_back_to_immutable_on_unwritable_dir() {
         // #263 must keep working after #319: on a `chmod -w` parent directory
-        // the live `mode=ro` open can't create the `-shm` sidecar, so
-        // open_readonly must fall back to `immutable=1` and still read.
+        // the live `mode=ro` open can't create the `-shm` sidecar for a WAL
+        // DB, so open_readonly must fall back to `immutable=1` and still read.
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("sandboxed.db");
         let seeded = seed_writable_db(&path);
-        // Checkpoint + drop WAL so the DB is a single self-contained file the
-        // immutable open can read without touching sidecars.
+        // Keep the DB in WAL mode (that's what forces the -shm requirement)
+        // but fold all rows into the main file and drop the sidecars, so a
+        // fresh read-only open must recreate -shm — which fails in a
+        // read-only dir. (A DELETE-mode DB would open fine via plain mode=ro
+        // and never exercise the fallback.)
         {
             let rw = SqliteStore::new(&path).unwrap();
             rw.conn
-                .execute_batch("PRAGMA wal_checkpoint(TRUNCATE); PRAGMA journal_mode=DELETE;")
+                .execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")
                 .unwrap();
+        }
+        for ext in ["-wal", "-shm"] {
+            let mut side = path.as_os_str().to_os_string();
+            side.push(ext);
+            let _ = std::fs::remove_file(std::path::PathBuf::from(side));
         }
 
         let original = std::fs::metadata(dir.path()).unwrap().permissions();
         std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
 
+        // Guard: confirm the live `mode=ro` path is genuinely unusable here,
+        // otherwise this test would pass without ever exercising the fallback.
+        let live_reads = match open_readonly_uri(&path, false) {
+            Ok(conn) => conn
+                .query_row("SELECT count(*) FROM sqlite_master", [], |_| Ok(()))
+                .is_ok(),
+            Err(_) => false,
+        };
+        // The public open_readonly must still succeed via the immutable fallback.
         let opened = SqliteStore::open_readonly(&path);
 
         // Restore permissions before asserting so tempdir cleanup succeeds.
         std::fs::set_permissions(dir.path(), original).unwrap();
 
+        assert!(
+            !live_reads,
+            "sandbox setup must make the live mode=ro path unusable, else the fallback isn't tested"
+        );
         let ro = opened.expect("read-only open must fall back to immutable on a chmod -w dir");
         let got = ro
             .get(&seeded.id)

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -59,22 +59,10 @@ fn ensure_sqlite_vec() {
     });
 }
 
-/// Open `path` strictly read-only **and** immutable.
-///
-/// `SQLITE_OPEN_READ_ONLY` alone is not enough on a `chmod -w` parent
-/// directory: SQLite still tries to create / refresh the `-shm` and
-/// `-wal` companion files for any WAL-mode database, which fails with
-/// "attempt to write a readonly database". The `immutable=1` URI flag
-/// tells SQLite the file will not change for the lifetime of the
-/// connection and disables that WAL bookkeeping path entirely. This
-/// is the standard recipe for read-only sandboxes and matches what
-/// every SQLite "read-only inspect" tool does.
-///
-/// URI-encodes the path so a backslash on Windows or a `?`/`#` in a
-/// pathological filename can't break the URI parser.
-fn open_readonly_immutable(path: &Path) -> IcmResult<Connection> {
-    let raw = path.to_string_lossy();
-    let encoded: String = raw
+/// URI-encode a filesystem path for a SQLite `file:` URI so a backslash on
+/// Windows or a `?`/`#`/`%` in a pathological filename can't break the parser.
+fn encode_sqlite_uri_path(path: &Path) -> String {
+    path.to_string_lossy()
         .chars()
         .map(|c| match c {
             '?' | '#' | '%' => format!("%{:02X}", c as u32),
@@ -82,8 +70,23 @@ fn open_readonly_immutable(path: &Path) -> IcmResult<Connection> {
             '\\' => "/".into(),
             other => other.to_string(),
         })
-        .collect();
-    let uri = format!("file:{encoded}?mode=ro&immutable=1");
+        .collect()
+}
+
+/// Open `path` strictly read-only. When `immutable` is set, add the
+/// `immutable=1` URI flag — SQLite then assumes the file never changes and
+/// touches no `-shm`/`-wal` sidecars, which is required on a `chmod -w`
+/// parent directory (issue #263) but serves a permanently stale snapshot and
+/// eventually reports spurious `SQLITE_CORRUPT` on a live DB (issue #319).
+/// Plain `mode=ro` (immutable = false) is WAL-aware and sees committed
+/// writes, at the cost of needing a writable directory for the sidecars.
+fn open_readonly_uri(path: &Path, immutable: bool) -> IcmResult<Connection> {
+    let encoded = encode_sqlite_uri_path(path);
+    let uri = if immutable {
+        format!("file:{encoded}?mode=ro&immutable=1")
+    } else {
+        format!("file:{encoded}?mode=ro")
+    };
     Connection::open_with_flags(
         uri,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
@@ -91,6 +94,33 @@ fn open_readonly_immutable(path: &Path) -> IcmResult<Connection> {
             | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )
     .map_err(|e| IcmError::Database(format!("cannot open database read-only: {e}")))
+}
+
+/// Open a long-lived read-only connection (issue #319).
+///
+/// Prefer a normal WAL-aware `mode=ro` connection: it respects locking and
+/// sees writes committed after it opened — the actual deployment model for
+/// `icm --read-only serve`, where hooks keep writing the same DB. Fall back to
+/// `immutable=1` only when the live open can't even read the DB, e.g. a
+/// `chmod -w` sandbox where SQLite can't create the `-shm` sidecar for a
+/// WAL-mode file (issue #263). The read probe is essential: on such a
+/// directory the open may *succeed* yet the first real read fails, so opening
+/// alone is not a sufficient signal.
+fn open_readonly_connection(path: &Path) -> IcmResult<Connection> {
+    if let Ok(conn) = open_readonly_uri(path, false) {
+        // Give a momentarily-locked writer time to release before deciding
+        // the live open is unusable.
+        let _ = conn.execute_batch("PRAGMA busy_timeout=30000;");
+        // Exercise a real table read (touches the WAL/-shm path) — `SELECT 1`
+        // would not.
+        if conn
+            .query_row("SELECT count(*) FROM sqlite_master", [], |_| Ok(()))
+            .is_ok()
+        {
+            return Ok(conn);
+        }
+    }
+    open_readonly_uri(path, true)
 }
 
 /// In-process LRU cache size for hot memories. Each entry is one
@@ -137,7 +167,7 @@ impl SqliteStore {
                 path.display()
             )));
         }
-        let conn = open_readonly_immutable(path)?;
+        let conn = open_readonly_connection(path)?;
         // foreign_keys is a no-op for reads; busy_timeout is still useful
         // when another writer holds the file.
         conn.execute_batch("PRAGMA foreign_keys=ON; PRAGMA busy_timeout=30000;")
@@ -300,8 +330,10 @@ impl SqliteStore {
         // which fails when the parent directory is non-writable.
         // The `immutable=1` URI flag tells SQLite the file will not
         // change during the connection's lifetime and stops it from
-        // touching WAL infrastructure entirely.
-        let conn = open_readonly_immutable(path)?;
+        // touching WAL infrastructure entirely. This is a one-shot probe
+        // (not a long-lived connection), so the staleness that #319 fixes
+        // for `open_readonly` does not apply here.
+        let conn = open_readonly_uri(path, true)?;
         // Probe for the metadata table — legacy DBs predate it.
         let has_table: bool = conn
             .query_row(
@@ -4088,6 +4120,71 @@ mod tests {
         let got = ro.get(&seeded.id).unwrap().expect("memory must be present");
         assert_eq!(got.topic, "project:icm");
         assert_eq!(got.summary, "read-only fixture summary");
+    }
+
+    #[test]
+    fn read_only_connection_sees_writes_committed_after_open() {
+        // #319: a long-lived `--read-only serve` connection must observe
+        // writes that hooks/CLI commit to the same DB *after* the server
+        // opened. The old `immutable=1` open served a permanently stale
+        // snapshot (and eventually spurious "database disk image is malformed"
+        // on a healthy DB).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("live.db");
+        let _ = seed_writable_db(&path); // 1 memory, WAL mode
+
+        let ro = SqliteStore::open_readonly(&path).unwrap();
+        assert_eq!(ro.count().unwrap(), 1);
+
+        // A separate writer commits a new memory to the same file.
+        {
+            let rw = SqliteStore::new(&path).unwrap();
+            let mut m = make_memory("project:icm", "written after the reader opened");
+            m.embedding = Some(vec![0.2_f32; icm_core::DEFAULT_EMBEDDING_DIMS]);
+            rw.store(m).unwrap();
+        }
+
+        // The already-open read-only connection must now see it.
+        assert_eq!(
+            ro.count().unwrap(),
+            2,
+            "read-only connection must see writes committed after it opened"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_readonly_falls_back_to_immutable_on_unwritable_dir() {
+        // #263 must keep working after #319: on a `chmod -w` parent directory
+        // the live `mode=ro` open can't create the `-shm` sidecar, so
+        // open_readonly must fall back to `immutable=1` and still read.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sandboxed.db");
+        let seeded = seed_writable_db(&path);
+        // Checkpoint + drop WAL so the DB is a single self-contained file the
+        // immutable open can read without touching sidecars.
+        {
+            let rw = SqliteStore::new(&path).unwrap();
+            rw.conn
+                .execute_batch("PRAGMA wal_checkpoint(TRUNCATE); PRAGMA journal_mode=DELETE;")
+                .unwrap();
+        }
+
+        let original = std::fs::metadata(dir.path()).unwrap().permissions();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let opened = SqliteStore::open_readonly(&path);
+
+        // Restore permissions before asserting so tempdir cleanup succeeds.
+        std::fs::set_permissions(dir.path(), original).unwrap();
+
+        let ro = opened.expect("read-only open must fall back to immutable on a chmod -w dir");
+        let got = ro
+            .get(&seeded.id)
+            .unwrap()
+            .expect("memory must be readable");
+        assert_eq!(got.topic, "project:icm");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #319.

## Problem (verified against the code)

`SqliteStore::open_readonly` opened with `mode=ro&immutable=1` (`store.rs`, `open_readonly_immutable`). `immutable=1` promises SQLite the file never changes — but the documented model for `icm --read-only serve` is a **long-lived MCP server against a DB that hooks/CLI keep writing**. So the server connection:
1. serves a **permanently stale snapshot** (writes after start are invisible), and
2. once the file grows/restructures, **every** query — reads included — fails with `database disk image is malformed`, on a healthy DB (`PRAGMA integrity_check` says `ok`; fresh connections work). The message sends operators chasing corruption that isn't there.

I confirmed `open_readonly_immutable` is the shared open path and that `immutable=1` was introduced for #263 (survive a `chmod -w` parent dir where SQLite can't create the `-shm`/`-wal` sidecars).

## Fix

`open_readonly` now uses `open_readonly_connection`:
1. Open a normal **WAL-aware `mode=ro`** connection — respects locking, sees committed writes.
2. **Probe** it with `SELECT count(*) FROM sqlite_master` (a real table read touches the WAL/-shm path; `SELECT 1` wouldn't). The probe is essential: on a `chmod -w` dir the open can *succeed* but the first read fails.
3. Only if the live connection can't read, **fall back to `immutable=1`** — preserving the #263 read-only-sandbox capability.

The one-shot `read_stored_embedding_dims` probe stays on `immutable=1` (a single read can't go stale, and it must survive the sandbox).

## Why not just drop immutable entirely

That would re-break #263 (`chmod -w` sandbox). The try-live-then-fallback keeps both: live reads for the normal long-lived server, immutable snapshot only where the directory is unwritable.

## Tests / validation

- New unit tests: a read-only connection **sees a write another connection commits after it opened** (the core fix); a **`chmod -w` sandbox still opens and reads** via the immutable fallback (#263 preserved).
- Store **196** / CLI **291** pass; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt` clean.
- E2E on the binary: `--read-only recall` reads live data; after `chmod -w` on the DB dir, `--read-only recall` still works (fallback engaged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)