### PR TITLE
fix(release): static musl binaries + old-glibc-aware install (#330)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,36 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
 
+  # Validates the fully-static musl binary shipped for old-glibc distros
+  # (issue #330: the glibc binaries need symbols newer than Debian Bookworm's
+  # glibc 2.36). Embeddings are dropped because `ort`/onnxruntime ships only
+  # glibc prebuilt binaries and can't link statically against musl.
+  musl:
+    name: musl static build
+    needs: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+      - uses: Swatinem/rust-cache@v2
+      - name: Install musl tools
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Build static musl binary (no embeddings)
+        run: >-
+          cargo build --release --target x86_64-unknown-linux-musl -p icm-cli
+          --no-default-features --features "backend-sqlite,tui,http-api"
+      - name: Verify the binary is fully static
+        run: |
+          bin=target/x86_64-unknown-linux-musl/release/icm
+          file "$bin"
+          if ldd "$bin" 2>&1 | grep -Eq "statically linked|not a dynamic executable"; then
+            echo "OK: statically linked — runs on any Linux regardless of glibc"
+          else
+            echo "FAIL: binary is dynamically linked"; ldd "$bin"; exit 1
+          fi
+
   security:
     name: security scan
     needs: clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
       - name: Install musl tools
         run: sudo apt-get update && sudo apt-get install -y musl-tools
       - name: Build static musl binary (no embeddings)
+        # sqlite-vec.c uses BSD type names (u_int8_t/u_int16_t/u_int64_t) that
+        # glibc provides but musl does not; map them to the standard names.
+        env:
+          CFLAGS_x86_64_unknown_linux_musl: "-Du_int8_t=uint8_t -Du_int16_t=uint16_t -Du_int32_t=uint32_t -Du_int64_t=uint64_t"
         run: >-
           cargo build --release --target x86_64-unknown-linux-musl -p icm-cli
           --no-default-features --features "backend-sqlite,tui,http-api"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,22 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
             archive: tar.gz
+          # Build the glibc binaries on an older runner (glibc 2.35) so they
+          # run on Debian 12 "Bookworm" (glibc 2.36) and other current distros
+          # — ubuntu-latest's glibc is too new (issue #330).
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             archive: tar.gz
           - target: aarch64-unknown-linux-gnu
+            os: ubuntu-22.04
+            archive: tar.gz
+          # Fully-static musl binary for old-glibc distros (issue #330:
+          # Debian Bookworm's glibc 2.36 is older than ubuntu-latest's).
+          # No embeddings: ort/onnxruntime has no static musl build.
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             archive: tar.gz
+            flags: --no-default-features --features backend-sqlite,tui,http-api
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             archive: zip
@@ -70,6 +80,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
+      - name: Install musl tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
       - name: Build (cross aarch64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: cargo build --release --target ${{ matrix.target }} -p icm-cli --features vendored-openssl
@@ -78,7 +94,7 @@ jobs:
 
       - name: Build
         if: matrix.target != 'aarch64-unknown-linux-gnu'
-        run: cargo build --release --target ${{ matrix.target }} -p icm-cli
+        run: cargo build --release --target ${{ matrix.target }} -p icm-cli ${{ matrix.flags }}
 
       - name: Package (Unix)
         if: matrix.archive == 'tar.gz'
@@ -101,7 +117,8 @@ jobs:
 
   build-deb:
     name: Build .deb
-    runs-on: ubuntu-latest
+    # Older glibc (2.35) so the packaged binary runs on Debian 12 (#330).
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,10 @@ jobs:
 
       - name: Build
         if: matrix.target != 'aarch64-unknown-linux-gnu'
+        # Target-specific, so a no-op for non-musl targets: sqlite-vec.c uses
+        # BSD type names (u_int8_t/…) that glibc provides but musl does not.
+        env:
+          CFLAGS_x86_64_unknown_linux_musl: "-Du_int8_t=uint8_t -Du_int16_t=uint16_t -Du_int32_t=uint32_t -Du_int64_t=uint64_t"
         run: cargo build --release --target ${{ matrix.target }} -p icm-cli ${{ matrix.flags }}
 
       - name: Package (Unix)

--- a/install.sh
+++ b/install.sh
@@ -83,6 +83,35 @@ detect_arch() {
     esac
 }
 
+# Choose the Linux libc flavor (issue #330). The default `unknown-linux-gnu`
+# binaries are built on glibc 2.35 and carry embeddings; systems older than
+# that — or musl distros like Alpine — can't run them, so fall back to the
+# fully-static `unknown-linux-musl` build (keyword search only, no embeddings).
+# musl artifacts are published for x86_64 only.
+select_linux_libc() {
+    if [ "$ARCH" != "x86_64" ]; then
+        TARGET_SUFFIX="unknown-linux-gnu"
+        return
+    fi
+    ldd_out=$(ldd --version 2>&1 | head -1)
+    if printf '%s' "$ldd_out" | grep -qi musl; then
+        TARGET_SUFFIX="unknown-linux-musl"
+        return
+    fi
+    glibc_ver=$(printf '%s' "$ldd_out" | grep -oE '[0-9]+\.[0-9]+' | tail -1)
+    if [ -n "$glibc_ver" ]; then
+        glibc_major=${glibc_ver%%.*}
+        glibc_minor=${glibc_ver#*.}
+        if [ "$glibc_major" -lt 2 ] || { [ "$glibc_major" -eq 2 ] && [ "$glibc_minor" -lt 35 ]; }; then
+            TARGET_SUFFIX="unknown-linux-musl"
+            return
+        fi
+    fi
+    # Modern glibc (>= 2.35, e.g. Debian 12+/Ubuntu 22.04+) or undetectable:
+    # keep the full-featured gnu build.
+    TARGET_SUFFIX="unknown-linux-gnu"
+}
+
 require() {
     command -v "$1" >/dev/null 2>&1 || error "$1 is required but not installed"
 }
@@ -127,6 +156,13 @@ The download was tampered with or corrupted."
 }
 
 install_binary() {
+    # On Linux, pick gnu vs static-musl based on the running libc (#330).
+    if [ "$OS" = "linux" ]; then
+        select_linux_libc
+        if [ "$TARGET_SUFFIX" = "unknown-linux-musl" ]; then
+            info "Old or musl libc detected — installing the fully-static build (keyword search only; no embeddings)."
+        fi
+    fi
     TARGET="${ARCH}-${TARGET_SUFFIX}"
 
     if [ "$OS" = "windows" ]; then


### PR DESCRIPTION
Fixes #330.

## Problem

The pre-built `icm` binaries are built on `ubuntu-latest` (glibc 2.39) and need symbols newer than Debian 12 "Bookworm" (glibc 2.36), so they don't run there at all (`linuxbrew` install → runtime symbol errors). The reporter asked for an older build target or static musl binaries.

## Fix (both, so Bookworm keeps embeddings)

1. **glibc binaries + `.deb` now build on `ubuntu-22.04` (glibc 2.35)** — they run on any glibc ≥ 2.35 (Bookworm 2.36, Ubuntu 22.04+, etc.) and keep the full feature set incl. embeddings.
2. **New fully-static `x86_64-unknown-linux-musl` artifact** for systems the glibc binary still can't serve: glibc < 2.35 and musl distros (Alpine). Embeddings are dropped on this target — `ort`/onnxruntime ships only glibc prebuilt binaries and cannot link statically against musl — so the static binary is keyword-search + store + MCP (`--no-default-features --features backend-sqlite,tui,http-api`).
3. **`install.sh` picks the right one**: it inspects `ldd --version` and selects `unknown-linux-musl` for musl libc or glibc < 2.35, otherwise the full-featured `unknown-linux-gnu`. musl artifacts are x86_64-only (aarch64 old-glibc keeps gnu).

## Why not musl-only

`ort`/onnxruntime has no static musl build, so a musl-only Linux release would drop embeddings (hybrid recall) for everyone. Lowering the glibc floor to 2.35 keeps embeddings for Bookworm+ while musl covers the long tail.

## Validation

- **New CI job `musl static build`** cross-compiles `x86_64-unknown-linux-musl` and asserts the binary is fully static (`ldd` → "not a dynamic executable") — so this path is validated on every PR, not just at release time.
- Locally: the no-embeddings feature set builds; `install.sh` passes `bash -n`; the libc-selection logic returns **gnu** for glibc ≥ 2.35 (incl. Bookworm 2.36) and **musl** for older glibc / Alpine (tested against sample `ldd` outputs).

Note: I can't run a real release build or a Debian Bookworm box from CI here, so the end-to-end "runs on Bookworm" is covered by the glibc-floor reasoning (binary built on 2.35 runs on ≥ 2.35) plus the static-linking CI assertion; a release dry-run is the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)