### PR TITLE
docs: add CLA + PR template with explicit CLA acknowledgment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+<!-- Thanks for contributing to ICM! -->
+
+## What & why
+
+<!-- Briefly describe the change and the motivation (link the issue: Closes #123). -->
+
+## Checklist
+
+- [ ] I have read the [Contributor License Agreement](https://github.com/rtk-ai/icm/blob/main/CLA.md) and I agree to it for this and my future contributions to this project.
+- [ ] This PR targets **`develop`** (contributor PRs must not target `main`).
+- [ ] `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` pass.
+- [ ] Tests cover the change where it makes sense.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,87 @@
+# Contributor License Agreement
+
+Thank you for your interest in contributing to ICM ("the Project"), maintained
+by RTK-AI ("we", "us", or "the Maintainer").
+
+This Contributor License Agreement ("Agreement") documents the rights granted
+by contributors to the Maintainer. By signing this Agreement — by posting the
+signature line requested on your pull request — you accept and agree to the
+following terms for your present and future Contributions submitted to the
+Project. Except for the licenses granted here, you reserve all right, title,
+and interest in and to your Contributions.
+
+## 1. Definitions
+
+- **"You"** (or **"Your"**) means the individual or legal entity making a
+  Contribution. For a legal entity, "You" includes any entity that controls,
+  is controlled by, or is under common control with that entity.
+- **"Contribution"** means any original work of authorship, including any
+  modifications or additions to an existing work, that You intentionally submit
+  to the Project for inclusion in, or documentation of, the Project. "Submitted"
+  means any form of electronic, verbal, or written communication sent to the
+  Maintainer or its representatives, including but not limited to pull requests,
+  issues, and comments, excluding communication conspicuously marked or
+  otherwise designated in writing by You as "Not a Contribution".
+
+## 2. Grant of Copyright License
+
+Subject to the terms of this Agreement, You grant to the Maintainer and to
+recipients of software distributed by the Maintainer a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contributions and such derivative works,
+including the right to relicense Your Contributions under the Project's license
+(currently Apache License 2.0) or any OSI-approved open-source license.
+
+## 3. Grant of Patent License
+
+Subject to the terms of this Agreement, You grant to the Maintainer and to
+recipients of software distributed by the Maintainer a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell, import,
+and otherwise transfer the Project, where such license applies only to those
+patent claims licensable by You that are necessarily infringed by Your
+Contribution alone or by combination of Your Contribution with the Project. If
+any entity institutes patent litigation against You or any other entity
+alleging that Your Contribution, or the Project to which You contributed,
+constitutes direct or contributory patent infringement, then any patent
+licenses granted to that entity under this Agreement for that Contribution or
+Project shall terminate as of the date such litigation is filed.
+
+## 4. Your Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses.
+2. Each of Your Contributions is Your original creation, or You have sufficient
+   rights to submit it under the terms of this Agreement.
+3. If Your employer has rights to intellectual property that You create, You
+   have received permission to make Contributions on behalf of that employer,
+   or Your employer has waived such rights for Your Contributions.
+4. Your Contribution does not, to Your knowledge, violate any third party's
+   copyrights, trademarks, patents, or other intellectual property rights.
+
+## 5. Third-Party Materials
+
+Should You wish to submit work that is not Your original creation, You may
+submit it separately from any Contribution, identifying the complete details of
+its source and of any license or other restriction (including related patents,
+trademarks, and license agreements) of which You are aware, and conspicuously
+marking the work as "Submitted on behalf of a third party: [named here]".
+
+## 6. Support and Warranties
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. Unless required by applicable law or
+agreed to in writing, You provide Your Contributions on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+## 7. Signing
+
+To sign this Agreement, post the following as a comment on your pull request:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your signature (GitHub username, associated pull request, and timestamp) will
+be recorded by the CLA Assistant bot. One signature covers all of Your future
+Contributions to the Project.


### PR DESCRIPTION
The **lightweight, works-now** half of the CLA setup — no bot, no secret required.

- `CLA.md` — individual CLA (copyright + patent grant, right to relicense under the project's Apache-2.0). Template — review with legal before relying on it.
- `.github/pull_request_template.md` — every new PR now shows a checklist whose **first item is an explicit CLA acknowledgment** (plus the `develop`-target and fmt/clippy/test reminders).

This gives explicit, visible per-PR consent immediately. The automated **CLA Assistant bot (#332)** layers signature *enforcement* on top later, once a `PERSONAL_ACCESS_TOKEN` secret is configured — the two are complementary. `#332` has been trimmed to just the workflow so `CLA.md` lands here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)