### PR TITLE
ci: enforce the CLA acknowledgment checkbox (secret-free)

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,0 +1,39 @@
+name: CLA
+
+# Lightweight, secret-free CLA gate: requires the CLA acknowledgment checkbox
+# in the PR description to be ticked. This is the interim enforcement until the
+# full CLA Assistant bot (records real per-contributor signatures) is enabled
+# with its PERSONAL_ACCESS_TOKEN secret — at which point this can be removed.
+#
+# Uses pull_request_target so the check runs from this (trusted) base-branch
+# workflow and a fork can't tamper with it. It only reads the PR body from the
+# event payload — no PR code is checked out — so the elevated context is safe.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  cla-acknowledged:
+    name: CLA acknowledged
+    runs-on: ubuntu-latest
+    # Skip automation that never carries the checkbox: the develop→main
+    # "Next Release" PR (head = develop) and bot PRs (release-please,
+    # dependabot, back-merge).
+    if: >-
+      github.event.pull_request.head.ref != 'develop' &&
+      github.event.pull_request.user.type != 'Bot'
+    steps:
+      - name: Require the CLA checkbox to be ticked
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if printf '%s' "$BODY" | grep -qiE '^[[:space:]]*-[[:space:]]*\[x\].*contributor license agreement'; then
+            echo "CLA acknowledged. ✅"
+          else
+            echo "::error title=CLA not acknowledged::Edit the PR description and tick the '- [ ] I have read the Contributor License Agreement and I agree…' checkbox (see CLA.md)."
+            exit 1
+          fi


### PR DESCRIPTION
Makes the CLA checkbox from #333 **actually block** — with **no PAT secret** (the middle ground between the honor-system checkbox and the full CLA Assistant bot #332).

## What it does
- New status check **`CLA / CLA acknowledged`**: fails until the PR description's CLA checkbox is ticked (`- [x] I have read the Contributor License Agreement…`).
- Re-runs on `edited`, so ticking the box flips it green — no new push needed.
- **No secret**: reads only `github.event.pull_request.body` from the event payload (no PR code checkout), so `pull_request_target` (used so a fork can't tamper) is safe.
- **Skips automation**: the develop→main "Next Release" PR (head = `develop`) and bot PRs (release-please, dependabot, back-merge) are exempt.

## To make it truly blocking
Mark **`CLA acknowledged`** as a **required status check** in branch protection for `develop` (and `main`). Otherwise it shows a red ❌ but doesn't hard-block.

## Relationship to the other CLA PRs
- #333 (merged): `CLA.md` + PR template with the checkbox — the notice.
- **This PR**: enforces the checkbox, secret-free — the interim gate.
- #332 (open): full CLA Assistant bot with recorded signatures — needs `PERSONAL_ACCESS_TOKEN`. Once enabled, this checkbox gate can be removed.

## Checklist
- [x] I have read the [Contributor License Agreement](https://github.com/rtk-ai/icm/blob/main/CLA.md) and I agree to it for this and my future contributions to this project.
- [x] This PR targets `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)