### PR TITLE
docs: drop the CLA section from CONTRIBUTING for now

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,17 +135,6 @@ Every change **must** include tests where it has a runtime surface. See [Testing
 
 Update docs for new features and changes to already-documented behavior.
 
-### Contributor License Agreement (CLA)
-
-All contributions require signing our **Contributor License Agreement (CLA)** before being merged.
-
-By signing, you certify that:
-- You have authored 100% of the contribution, or have the necessary rights to submit it.
-- You grant **rtk-ai** and **rtk-ai Labs** a perpetual, worldwide, royalty-free license to use your contribution — including in commercial products such as **rtk Pro** — under the [Apache License 2.0](LICENSE).
-- If your employer has rights over your work, you have obtained their permission.
-
-**This is automatic.** When you open a Pull Request, [CLA Assistant](https://cla-assistant.io) will post a comment asking you to sign. Click the link in that comment to sign with your GitHub account. You only need to sign once.
-
 ### 5. Target `develop`
 
 Open your Pull Request against the **`develop`** branch. `main` is reserved for stable releases — only maintainer `develop` → `main` PRs (cut via release-please) target it.


### PR DESCRIPTION
Removes the CLA requirement + CLA Assistant reference from `CONTRIBUTING.md` for the time being (per maintainer decision).

Contributions remain licensed under the project's **Apache-2.0** by default (inbound=outbound via GitHub ToS + Apache §5). A CLA can be reintroduced later if needed. `CONTRIBUTING.md` (minus the CLA section), `DISCLAIMER.md`, and `SECURITY.md` otherwise stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)