### PR TITLE
feat(consolidate): add `icm consolidate-all` for batch/cron rollups (#179)

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -328,6 +328,33 @@ enum Commands {
         summarizer_max_tokens: Option<usize>,
     },
 
+    /// Consolidate every topic whose memory count exceeds a threshold
+    /// (issue #179). Idempotent — a consolidated topic drops to one memory
+    /// (below the threshold) and is skipped on the next run. Designed for
+    /// cron / systemd timers / launchd, not interactive use.
+    ConsolidateAll {
+        /// Consolidate topics with more than this many memories.
+        #[arg(long, default_value = "10", value_name = "N")]
+        threshold: usize,
+
+        /// Summarizer provider: auto | claude | codex | gemini | ollama | none
+        /// (overrides `[consolidate.summarizer] provider`).
+        #[arg(long, value_name = "PROVIDER")]
+        summarizer_provider: Option<String>,
+
+        /// Summarizer model (provider-specific). Empty = provider's cheap default.
+        #[arg(long, value_name = "MODEL")]
+        summarizer_model: Option<String>,
+
+        /// Approximate token budget for each consolidated summary.
+        #[arg(long, value_name = "N")]
+        summarizer_max_tokens: Option<usize>,
+
+        /// List the topics that would be consolidated without changing anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
+
     /// Generate embeddings for memories that don't have one yet
     Embed {
         /// Only embed memories in this topic
@@ -1792,6 +1819,21 @@ fn main() -> Result<()> {
             summarizer_provider.as_deref(),
             summarizer_model.as_deref(),
             summarizer_max_tokens,
+        ),
+        Commands::ConsolidateAll {
+            threshold,
+            summarizer_provider,
+            summarizer_model,
+            summarizer_max_tokens,
+            dry_run,
+        } => cmd_consolidate_all(
+            &store,
+            threshold,
+            &cfg.consolidate.summarizer,
+            summarizer_provider.as_deref(),
+            summarizer_model.as_deref(),
+            summarizer_max_tokens,
+            dry_run,
         ),
         Commands::Embed {
             topic,
@@ -7046,6 +7088,75 @@ fn cmd_consolidate(
     Ok(())
 }
 
+/// `icm consolidate-all` — batch-consolidate every topic over `threshold`
+/// (issue #179). Reuses [`cmd_consolidate`] per topic; naturally idempotent
+/// because a consolidated topic collapses to one memory (below the threshold)
+/// and is skipped next time. Never keeps originals — that would defeat the
+/// idempotency the cron use case relies on.
+#[allow(clippy::too_many_arguments)]
+fn cmd_consolidate_all(
+    store: &Store,
+    threshold: usize,
+    cfg: &config::SummarizerConfig,
+    cli_provider: Option<&str>,
+    cli_model: Option<&str>,
+    cli_max_tokens: Option<usize>,
+    dry_run: bool,
+) -> Result<()> {
+    // Snapshot topics up front so consolidating one doesn't perturb iteration.
+    let mut candidates: Vec<(String, usize)> = store
+        .list_topics_with_prefix(None)?
+        .into_iter()
+        .filter(|(_, count)| *count > threshold)
+        .collect();
+    candidates.sort_by_key(|c| std::cmp::Reverse(c.1)); // biggest topics first
+
+    if candidates.is_empty() {
+        println!("No topic has more than {threshold} memories — nothing to consolidate.");
+        return Ok(());
+    }
+
+    if dry_run {
+        println!(
+            "(dry run) Would consolidate {} topic(s) over threshold {threshold}:",
+            candidates.len()
+        );
+        for (topic, count) in &candidates {
+            println!("  - {topic} ({count} memories)");
+        }
+        return Ok(());
+    }
+
+    let mut done = 0usize;
+    let mut failed = 0usize;
+    for (topic, count) in &candidates {
+        println!("[consolidate-all] {topic} ({count} memories)…");
+        match cmd_consolidate(
+            store,
+            topic,
+            false,
+            cfg,
+            cli_provider,
+            cli_model,
+            cli_max_tokens,
+        ) {
+            Ok(()) => done += 1,
+            Err(e) => {
+                eprintln!("[consolidate-all] {topic} failed: {e}");
+                failed += 1;
+            }
+        }
+    }
+
+    println!();
+    if failed == 0 {
+        println!("Consolidated {done} topic(s) over threshold {threshold}.");
+    } else {
+        println!("Consolidated {done} topic(s); {failed} failed (see errors above).");
+    }
+    Ok(())
+}
+
 fn cmd_extract(
     store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
@@ -9168,6 +9279,63 @@ mod hook_start_tests {
             ))
             .unwrap();
         store
+    }
+
+    #[test]
+    fn consolidate_all_over_threshold_and_idempotent() {
+        // #179: batch-consolidate topics over the threshold; a consolidated
+        // topic drops below it, so re-running is a no-op.
+        use icm_core::{Importance, Memory};
+        let store = icm_store::Store::in_memory().unwrap();
+        let seed = |topic: &str, n: usize| {
+            for i in 0..n {
+                store
+                    .store(Memory::new(
+                        topic.into(),
+                        format!("{topic} memory number {i}"),
+                        Importance::Medium,
+                    ))
+                    .unwrap();
+            }
+        };
+        seed("alpha", 5);
+        seed("beta", 2); // under threshold
+        seed("gamma", 4);
+
+        let cfg = config::SummarizerConfig::default();
+        // provider "none" → deterministic lexical consolidation, no LLM spawn.
+        cmd_consolidate_all(&store, 3, &cfg, Some("none"), None, None, false).unwrap();
+
+        assert_eq!(store.count_by_topic("alpha").unwrap(), 1);
+        assert_eq!(store.count_by_topic("gamma").unwrap(), 1);
+        assert_eq!(
+            store.count_by_topic("beta").unwrap(),
+            2,
+            "under-threshold topic untouched"
+        );
+
+        // Idempotent: nothing left over the threshold.
+        cmd_consolidate_all(&store, 3, &cfg, Some("none"), None, None, false).unwrap();
+        assert_eq!(store.count_by_topic("alpha").unwrap(), 1);
+        assert_eq!(store.count_by_topic("beta").unwrap(), 2);
+    }
+
+    #[test]
+    fn consolidate_all_dry_run_changes_nothing() {
+        use icm_core::{Importance, Memory};
+        let store = icm_store::Store::in_memory().unwrap();
+        for i in 0..5 {
+            store
+                .store(Memory::new("t".into(), format!("m{i}"), Importance::Medium))
+                .unwrap();
+        }
+        let cfg = config::SummarizerConfig::default();
+        cmd_consolidate_all(&store, 3, &cfg, Some("none"), None, None, true).unwrap();
+        assert_eq!(
+            store.count_by_topic("t").unwrap(),
+            5,
+            "dry-run must not consolidate"
+        );
     }
 
     #[test]

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -7093,7 +7093,6 @@ fn cmd_consolidate(
 /// because a consolidated topic collapses to one memory (below the threshold)
 /// and is skipped next time. Never keeps originals — that would defeat the
 /// idempotency the cron use case relies on.
-#[allow(clippy::too_many_arguments)]
 fn cmd_consolidate_all(
     store: &Store,
     threshold: usize,
@@ -7103,6 +7102,31 @@ fn cmd_consolidate_all(
     cli_max_tokens: Option<usize>,
     dry_run: bool,
 ) -> Result<()> {
+    // `threshold = 0` would leave a just-consolidated single-memory topic still
+    // "over" the threshold (1 > 0), so every run re-consolidates everything —
+    // infinite churn on a cron timer. Require >= 1.
+    if threshold == 0 {
+        bail!("--threshold must be >= 1 (0 would re-consolidate every topic on every run)");
+    }
+
+    // Safety guard (see #186): a batch run with the summarizer resolving to
+    // `none` would replace EVERY over-threshold topic with a lexical ' | '
+    // join and delete the originals — a store-wide quality loss from a bare
+    // cron `consolidate-all`. Refuse unless the user explicitly opted into
+    // lexical with `--summarizer-provider none`.
+    let resolved = resolve_consolidate_provider(cfg, cli_provider)?;
+    let explicit_none = cli_provider
+        .map(|p| p.trim().eq_ignore_ascii_case("none"))
+        .unwrap_or(false);
+    if matches!(resolved, summarizer::ProviderKind::None) && !explicit_none {
+        bail!(
+            "consolidate-all would replace every over-threshold topic with a lexical \
+             ' | ' join and delete the originals (summarizer provider resolves to 'none'). \
+             Pass --summarizer-provider <claude|codex|gemini|ollama> for real consolidation, \
+             or --summarizer-provider none to explicitly accept lexical joins."
+        );
+    }
+
     // Snapshot topics up front so consolidating one doesn't perturb iteration.
     let mut candidates: Vec<(String, usize)> = store
         .list_topics_with_prefix(None)?
@@ -9336,6 +9360,28 @@ mod hook_start_tests {
             5,
             "dry-run must not consolidate"
         );
+    }
+
+    #[test]
+    fn consolidate_all_guards_lexical_and_zero_threshold() {
+        use icm_core::{Importance, Memory};
+        let store = icm_store::Store::in_memory().unwrap();
+        for i in 0..5 {
+            store
+                .store(Memory::new("t".into(), format!("m{i}"), Importance::Medium))
+                .unwrap();
+        }
+        let cfg = config::SummarizerConfig::default(); // provider defaults to "none"
+                                                       // Bare run (no explicit provider) resolves to none → refuse (a batch
+                                                       // lexical join + delete of originals across the whole store).
+        assert!(cmd_consolidate_all(&store, 3, &cfg, None, None, None, false).is_err());
+        // threshold 0 → refuse.
+        assert!(cmd_consolidate_all(&store, 0, &cfg, Some("none"), None, None, false).is_err());
+        // Neither refused call touched the data.
+        assert_eq!(store.count_by_topic("t").unwrap(), 5);
+        // Explicit `none` is an accepted opt-in and does consolidate.
+        assert!(cmd_consolidate_all(&store, 3, &cfg, Some("none"), None, None, false).is_ok());
+        assert_eq!(store.count_by_topic("t").unwrap(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Implements the **cron-style rollup** half of #179 (the standalone command; not the in-process worker daemon).

## What
`icm consolidate-all --threshold N [--summarizer-provider …] [--summarizer-model …] [--dry-run]` — consolidates every topic whose memory count exceeds the threshold, in one batch. Lets users get LLM-consolidation quality without paying the ~13s-per-call latency inside interactive sessions.

## Why it's safe to cron
**Idempotent by construction**: consolidating a topic collapses it to a single memory (below the threshold), so the next run skips it. It never keeps originals — that's what makes re-running a no-op. Drive it from a systemd timer / cron / launchd.

## Implementation
- Reuses the existing per-topic `cmd_consolidate` (same provider resolution, model, and lexical fallback) — no duplicated consolidation logic.
- Iterates a **snapshot** of `list_topics_with_prefix(None)` (biggest topics first) so consolidating one doesn't perturb iteration.
- Per-topic failures are logged and don't abort the batch (`Consolidated N topic(s); M failed`).
- `--dry-run` lists what would be consolidated, changes nothing.

## Tests / validation
- Unit: consolidates only over-threshold topics, leaves under-threshold ones untouched, **second run is a no-op** (idempotent); `--dry-run` changes nothing.
- E2E on the binary (lexical provider): seeded alpha=5/beta=2/gamma=4, `--threshold 3` → dry-run lists alpha+gamma, real run collapses both to 1, beta untouched, second run reports "nothing to consolidate".
- `cargo clippy --all-targets -- -D warnings` clean; 298 cli tests pass.

Follow-up (not in scope): the in-process background queue + worker thread + `icm consolidate-jobs` status (mechanism #1 of #179) can come later; this delivers the cron path now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)