### PR TITLE
fix(store): make `icm doctor` and `repair --dry-run` truly read-only (#313)

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -5690,7 +5690,10 @@ fn report_db_integrity(db_path: &std::path::Path) {
         );
         return;
     }
-    let store = match Store::open_maintenance(db_path) {
+    // Open READ-ONLY and run only the structural (PRAGMA) check: `doctor` is a
+    // diagnostic and must not write / checkpoint the DB it inspects. The deeper
+    // FTS content check runs during the actual `icm repair`.
+    let store = match Store::open_readonly(db_path) {
         Ok(s) => s,
         Err(e) => {
             println!(
@@ -5700,7 +5703,7 @@ fn report_db_integrity(db_path: &std::path::Path) {
             return;
         }
     };
-    match store.integrity_check() {
+    match store.integrity_check_structural() {
         Ok(rows) if rows.len() == 1 && rows[0] == "ok" => {
             println!("Database integrity: ok ({}).", db_path.display());
         }
@@ -5770,6 +5773,44 @@ fn cmd_repair(db_path: &std::path::Path, dry_run: bool) -> Result<()> {
         return Ok(());
     }
 
+    if dry_run {
+        // A dry run must NOT modify the DB — open READ-ONLY and run only the
+        // structural (PRAGMA) check (no writable open, no WAL checkpoint). The
+        // deeper FTS content check runs in the actual repair below.
+        let store = match Store::open_readonly(db_path) {
+            Ok(s) => s,
+            Err(e) => {
+                println!("Could not open {} for inspection: {e}", db_path.display());
+                return Ok(());
+            }
+        };
+        let problems = store.integrity_check_structural()?;
+        if problems.len() == 1 && problems[0] == "ok" {
+            println!(
+                "integrity_check (structural): ok — {} looks healthy.",
+                db_path.display()
+            );
+            println!("(dry run is read-only; run `icm repair` for the deeper FTS content check.)");
+            return Ok(());
+        }
+        println!(
+            "integrity_check reported {} structural problem(s) on {}:",
+            problems.len(),
+            db_path.display()
+        );
+        for line in problems.iter().take(8) {
+            println!("  - {line}");
+        }
+        if problems.len() > 8 {
+            println!("  … and {} more", problems.len() - 8);
+        }
+        println!(
+            "\n(dry run) Would back up the DB, rebuild FTS shadow tables + REINDEX, \
+             then re-check (the real run also runs a deeper FTS content check)."
+        );
+        return Ok(());
+    }
+
     let store = match Store::open_maintenance(db_path) {
         Ok(s) => s,
         Err(e) => {
@@ -5809,13 +5850,6 @@ fn cmd_repair(db_path: &std::path::Path, dry_run: bool) -> Result<()> {
     }
     if before.len() > 8 {
         println!("  … and {} more", before.len() - 8);
-    }
-
-    if dry_run {
-        println!(
-            "\n(dry run) Would back up the DB, rebuild FTS shadow tables + REINDEX, then re-check."
-        );
-        return Ok(());
     }
 
     // Always back up before mutating a damaged DB.

--- a/crates/icm-store/src/backend.rs
+++ b/crates/icm-store/src/backend.rs
@@ -224,6 +224,19 @@ impl Store {
         }
     }
 
+    /// Structural-only integrity check, safe on a read-only connection
+    /// (issue #313 follow-up). Does not run the write-requiring FTS5 check.
+    pub fn integrity_check_structural(&self) -> IcmResult<Vec<String>> {
+        match self {
+            #[cfg(feature = "backend-sqlite")]
+            Store::Sqlite(s) => s.integrity_check_structural(),
+            #[allow(unreachable_patterns)]
+            _ => Err(IcmError::Config(
+                "integrity_check is only supported on the SQLite backend".into(),
+            )),
+        }
+    }
+
     /// Rebuild FTS shadow tables and `REINDEX` on the SQLite backend
     /// (issue #313). Returns the FTS tables rebuilt. Other backends return a
     /// config error.

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -265,6 +265,25 @@ impl SqliteStore {
         }
     }
 
+    /// Structural-only integrity check (`PRAGMA integrity_check`), safe on a
+    /// read-only connection (issue #313 follow-up). Unlike
+    /// [`Self::integrity_check`] it does NOT run the FTS5 `'integrity-check'`
+    /// (which is an `INSERT` and needs a writable connection), so it never
+    /// mutates the DB or triggers a WAL checkpoint. Used by the read-only
+    /// inspection paths (`icm doctor`, `icm repair --dry-run`). A healthy DB
+    /// yields `["ok"]`. Never returns `Err`.
+    pub fn integrity_check_structural(&self) -> IcmResult<Vec<String>> {
+        let problems: Vec<String> = match self.run_integrity_pragma() {
+            Ok(lines) => lines.into_iter().filter(|l| l != "ok").collect(),
+            Err(e) => vec![format!("integrity_check pragma failed: {e}")],
+        };
+        if problems.is_empty() {
+            Ok(vec!["ok".to_string()])
+        } else {
+            Ok(problems)
+        }
+    }
+
     /// Run `PRAGMA integrity_check` and collect its result rows.
     fn run_integrity_pragma(&self) -> IcmResult<Vec<String>> {
         let mut stmt = self
@@ -4013,6 +4032,28 @@ mod tests {
         let store = test_store();
         store.store(make_memory("t", "healthy row")).unwrap();
         assert_eq!(store.integrity_check().unwrap(), vec!["ok".to_string()]);
+    }
+
+    #[test]
+    fn integrity_check_structural_works_on_a_read_only_connection() {
+        // #313 follow-up: `icm doctor` / `repair --dry-run` must inspect a DB
+        // without a writable open. The structural check runs `PRAGMA
+        // integrity_check` only (no FTS INSERT), so it works read-only.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro.db");
+        let _ = seed_writable_db(&path);
+
+        let ro = SqliteStore::open_readonly(&path).unwrap();
+        assert!(ro.is_readonly());
+        // Read-only structural check succeeds and reports healthy.
+        assert_eq!(
+            ro.integrity_check_structural().unwrap(),
+            vec!["ok".to_string()]
+        );
+        // The full check issues an FTS `INSERT` a read-only connection can't
+        // run, so it degrades to reporting that as a problem — which is exactly
+        // why the read-only inspection paths use the structural variant.
+        assert_ne!(ro.integrity_check().unwrap(), vec!["ok".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
Security-review follow-up (from the release audit of #326).

## Problem
The DB-inspection paths opened the store **writable** (`open_maintenance`) — because the FTS5 `'integrity-check'` is an `INSERT` — so on a WAL database `icm doctor` and `icm repair --dry-run` could trigger a **checkpoint** (a write to the main file). That violates `--dry-run`'s documented "**without modifying the DB**" contract, and happens on a possibly-corrupt file before any backup exists.

## Fix
- New `Store::integrity_check_structural()` — `PRAGMA integrity_check` only (no FTS `INSERT`), so it's safe on a **read-only** connection and never writes or checkpoints.
- `icm doctor` and `icm repair --dry-run` now **open read-only** and run the structural check.
- Only the actual `icm repair` opens writable (`open_maintenance`) and runs the **full** check (structural + FTS content) + backup + rebuild — unchanged.
- The dry-run/doctor output notes that the deeper FTS content check runs during the real `icm repair` (so a "structural: ok" verdict isn't mistaken for a full clean bill).

## Validation
- **E2E**: after `repair --dry-run` and `doctor`, the DB file's **mtime and size are unchanged** (no write/checkpoint). The real `icm repair` still detects an FTS desync and rebuilds (with backup incl. sidecars).
- **Unit**: `integrity_check_structural` succeeds on a read-only connection; the full check degrades on read-only (why the structural variant exists).
- `cargo clippy --all-targets -- -D warnings` clean; store + cli suites pass.

This was the one actionable item from the release security review; the rest of the release was clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)