### PR TITLE
feat(embeddings): load-dynamic ort variant for homebrew-core (#345)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,38 @@ jobs:
             echo "FAIL: binary is dynamically linked"; ldd "$bin"; exit 1
           fi
 
+  # Validates the load-dynamic embeddings variant (issue #345): it must build
+  # WITHOUT onnxruntime (so homebrew-core's network-less sandbox can build it
+  # with embeddings), and at runtime degrade to keyword-only search — never
+  # crash — when the onnxruntime lib is absent. The release profile is
+  # `panic = "abort"`, so this exercises the dlopen pre-flight, not catch_unwind.
+  embeddings-dynamic:
+    name: load-dynamic embeddings
+    needs: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build load-dynamic variant (no build-time onnxruntime)
+        run: >-
+          cargo build -p icm-cli --no-default-features
+          --features "embeddings-dynamic,backend-sqlite,tui,http-api"
+      - name: Unit-test the dylib pre-flight
+        run: cargo test -p icm-core --features embeddings-dynamic
+      - name: Graceful degradation when onnxruntime is absent
+        # Force the missing-runtime path deterministically. The store must still
+        # succeed (keyword-only) and the process must exit 0, not abort.
+        env:
+          ORT_DYLIB_PATH: /nonexistent/libonnxruntime.so
+        run: |
+          bin=target/debug/icm
+          db="$RUNNER_TEMP/dyn.db"
+          "$bin" --db "$db" store -t t -c "ci dynamic graceful delta"
+          "$bin" --no-embeddings --db "$db" recall delta | grep -qi delta \
+            && echo "OK: degraded to keyword-only without crashing" \
+            || { echo "FAIL: memory not stored / recall failed"; exit 1; }
+
   security:
     name: security scan
     needs: clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,6 +1488,7 @@ dependencies = [
  "chrono",
  "directories",
  "fastembed",
+ "libc",
  "serde",
  "serde_json",
  "thiserror",
@@ -1841,6 +1842,16 @@ checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
 dependencies = [
  "arbitrary",
  "cc",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
 ]
 
 [[package]]
@@ -2324,6 +2335,7 @@ version = "2.0.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52afb44b6b0cffa9bf45e4d37e5a4935b0334a51570658e279e9e3e6cf324aa5"
 dependencies = [
+ "libloading",
  "ndarray",
  "ort-sys",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,10 @@ sqlite-vec = "0.1"
 zerocopy = { version = "0.8", features = ["derive"] }
 
 # Embeddings (optional)
-fastembed = "4"
+# default-features off so each member selects its own ort backend
+# (ort-download-binaries for the static default build, ort-load-dynamic for the
+# homebrew-core-buildable variant — issue #345). hf-hub is re-added per-feature.
+fastembed = { version = "4", default-features = false }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/crates/icm-cli/Cargo.toml
+++ b/crates/icm-cli/Cargo.toml
@@ -17,8 +17,17 @@ path = "src/main.rs"
 # `ICM_DB_BACKEND` (issue #301). Backends are additive; for a lean build
 # (e.g. SQLite-only) use `--no-default-features --features
 # "embeddings,tui,http-api,backend-sqlite"`.
-default = ["embeddings", "tui", "http-api", "backend-sqlite", "postgres", "opensearch"]
+default = ["embeddings-static", "tui", "http-api", "backend-sqlite", "postgres", "opensearch"]
+# Code-level embeddings (no ort backend); pick a variant below. Kept as a
+# feature so all `#[cfg(feature = "embeddings")]` code stays unchanged.
 embeddings = ["icm-core/embeddings", "icm-mcp/embeddings"]
+# Default: static onnxruntime (unchanged behavior). The published binaries and
+# install.sh/tap use this.
+embeddings-static = ["embeddings", "icm-core/embeddings-static"]
+# load-dynamic variant (issue #345): compiles with no build-time onnxruntime,
+# so `brew install` (homebrew-core) can build it with embeddings. Used as
+# `--no-default-features --features "embeddings-dynamic,backend-sqlite,tui,http-api"`.
+embeddings-dynamic = ["embeddings", "icm-core/embeddings-dynamic"]
 tui = ["dep:ratatui", "dep:crossterm"]
 # Storage backends (additive). SQLite is in-process; postgres / opensearch
 # are network-accessible so several `icm` processes / Kubernetes replicas

--- a/crates/icm-core/Cargo.toml
+++ b/crates/icm-core/Cargo.toml
@@ -5,7 +5,16 @@ edition = "2021"
 
 [features]
 default = []
-embeddings = ["fastembed", "directories", "cachedir"]
+# `embeddings` = the embedder code + model download (hf-hub). It does NOT pick
+# an ort backend by itself; a consumer selects exactly one of the two below
+# (issue #345). This keeps every `#[cfg(feature = "embeddings")]` unchanged.
+embeddings = ["fastembed", "directories", "cachedir", "fastembed/hf-hub-native-tls"]
+# Static onnxruntime downloaded at build time (default; needs network at build).
+embeddings-static = ["embeddings", "fastembed/ort-download-binaries"]
+# onnxruntime loaded dynamically at runtime — builds with NO network, so the
+# binary is homebrew-core-buildable with embeddings (the runtime lib is resolved
+# at first use). See issue #345.
+embeddings-dynamic = ["embeddings", "fastembed/ort-load-dynamic"]
 
 [dependencies]
 chrono = { workspace = true }
@@ -18,3 +27,8 @@ fastembed = { workspace = true, optional = true }
 directories = { workspace = true, optional = true }
 cachedir = { workspace = true, optional = true }
 tracing = { workspace = true }
+
+# Unix-only: used by the load-dynamic embeddings build to pre-flight the
+# onnxruntime dylib (dlopen) before ort initializes. See issue #345.
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }

--- a/crates/icm-core/src/fastembed_embedder.rs
+++ b/crates/icm-core/src/fastembed_embedder.rs
@@ -25,6 +25,38 @@ fn cache_dir() -> PathBuf {
         })
 }
 
+/// Best-effort check that the onnxruntime shared library is loadable, mirroring
+/// how `ort`'s load-dynamic backend resolves it: `ORT_DYLIB_PATH` if set, else
+/// the platform default name. Used only by the load-dynamic build (issue #345)
+/// to avoid ort's panic-on-missing-runtime under `panic = "abort"`.
+#[cfg(all(unix, feature = "embeddings-dynamic"))]
+fn onnxruntime_dylib_available() -> bool {
+    use std::ffi::CString;
+    let default_name = if cfg!(target_os = "macos") {
+        "libonnxruntime.dylib"
+    } else {
+        "libonnxruntime.so"
+    };
+    let name = match std::env::var("ORT_DYLIB_PATH") {
+        Ok(p) if !p.is_empty() => p,
+        _ => default_name.to_string(),
+    };
+    let Ok(cname) = CString::new(name) else {
+        return false;
+    };
+    // SAFETY: `cname` is a valid NUL-terminated C string for the duration of the
+    // call; the returned handle is only tested for null and immediately closed.
+    unsafe {
+        let handle = libc::dlopen(cname.as_ptr(), libc::RTLD_LAZY);
+        if handle.is_null() {
+            false
+        } else {
+            libc::dlclose(handle);
+            true
+        }
+    }
+}
+
 pub struct FastEmbedder {
     model: OnceLock<TextEmbedding>,
     init_lock: Mutex<()>,
@@ -112,6 +144,22 @@ impl FastEmbedder {
         std::fs::create_dir_all(&cache)
             .and_then(|()| cachedir::ensure_tag(&cache))
             .unwrap_or_else(|e| tracing::warn!("could not tag cache dir: {e}"));
+        // With the load-dynamic ort backend (issue #345) onnxruntime is resolved
+        // at runtime. If it's absent, ort *panics* inside init — and since the
+        // release profile is `panic = "abort"`, that would kill the process
+        // rather than unwind (so catch_unwind can't help). Pre-flight the dylib
+        // instead: if it can't be dlopen'd, return a clean error (→ keyword-only
+        // search) before ort ever initializes. Static builds link onnxruntime
+        // in, so this check is compiled out there.
+        #[cfg(all(unix, feature = "embeddings-dynamic"))]
+        if !onnxruntime_dylib_available() {
+            return Err(IcmError::Embedding(
+                "onnxruntime runtime not found for this load-dynamic build; \
+                 install onnxruntime (or set ORT_DYLIB_PATH), or run with \
+                 --no-embeddings for keyword-only search"
+                    .to_string(),
+            ));
+        }
         let model = TextEmbedding::try_new(
             InitOptions::new(emb_model)
                 .with_show_download_progress(true)
@@ -235,6 +283,28 @@ mod tests {
                 ("", ""),
                 "expected no instruction prefix for {model}"
             );
+        }
+    }
+
+    // The load-dynamic pre-flight (issue #345) must report a bogus dylib path as
+    // unavailable — this is what lets a load-dynamic build return a clean error
+    // (→ keyword-only) instead of ort aborting under `panic = "abort"`. Run with
+    // `cargo test -p icm-core --features embeddings-dynamic`.
+    #[cfg(all(unix, feature = "embeddings-dynamic"))]
+    #[test]
+    fn missing_onnxruntime_dylib_is_reported_unavailable() {
+        let prev = std::env::var("ORT_DYLIB_PATH").ok();
+        std::env::set_var(
+            "ORT_DYLIB_PATH",
+            "/nonexistent/icm-test/libonnxruntime-does-not-exist.so",
+        );
+        assert!(
+            !onnxruntime_dylib_available(),
+            "a non-existent ORT_DYLIB_PATH must be detected as unavailable"
+        );
+        match prev {
+            Some(v) => std::env::set_var("ORT_DYLIB_PATH", v),
+            None => std::env::remove_var("ORT_DYLIB_PATH"),
         }
     }
 }

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -1,3 +1,17 @@
+// The `embeddings` feature carries only the embedder code + model download; an
+// onnxruntime backend must be selected explicitly (issue #345). Enabling bare
+// `embeddings` would build `fastembed` with no ort backend — a confusing link
+// error or a runtime with no way to load onnxruntime — so fail loudly here.
+#[cfg(all(
+    feature = "embeddings",
+    not(any(feature = "embeddings-static", feature = "embeddings-dynamic"))
+))]
+compile_error!(
+    "the `embeddings` feature needs an onnxruntime backend: enable \
+     `embeddings-static` (build-time download) or `embeddings-dynamic` \
+     (runtime load-dynamic), not bare `embeddings`. See issue #345."
+);
+
 pub mod auto_link;
 pub mod context_snapshot;
 pub mod embedder;

--- a/crates/icm-mcp/Cargo.toml
+++ b/crates/icm-mcp/Cargo.toml
@@ -5,7 +5,12 @@ edition = "2021"
 
 [features]
 default = ["backend-sqlite"]
+# Code-level embeddings; a backend variant must be selected (issue #345). The
+# binary crate (icm-cli) selects one, which unifies onto icm-core; these
+# pass-throughs let `cargo {build,test} -p icm-mcp` pick one directly too.
 embeddings = ["icm-core/embeddings"]
+embeddings-static = ["embeddings", "icm-core/embeddings-static"]
+embeddings-dynamic = ["embeddings", "icm-core/embeddings-dynamic"]
 # Storage backend selection is driven by the binary crate (icm-cli); these
 # pass-through features let `cargo test -p icm-mcp` pick one directly.
 backend-sqlite = ["icm-store/backend-sqlite"]


### PR DESCRIPTION
Part of #345 (Phase 1 — build variant + graceful degradation; remaining phases tracked in the issue).

## Problem
`brew install icm` can't build **with embeddings**: the default build downloads onnxruntime at build time (`ort/download-binaries`), but homebrew-core builds run in a **network-less sandbox**. Today the only homebrew-buildable path is `--no-embeddings` (keyword-only).

## What this does
Splits the `embeddings` feature into a code-only base + two mutually exclusive ort backends:

| Feature | ort backend | Build-time network | Use |
|---|---|---|---|
| `embeddings-static` (**default**) | `ort/download-binaries` | yes | published binaries, `install.sh`, tap — **unchanged** |
| `embeddings-dynamic` | `ort/load-dynamic` | **no** | homebrew-core-buildable **with** embeddings |

`fastembed` is now `default-features = false`; each build selects exactly one backend (hf-hub model download re-added per-feature). All `#[cfg(feature = "embeddings")]` code is untouched.

## Graceful degradation (the tricky part)
With `load-dynamic`, ort **panics** if `libonnxruntime` is missing — and the release profile is `panic = "abort"`, so `catch_unwind` is useless. Fix: a unix **`dlopen` pre-flight** that runs *before* ort initializes. Missing runtime → clean `IcmError` → **keyword-only search**, never a crash.

Verified in a **release** (`panic = "abort"`) build:
```
$ ORT_DYLIB_PATH=/nonexistent icm store -t t -c "..."
warning: embedding failed: onnxruntime runtime not found ... run with --no-embeddings ...
Stored: 01KY...              # ← stored keyword-only, exit 0 (no abort)
```

## Safety rails
- `compile_error!` if bare `embeddings` is enabled with no backend (clear message, not a confusing ort link error).
- New CI job **`load-dynamic embeddings`**: builds the variant + asserts graceful degradation with `ORT_DYLIB_PATH` forced to a bogus path.
- Unit test for the dylib pre-flight (`cargo test -p icm-core --features embeddings-dynamic`).

## Verification (all local, real runs — not diff-only)
- ✅ default (static) build compiles — **non-breaking**
- ✅ dynamic build compiles **without** downloading onnxruntime (dev + **release/LTO**, 8m10)
- ✅ release dynamic degrades gracefully (no abort) when runtime absent
- ✅ `cargo fmt --check`, `clippy -p icm-core --features embeddings-dynamic -D warnings`, `clippy -p icm-cli -D warnings`
- ✅ workspace tests green (302 passed)

## Not in this PR (follow-up)
- Switching the homebrew formula to `embeddings-dynamic` + resolving onnxruntime for the user (auto-download at first launch, per the opt-in design in #345).
- Windows pre-flight (this PR covers unix macOS/Linux — the homebrew-core targets).
- fastembed 4→5 major upgrade (separate; v5 keeps `ort-load-dynamic`).
