### PR TITLE
feat(embeddings): first-launch opt-in onnxruntime download (#345)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,11 @@ jobs:
         run: >-
           cargo build -p icm-cli --no-default-features
           --features "embeddings-dynamic,backend-sqlite,tui,http-api"
-      - name: Unit-test the dylib pre-flight
-        run: cargo test -p icm-core --features embeddings-dynamic
+      - name: Unit-test the dylib pre-flight + ort_runtime helpers
+        run: |
+          cargo test -p icm-core --features embeddings-dynamic
+          cargo test -p icm-cli --no-default-features \
+            --features "embeddings-dynamic,backend-sqlite,tui,http-api" ort_runtime
       - name: Graceful degradation when onnxruntime is absent
         # Force the missing-runtime path deterministically. The store must still
         # succeed (keyword-only) and the process must exit 0, not abort.
@@ -117,6 +120,24 @@ jobs:
           "$bin" --no-embeddings --db "$db" recall delta | grep -qi delta \
             && echo "OK: degraded to keyword-only without crashing" \
             || { echo "FAIL: memory not stored / recall failed"; exit 1; }
+      - name: Opt-in download + semantic search (onnxruntime 1.20.1 ↔ ort ABI)
+        # The highest-risk regression: the pinned onnxruntime must load under the
+        # `ort` version fastembed uses, or ort's version assertion aborts. Prove
+        # it end-to-end — download the runtime, then embed with a small model and
+        # confirm a purely semantic recall (query shares no keywords with the
+        # stored text, so a keyword hit is impossible).
+        run: |
+          bin=target/debug/icm
+          "$bin" embeddings download
+          "$bin" embeddings status | grep -qi "installed" \
+            || { echo "FAIL: runtime not reported installed"; exit 1; }
+          cfg="$RUNNER_TEMP/icm.toml"
+          printf '[embeddings]\nmodel = "Qdrant/all-MiniLM-L6-v2-onnx"\n' > "$cfg"
+          db="$RUNNER_TEMP/sem.db"
+          ICM_CONFIG="$cfg" "$bin" --db "$db" store -t t -c "the quick brown fox jumps over the lazy dog"
+          ICM_CONFIG="$cfg" "$bin" --db "$db" recall "a fast animal leaping above a sleepy canine" | grep -qi fox \
+            && echo "OK: downloaded onnxruntime loads under ort and embeds" \
+            || { echo "FAIL: semantic search did not work with the downloaded runtime"; exit 1; }
 
   security:
     name: security scan

--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ cargo install --path crates/icm-cli
 
 Re-run the install command to upgrade to the latest release. To pin a version, pass `--version icm-vX.Y.Z` (sh: `sh -s -- --version …`).
 
+### Semantic search runtime
+
+Keyword search works out of the box. **Semantic (vector) search** needs the ONNX Runtime. The prebuilt binaries and `install.sh` bundle it — nothing to do. The **Homebrew** build ships lean without it (it builds in a network-less sandbox), and offers a one-time download on first use in a terminal:
+
+```bash
+# Explicitly enable semantic search (downloads onnxruntime ~7 MB, one time)
+icm embeddings download
+
+# Check the runtime state
+icm embeddings status
+```
+
+If declined (or in a non-interactive context — MCP server, hooks, CI), ICM stays keyword-only until you run `icm embeddings download`. To use your own runtime, set `ORT_DYLIB_PATH` to an ONNX Runtime **1.20.x** library.
+
 ## Setup
 
 ```bash

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -13,6 +13,11 @@ mod import;
 mod install_manifest;
 #[cfg(test)]
 mod learn_tests;
+// First-launch onnxruntime resolution for the load-dynamic embeddings build
+// (issue #345). Only the dynamic build needs a runtime downloaded at execution
+// time; the static build links onnxruntime in.
+#[cfg(feature = "embeddings-dynamic")]
+mod ort_runtime;
 mod recall_format;
 mod summarizer;
 #[cfg(feature = "tui")]
@@ -772,6 +777,15 @@ enum Commands {
         since_hours: u64,
     },
 
+    /// Manage the semantic-search runtime (onnxruntime).
+    ///
+    /// Keyword search works with no runtime. Semantic (vector) search needs
+    /// onnxruntime; the load-dynamic build downloads it on demand (issue #345).
+    Embeddings {
+        #[command(subcommand)]
+        action: EmbeddingsAction,
+    },
+
     /// Launch interactive TUI dashboard
     #[cfg(feature = "tui")]
     Dashboard,
@@ -780,6 +794,14 @@ enum Commands {
     #[cfg(feature = "tui")]
     #[command(hide = true)]
     Tui,
+}
+
+#[derive(Subcommand)]
+enum EmbeddingsAction {
+    /// Show whether the onnxruntime runtime is installed.
+    Status,
+    /// Download the onnxruntime runtime to enable semantic (vector) search.
+    Download,
 }
 
 #[derive(Subcommand)]
@@ -1516,6 +1538,35 @@ fn init_embedder(_model: &str) -> Option<DisabledEmbedder> {
     None
 }
 
+/// `icm embeddings status|download` — manage the semantic-search runtime.
+/// Behavior depends on how this binary was built (issue #345).
+fn cmd_embeddings(action: &EmbeddingsAction) -> Result<()> {
+    match action {
+        EmbeddingsAction::Status => {
+            #[cfg(feature = "embeddings-dynamic")]
+            ort_runtime::cmd_status();
+            #[cfg(all(feature = "embeddings", not(feature = "embeddings-dynamic")))]
+            println!(
+                "onnxruntime is statically linked into this build — semantic search is \
+                 always available."
+            );
+            #[cfg(not(feature = "embeddings"))]
+            println!("This build was compiled without embeddings (keyword-only search).");
+        }
+        EmbeddingsAction::Download => {
+            #[cfg(feature = "embeddings-dynamic")]
+            {
+                ort_runtime::cmd_download()?;
+            }
+            #[cfg(all(feature = "embeddings", not(feature = "embeddings-dynamic")))]
+            println!("Nothing to download: onnxruntime is statically linked into this build.");
+            #[cfg(not(feature = "embeddings"))]
+            println!("This build was compiled without embeddings; nothing to download.");
+        }
+    }
+    Ok(())
+}
+
 fn main() -> Result<()> {
     // Reset SIGPIPE to default so piped commands (e.g. `icm export | head`)
     // don't panic on broken pipe.
@@ -1535,6 +1586,24 @@ fn main() -> Result<()> {
     let cfg = config::load_config()?;
     let embeddings_enabled =
         cfg.embeddings.enabled && !cli.no_embeddings && std::env::var("ICM_NO_EMBEDDINGS").is_err();
+    // Load-dynamic build (issue #345): resolve the onnxruntime runtime. Activate
+    // a previously-downloaded copy (always), and offer a one-time interactive
+    // download on first use — but never in `serve`/`hook`/`embeddings` or when
+    // stdin/stderr aren't a terminal (piped/CI), where we silently keep
+    // keyword-only. If no runtime is available, drop to keyword-only so there
+    // are no per-operation "embedding failed" warnings.
+    #[cfg(feature = "embeddings-dynamic")]
+    let embeddings_enabled = embeddings_enabled
+        // The `embeddings` command manages the runtime itself; skip activation
+        // and any prompt here so `status` reports the pristine environment.
+        && !matches!(cli.command, Commands::Embeddings { .. })
+        && {
+            use std::io::IsTerminal;
+            let interactive = !matches!(cli.command, Commands::Serve { .. } | Commands::Hook { .. })
+                && std::io::stdin().is_terminal()
+                && std::io::stderr().is_terminal();
+            ort_runtime::ensure_for_run(interactive)
+        };
     #[allow(unused_variables)]
     let embedder = if embeddings_enabled {
         init_embedder(&cfg.embeddings.model)
@@ -1602,6 +1671,11 @@ fn main() -> Result<()> {
     } = &command
     {
         return cmd_hook_disable(*dry_run);
+    }
+    // `icm embeddings status|download` manages the onnxruntime runtime and needs
+    // neither the store nor the DB — dispatch before `open_store`.
+    if let Commands::Embeddings { action } = &command {
+        return cmd_embeddings(action);
     }
 
     let store = if read_only_requested(cli.read_only) {
@@ -1933,6 +2007,9 @@ fn main() -> Result<()> {
         Commands::Doctor => cmd_doctor(&db_path),
         Commands::Repair { dry_run } => cmd_repair(&db_path, dry_run),
         Commands::Uninstall(_) => unreachable!("dispatched before open_store"),
+        // `icm embeddings` is dispatched before `open_store` above; this arm
+        // exists only for match exhaustiveness and is unreachable.
+        Commands::Embeddings { .. } => unreachable!("dispatched before open_store"),
         Commands::CodeAreas {
             in_file,
             project,

--- a/crates/icm-cli/src/ort_runtime.rs
+++ b/crates/icm-cli/src/ort_runtime.rs
@@ -1,0 +1,401 @@
+//! First-launch opt-in onnxruntime runtime for the `embeddings-dynamic` build
+//! (issue #345).
+//!
+//! The load-dynamic build ships without onnxruntime so it compiles in a
+//! network-less sandbox (e.g. homebrew-core). This module resolves the runtime
+//! at *execution* time instead:
+//!
+//! - [`activate_if_present`] points `ort` at a previously-downloaded,
+//!   icm-managed copy (always, even for `serve`/`hook`).
+//! - [`ensure_for_run`] additionally offers an interactive one-time download on
+//!   first use (never in non-interactive contexts).
+//! - [`cmd_download`] / [`cmd_status`] back the explicit `icm embeddings`
+//!   subcommand for scripted setup.
+//!
+//! Safety: `ort` 2.0.0-rc.9 targets ONNX Runtime **1.20**; a mismatched runtime
+//! makes ort's version assertion abort under `panic = "abort"`. We therefore
+//! pin 1.20.1, verify a hard-coded SHA256, and trust *only* our managed copy
+//! (or an explicit user `ORT_DYLIB_PATH`) — never an ambient system library.
+
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+use anyhow::{anyhow, bail, Context, Result};
+use sha2::{Digest, Sha256};
+
+/// onnxruntime release to fetch. MUST stay ABI-compatible with the `ort`
+/// version fastembed pins (currently `ort` 2.0.0-rc.9 → ONNX Runtime 1.20).
+const ORT_VERSION: &str = "1.20.1";
+
+const ORT_DYLIB_ENV: &str = "ORT_DYLIB_PATH";
+
+/// A supported download target: the Microsoft asset infix, the pinned SHA256 of
+/// `onnxruntime-<asset>-<ver>.tgz`, and the canonical shared-library filename
+/// that ort's load-dynamic backend looks for.
+struct Target {
+    asset: &'static str,
+    sha256: &'static str,
+    lib_name: &'static str,
+}
+
+/// Resolve the onnxruntime asset for this platform, or `None` if unsupported
+/// (Windows `.zip` and exotic arches are deferred — issue #345).
+fn detect_target() -> Option<Target> {
+    let lib_name = if cfg!(target_os = "macos") {
+        "libonnxruntime.dylib"
+    } else {
+        "libonnxruntime.so"
+    };
+    let (asset, sha256) = match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => (
+            "osx-arm64",
+            "b678fc3c2354c771fea4fba420edeccfba205140088334df801e7fc40e83a57a",
+        ),
+        ("macos", "x86_64") => (
+            "osx-x86_64",
+            "0f73006813af2a1a5d1723ed7dfb694fc629d15037124081bb61b7bf7d99fc78",
+        ),
+        ("linux", "x86_64") => (
+            "linux-x64",
+            "67db4dc1561f1e3fd42e619575c82c601ef89849afc7ea85a003abbac1a1a105",
+        ),
+        ("linux", "aarch64") => (
+            "linux-aarch64",
+            "ae4fedbdc8c18d688c01306b4b50c63de3445cdf2dbd720e01a2fa3810b8106a",
+        ),
+        _ => return None,
+    };
+    Some(Target {
+        asset,
+        sha256,
+        lib_name,
+    })
+}
+
+fn onnxruntime_root() -> Option<PathBuf> {
+    directories::ProjectDirs::from("dev", "icm", "icm").map(|d| d.data_dir().join("onnxruntime"))
+}
+
+/// Version-scoped directory holding the managed runtime.
+fn managed_dir() -> Option<PathBuf> {
+    onnxruntime_root().map(|d| d.join(ORT_VERSION))
+}
+
+/// Full path to the managed shared library for this platform.
+fn managed_lib_path() -> Option<PathBuf> {
+    let target = detect_target()?;
+    Some(managed_dir()?.join(target.lib_name))
+}
+
+/// Marker written when the user declines the first-launch download, so we don't
+/// nag on every run. Kept outside the version dir so it survives version bumps.
+fn declined_marker() -> Option<PathBuf> {
+    onnxruntime_root().map(|d| d.join(".declined"))
+}
+
+fn user_set_dylib() -> bool {
+    std::env::var_os(ORT_DYLIB_ENV).is_some_and(|v| !v.is_empty())
+}
+
+/// Point `ort` at the managed library if it exists and the user hasn't set
+/// `ORT_DYLIB_PATH`. Returns whether a runtime is now resolvable. Safe to call
+/// unconditionally (including for `serve`/`hook`).
+pub fn activate_if_present() -> bool {
+    if user_set_dylib() {
+        return true;
+    }
+    if let Some(lib) = managed_lib_path() {
+        if lib.is_file() {
+            std::env::set_var(ORT_DYLIB_ENV, &lib);
+            return true;
+        }
+    }
+    false
+}
+
+fn download_bytes(url: &str) -> Result<Vec<u8>> {
+    let resp = ureq::get(url)
+        .set("User-Agent", "icm-onnxruntime-fetch")
+        .call()
+        .with_context(|| format!("failed to download {url}"))?;
+    let mut buf = Vec::new();
+    resp.into_reader()
+        .read_to_end(&mut buf)
+        .context("failed to read download body")?;
+    Ok(buf)
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    format!("{:x}", hasher.finalize())
+}
+
+fn verify_sha(bytes: &[u8], expected: &str, what: &str) -> Result<()> {
+    let actual = sha256_hex(bytes);
+    if actual != expected {
+        bail!(
+            "checksum mismatch for {what}: expected {expected}, got {actual} — refusing to install"
+        );
+    }
+    Ok(())
+}
+
+/// Extract the real onnxruntime shared library from the downloaded `.tgz`.
+///
+/// The archive carries `.../lib/libonnxruntime.<ver>.{dylib,so}` as a regular
+/// file plus an unversioned symlink; we want the regular file's bytes and must
+/// avoid the `libonnxruntime_providers_*` siblings (they start with an
+/// underscore, so `"libonnxruntime."` prefix-matching excludes them).
+fn extract_lib(archive: &[u8]) -> Result<Vec<u8>> {
+    use flate2::read::GzDecoder;
+    let mut tar = tar::Archive::new(GzDecoder::new(archive));
+    for entry in tar.entries().context("reading onnxruntime archive")? {
+        let mut entry = entry.context("reading archive entry")?;
+        if entry.header().entry_type() != tar::EntryType::Regular {
+            continue; // skip the unversioned symlink
+        }
+        let name = entry
+            .path()
+            .ok()
+            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .unwrap_or_default();
+        let is_lib = name.starts_with("libonnxruntime.")
+            && (name.contains(".dylib") || name.contains(".so"));
+        if is_lib {
+            let mut buf = Vec::new();
+            entry
+                .read_to_end(&mut buf)
+                .context("reading library bytes")?;
+            if !buf.is_empty() {
+                return Ok(buf);
+            }
+        }
+    }
+    bail!("libonnxruntime not found in onnxruntime archive")
+}
+
+/// Download, verify, and install onnxruntime to the managed path, then point
+/// `ort` at it. `progress` prints one-line status to stderr.
+pub fn download(progress: bool) -> Result<PathBuf> {
+    let target = detect_target().ok_or_else(|| {
+        anyhow!(
+            "no prebuilt onnxruntime for this platform ({}/{}); set {ORT_DYLIB_ENV} \
+             to an onnxruntime {ORT_VERSION} library manually",
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        )
+    })?;
+    let dir = managed_dir().ok_or_else(|| anyhow!("cannot resolve the icm data directory"))?;
+    let lib_path = dir.join(target.lib_name);
+
+    let asset = format!("onnxruntime-{}-{ORT_VERSION}.tgz", target.asset);
+    let url = format!(
+        "https://github.com/microsoft/onnxruntime/releases/download/v{ORT_VERSION}/{asset}"
+    );
+    if progress {
+        eprintln!("Downloading {asset} (~7 MB, one time)…");
+    }
+    let bytes = download_bytes(&url)?;
+    verify_sha(&bytes, target.sha256, &asset)?;
+    let lib_bytes = extract_lib(&bytes)?;
+
+    std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+    // Write to a temp sibling then rename, so a concurrent reader never sees a
+    // half-written library.
+    let tmp = lib_path.with_extension("new");
+    std::fs::write(&tmp, &lib_bytes).with_context(|| format!("writing {}", tmp.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755))
+            .context("setting permissions on onnxruntime library")?;
+    }
+    std::fs::rename(&tmp, &lib_path)
+        .with_context(|| format!("installing {}", lib_path.display()))?;
+
+    // The user has opted in: clear any prior "declined" marker.
+    if let Some(marker) = declined_marker() {
+        let _ = std::fs::remove_file(marker);
+    }
+    std::env::set_var(ORT_DYLIB_ENV, &lib_path);
+    if progress {
+        eprintln!(
+            "Installed onnxruntime {ORT_VERSION} → {}",
+            lib_path.display()
+        );
+    }
+    Ok(lib_path)
+}
+
+/// Interactive `[y/N]` confirmation, prompted on **stderr** so it still reaches
+/// the user when stdout is piped (e.g. `icm recall … | grep`).
+fn confirm(prompt: &str) -> bool {
+    eprint!("{prompt} [y/N] ");
+    let _ = std::io::stderr().flush();
+    let mut buf = String::new();
+    if std::io::stdin().read_line(&mut buf).is_err() {
+        return false;
+    }
+    matches!(buf.trim().chars().next(), Some('y' | 'Y'))
+}
+
+/// Resolve the runtime for a normal CLI run. Returns whether semantic
+/// embeddings can be used (else the caller degrades to keyword-only). Prompts
+/// for a one-time download only when `interactive` is true.
+pub fn ensure_for_run(interactive: bool) -> bool {
+    if activate_if_present() {
+        return true;
+    }
+    if !interactive || detect_target().is_none() {
+        return false;
+    }
+    // Respect a previous decline.
+    if let Some(marker) = declined_marker() {
+        if marker.exists() {
+            return false;
+        }
+    }
+    let prompt = format!(
+        "Enable semantic (vector) search? This downloads ONNX Runtime {ORT_VERSION} \
+         (~7 MB, one time). Download now?"
+    );
+    if confirm(&prompt) {
+        match download(true) {
+            Ok(_) => true,
+            Err(e) => {
+                eprintln!("onnxruntime download failed: {e}");
+                eprintln!("Continuing with keyword-only search. Retry: icm embeddings download");
+                false
+            }
+        }
+    } else {
+        // Persist the decline so we don't ask again every run.
+        if let Some(marker) = declined_marker() {
+            if let Some(parent) = marker.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let _ = std::fs::write(&marker, b"user declined the onnxruntime download\n");
+        }
+        eprintln!("Continuing with keyword-only search. Enable later: icm embeddings download");
+        false
+    }
+}
+
+/// `icm embeddings download` — force a (re)install, non-interactively.
+pub fn cmd_download() -> Result<()> {
+    let path = download(true)?;
+    println!(
+        "Semantic search enabled (onnxruntime {ORT_VERSION} at {}).",
+        path.display()
+    );
+    Ok(())
+}
+
+/// `icm embeddings status` — report the runtime state.
+pub fn cmd_status() {
+    if user_set_dylib() {
+        let p = std::env::var(ORT_DYLIB_ENV).unwrap_or_default();
+        println!("onnxruntime: using {ORT_DYLIB_ENV} override ({p})");
+        return;
+    }
+    match managed_lib_path() {
+        Some(p) if p.is_file() => {
+            println!("onnxruntime {ORT_VERSION}: installed ({})", p.display());
+        }
+        Some(_) => {
+            println!(
+                "onnxruntime {ORT_VERSION}: not installed — run `icm embeddings download` \
+                 to enable semantic search (keyword search works without it)"
+            );
+        }
+        None => {
+            println!(
+                "onnxruntime: no prebuilt runtime for this platform ({}/{}); set \
+                 {ORT_DYLIB_ENV} to an onnxruntime {ORT_VERSION} library manually",
+                std::env::consts::OS,
+                std::env::consts::ARCH
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_target_matches_host_lib_extension() {
+        // On the supported CI/dev hosts (macOS/Linux, x86_64/aarch64) we expect
+        // a target whose canonical lib name matches the OS.
+        if let Some(t) = detect_target() {
+            if cfg!(target_os = "macos") {
+                assert_eq!(t.lib_name, "libonnxruntime.dylib");
+                assert!(t.asset.starts_with("osx-"));
+            } else if cfg!(target_os = "linux") {
+                assert_eq!(t.lib_name, "libonnxruntime.so");
+                assert!(t.asset.starts_with("linux-"));
+            }
+            assert_eq!(t.sha256.len(), 64, "pinned sha256 must be 64 hex chars");
+        }
+    }
+
+    #[test]
+    fn managed_paths_are_version_scoped() {
+        if let Some(p) = managed_lib_path() {
+            let s = p.to_string_lossy();
+            assert!(
+                s.contains("onnxruntime"),
+                "path should be under onnxruntime/: {s}"
+            );
+            assert!(
+                s.contains(ORT_VERSION),
+                "path should be version-scoped: {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn sha_mismatch_is_rejected() {
+        assert!(verify_sha(b"hello", &sha256_hex(b"hello"), "x").is_ok());
+        assert!(verify_sha(b"hello", &sha256_hex(b"world"), "x").is_err());
+    }
+
+    #[test]
+    fn extract_lib_picks_versioned_regular_file() {
+        // Build a tiny .tgz: a providers sibling (must be ignored) + the real
+        // versioned library. No symlink entry (tar builder appends regular
+        // files), which still exercises the prefix/underscore filtering.
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        fn tar_entry(builder: &mut tar::Builder<Vec<u8>>, path: &str, data: &[u8]) {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_cksum();
+            builder.append_data(&mut header, path, data).unwrap();
+        }
+
+        let mut builder = tar::Builder::new(Vec::new());
+        tar_entry(
+            &mut builder,
+            "onnxruntime-osx-arm64-1.20.1/lib/libonnxruntime_providers_shared.dylib",
+            b"PROVIDER",
+        );
+        tar_entry(
+            &mut builder,
+            "onnxruntime-osx-arm64-1.20.1/lib/libonnxruntime.1.20.1.dylib",
+            b"REAL-LIBRARY-BYTES",
+        );
+        let tar_bytes = builder.into_inner().unwrap();
+
+        let mut gz = GzEncoder::new(Vec::new(), Compression::fast());
+        gz.write_all(&tar_bytes).unwrap();
+        let tgz = gz.finish().unwrap();
+
+        let extracted = extract_lib(&tgz).expect("should find the versioned library");
+        assert_eq!(extracted, b"REAL-LIBRARY-BYTES");
+    }
+}


### PR DESCRIPTION
Part of #345 (Phase 2). Builds on #346 (the `embeddings-dynamic` build variant).

## Problem
The load-dynamic build (Phase 1) compiles without onnxruntime — great for homebrew-core's network-less sandbox — but can't do semantic search until a runtime is present. This wires up **resolving that runtime at execution time**, per Patrick's direction: *lean by default (keyword-only), ask at first launch whether to download*.

## What this adds
**`crates/icm-cli/src/ort_runtime.rs`** (cfg `embeddings-dynamic`):
- Pins **onnxruntime 1.20.1** — ABI-compatible with the `ort` 2.0.0-rc.9 fastembed uses. A mismatched runtime makes ort's version assertion **abort** under `panic = "abort"`, so the version + a hard-coded **SHA256 per platform** are verified before install.
- `activate_if_present()` — points ort at the managed lib (always, incl. `serve`/`hook`).
- `ensure_for_run()` — offers a **one-time interactive download** on first use; never in `serve`/`hook`/`embeddings`, and only when **stdin+stderr are a TTY** (prompt on stderr so `… | grep` still shows it). Declining writes a marker (no nagging). No runtime → keyword-only, silently.
- Trusts **only** the managed 1.20.1 lib (or an explicit user `ORT_DYLIB_PATH`) — never an ambient system lib whose version could abort ort.

**`icm embeddings status|download`** — explicit, non-interactive setup for scripts/CI/Docker and for users who declined. Static builds report "statically linked".

## Verified end-to-end (real runs, macOS arm64 — not diff-only)
- ✅ fresh state → `status`: "not installed"
- ✅ non-interactive (piped stdin) → **no prompt**, keyword-only
- ✅ `icm embeddings download` → downloads + SHA-verifies + installs onnxruntime 1.20.1
- ✅ subsequent `store`/`recall` → **semantic** hit via the managed lib (query with no shared keywords, score 0.6) — proving onnxruntime 1.20.1 loads under ort rc.9 with no version panic (also checked in a **release/`panic=abort`** build)
- ✅ 4 `ort_runtime` unit tests (target detection, version-scoped paths, SHA-mismatch rejected, tgz extraction picks the versioned lib over the providers sibling)
- ✅ `fmt`, `clippy -D warnings` (static + dynamic + no-embeddings), workspace tests

## CI
The `load-dynamic embeddings` job now, in addition to the graceful-degradation check, runs `icm embeddings download` then asserts a purely **semantic** recall with a small model — a runtime regression guard for the onnxruntime↔ort ABI (the highest-risk part).

## Not in this PR (follow-ups, tracked in #345)
- Windows pre-flight + `.zip` download (unix = the homebrew-core targets).
- The homebrew-core formula PR submission (separate repo; needs a release carrying this feature — scratchpad formula updated to `embeddings-dynamic` + caveats).
- fastembed 4→5 major upgrade (separate; v5 keeps `ort-load-dynamic`).