### PR TITLE
feat(embeddings): Windows onnxruntime download + dll pre-flight (#345)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+# Windows defaults the main-thread stack to 1 MiB, where unix reserves 8 MiB.
+# ICM's startup/embedding path has a fixed stack frame that fits comfortably in
+# 8 MiB but overflows 1 MiB (surfaced as "thread 'main' has overflowed its
+# stack" when running the CLI on Windows — issue #345). Reserve 8 MiB so the
+# Windows binary matches unix behaviour. Scoped to the MSVC target, so unix and
+# musl builds are unaffected.
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-arg=/STACK:8388608"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,7 @@ jobs:
           ORT_DYLIB_PATH: C:\nonexistent\onnxruntime.dll
         run: |
           bin=target/debug/icm.exe
+          "$bin" --version  # smoke: the binary must launch (8 MiB stack, see .cargo/config.toml)
           db="$RUNNER_TEMP/dyn.db"
           "$bin" --db "$db" store -t t -c "ci dynamic graceful delta"
           "$bin" --no-embeddings --db "$db" recall delta | grep -qi delta \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,58 @@ jobs:
             && echo "OK: downloaded onnxruntime loads under ort and embeds" \
             || { echo "FAIL: semantic search did not work with the downloaded runtime"; exit 1; }
 
+  # Same load-dynamic variant on Windows (issue #345): the onnxruntime asset is a
+  # `.zip` (not the unix `.tgz`) and the runtime is `onnxruntime.dll`, so this
+  # exercises the zip extractor and the `LoadLibraryW` pre-flight. It's the only
+  # real proof that the pinned onnxruntime loads under ort's ABI on Windows.
+  embeddings-dynamic-windows:
+    name: load-dynamic embeddings (windows)
+    needs: clippy
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build load-dynamic variant (no build-time onnxruntime)
+        run: >-
+          cargo build -p icm-cli --no-default-features
+          --features "embeddings-dynamic,backend-sqlite,tui,http-api"
+      - name: Unit-test the dll pre-flight + ort_runtime helpers
+        run: |
+          cargo test -p icm-core --features embeddings-dynamic
+          cargo test -p icm-cli --no-default-features \
+            --features "embeddings-dynamic,backend-sqlite,tui,http-api" ort_runtime
+      - name: Graceful degradation when onnxruntime is absent
+        # A bogus ORT_DYLIB_PATH must degrade to keyword-only, never abort.
+        env:
+          ORT_DYLIB_PATH: C:\nonexistent\onnxruntime.dll
+        run: |
+          bin=target/debug/icm.exe
+          db="$RUNNER_TEMP/dyn.db"
+          "$bin" --db "$db" store -t t -c "ci dynamic graceful delta"
+          "$bin" --no-embeddings --db "$db" recall delta | grep -qi delta \
+            && echo "OK: degraded to keyword-only without crashing" \
+            || { echo "FAIL: memory not stored / recall failed"; exit 1; }
+      - name: Opt-in download + semantic search (onnxruntime 1.20.1 ↔ ort ABI)
+        # Highest-risk regression on Windows: the pinned onnxruntime.dll must load
+        # under the `ort` version fastembed uses, or ort's version assertion
+        # aborts. Prove it end-to-end with a purely semantic recall.
+        run: |
+          bin=target/debug/icm.exe
+          "$bin" embeddings download
+          "$bin" embeddings status | grep -qi "installed" \
+            || { echo "FAIL: runtime not reported installed"; exit 1; }
+          cfg="$RUNNER_TEMP/icm.toml"
+          printf '[embeddings]\nmodel = "Qdrant/all-MiniLM-L6-v2-onnx"\n' > "$cfg"
+          db="$RUNNER_TEMP/sem.db"
+          ICM_CONFIG="$cfg" "$bin" --db "$db" store -t t -c "the quick brown fox jumps over the lazy dog"
+          ICM_CONFIG="$cfg" "$bin" --db "$db" recall "a fast animal leaping above a sleepy canine" | grep -qi fox \
+            && echo "OK: downloaded onnxruntime.dll loads under ort and embeds" \
+            || { echo "FAIL: semantic search did not work with the downloaded runtime"; exit 1; }
+
   security:
     name: security scan
     needs: clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arg_enum_proc_macro"
@@ -752,6 +755,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1478,6 +1492,7 @@ dependencies = [
  "tracing-subscriber",
  "ureq",
  "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -4675,10 +4690,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ rpassword = "5"
 sha2 = "0.10"
 flate2 = "1"
 tar = "0.4.45"
+# Windows onnxruntime runtime (issue #345) ships as a .zip, unlike the unix
+# .tgz; `deflate` is the only compression the Microsoft asset uses.
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 # Platform
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ icm embeddings status
 
 If declined (or in a non-interactive context — MCP server, hooks, CI), ICM stays keyword-only until you run `icm embeddings download`. To use your own runtime, set `ORT_DYLIB_PATH` to an ONNX Runtime **1.20.x** library.
 
+The download supports macOS (arm64/x86_64), Linux (x86_64/aarch64), and Windows (x86_64). On Windows the runtime is the larger `onnxruntime.dll` package (~65 MB); everywhere else it's ~7 MB.
+
 ## Setup
 
 ```bash

--- a/crates/icm-cli/Cargo.toml
+++ b/crates/icm-cli/Cargo.toml
@@ -27,7 +27,7 @@ embeddings-static = ["embeddings", "icm-core/embeddings-static"]
 # load-dynamic variant (issue #345): compiles with no build-time onnxruntime,
 # so `brew install` (homebrew-core) can build it with embeddings. Used as
 # `--no-default-features --features "embeddings-dynamic,backend-sqlite,tui,http-api"`.
-embeddings-dynamic = ["embeddings", "icm-core/embeddings-dynamic"]
+embeddings-dynamic = ["embeddings", "icm-core/embeddings-dynamic", "dep:zip"]
 tui = ["dep:ratatui", "dep:crossterm"]
 # Storage backends (additive). SQLite is in-process; postgres / opensearch
 # are network-accessible so several `icm` processes / Kubernetes replicas
@@ -74,6 +74,8 @@ rpassword = { workspace = true }
 sha2 = { workspace = true }
 flate2 = { workspace = true }
 tar = { workspace = true }
+# Only the load-dynamic embeddings build needs zip (Windows onnxruntime asset).
+zip = { workspace = true, optional = true }
 ratatui = { workspace = true, optional = true }
 crossterm = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }

--- a/crates/icm-cli/src/ort_runtime.rs
+++ b/crates/icm-cli/src/ort_runtime.rs
@@ -29,47 +29,71 @@ const ORT_VERSION: &str = "1.20.1";
 
 const ORT_DYLIB_ENV: &str = "ORT_DYLIB_PATH";
 
-/// A supported download target: the Microsoft asset infix, the pinned SHA256 of
-/// `onnxruntime-<asset>-<ver>.tgz`, and the canonical shared-library filename
-/// that ort's load-dynamic backend looks for.
+/// A supported download target: the Microsoft asset infix, the archive
+/// extension (`tgz` on unix, `zip` on Windows), the pinned SHA256 of
+/// `onnxruntime-<asset>-<ver>.<ext>`, the canonical shared-library filename that
+/// ort's load-dynamic backend looks for, and a human-readable download size for
+/// the first-launch prompt.
 struct Target {
     asset: &'static str,
+    archive_ext: &'static str,
     sha256: &'static str,
     lib_name: &'static str,
+    approx_size: &'static str,
 }
 
-/// Resolve the onnxruntime asset for this platform, or `None` if unsupported
-/// (Windows `.zip` and exotic arches are deferred — issue #345).
-fn detect_target() -> Option<Target> {
-    let lib_name = if cfg!(target_os = "macos") {
-        "libonnxruntime.dylib"
-    } else {
-        "libonnxruntime.so"
-    };
-    let (asset, sha256) = match (std::env::consts::OS, std::env::consts::ARCH) {
+/// Resolve the onnxruntime asset for a given `(os, arch)`, or `None` if
+/// unsupported (Windows-on-ARM and exotic arches are deferred — issue #345).
+/// Split out from [`detect_target`] so the target table is unit-testable across
+/// platforms from any host.
+fn target_for(os: &str, arch: &str) -> Option<Target> {
+    // (asset, sha256, approx_size) — the shared-library name and archive format
+    // are derived from `os` below.
+    let (asset, sha256, approx_size) = match (os, arch) {
         ("macos", "aarch64") => (
             "osx-arm64",
             "b678fc3c2354c771fea4fba420edeccfba205140088334df801e7fc40e83a57a",
+            "~7 MB",
         ),
         ("macos", "x86_64") => (
             "osx-x86_64",
             "0f73006813af2a1a5d1723ed7dfb694fc629d15037124081bb61b7bf7d99fc78",
+            "~7 MB",
         ),
         ("linux", "x86_64") => (
             "linux-x64",
             "67db4dc1561f1e3fd42e619575c82c601ef89849afc7ea85a003abbac1a1a105",
+            "~7 MB",
         ),
         ("linux", "aarch64") => (
             "linux-aarch64",
             "ae4fedbdc8c18d688c01306b4b50c63de3445cdf2dbd720e01a2fa3810b8106a",
+            "~7 MB",
+        ),
+        ("windows", "x86_64") => (
+            "win-x64",
+            "78d447051e48bd2e1e778bba378bec4ece11191c9e538cf7b2c4a4565e8f5581",
+            "~65 MB",
         ),
         _ => return None,
     };
+    let (archive_ext, lib_name) = match os {
+        "windows" => ("zip", "onnxruntime.dll"),
+        "macos" => ("tgz", "libonnxruntime.dylib"),
+        _ => ("tgz", "libonnxruntime.so"),
+    };
     Some(Target {
         asset,
+        archive_ext,
         sha256,
         lib_name,
+        approx_size,
     })
+}
+
+/// Resolve the onnxruntime asset for the host platform.
+fn detect_target() -> Option<Target> {
+    target_for(std::env::consts::OS, std::env::consts::ARCH)
 }
 
 fn onnxruntime_root() -> Option<PathBuf> {
@@ -141,13 +165,25 @@ fn verify_sha(bytes: &[u8], expected: &str, what: &str) -> Result<()> {
     Ok(())
 }
 
-/// Extract the real onnxruntime shared library from the downloaded `.tgz`.
+/// Does this archive entry's file name identify the onnxruntime library we want?
 ///
-/// The archive carries `.../lib/libonnxruntime.<ver>.{dylib,so}` as a regular
-/// file plus an unversioned symlink; we want the regular file's bytes and must
-/// avoid the `libonnxruntime_providers_*` siblings (they start with an
-/// underscore, so `"libonnxruntime."` prefix-matching excludes them).
-fn extract_lib(archive: &[u8]) -> Result<Vec<u8>> {
+/// - unix `.tgz`: `libonnxruntime.<ver>.{dylib,so}` (a regular file; the
+///   `libonnxruntime_providers_*` siblings start with an underscore, so the
+///   `"libonnxruntime."` prefix excludes them).
+/// - Windows `.zip`: `onnxruntime.dll` exactly (the `onnxruntime_providers_*.dll`
+///   siblings start with an underscore, so an exact match excludes them).
+fn is_onnxruntime_lib(name: &str) -> bool {
+    let unix =
+        name.starts_with("libonnxruntime.") && (name.contains(".dylib") || name.contains(".so"));
+    unix || name == "onnxruntime.dll"
+}
+
+/// Extract the real onnxruntime shared library from the downloaded archive,
+/// dispatching on `archive_ext` (`tgz` on unix, `zip` on Windows).
+fn extract_lib(archive: &[u8], archive_ext: &str) -> Result<Vec<u8>> {
+    if archive_ext == "zip" {
+        return extract_lib_zip(archive);
+    }
     use flate2::read::GzDecoder;
     let mut tar = tar::Archive::new(GzDecoder::new(archive));
     for entry in tar.entries().context("reading onnxruntime archive")? {
@@ -160,9 +196,7 @@ fn extract_lib(archive: &[u8]) -> Result<Vec<u8>> {
             .ok()
             .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
             .unwrap_or_default();
-        let is_lib = name.starts_with("libonnxruntime.")
-            && (name.contains(".dylib") || name.contains(".so"));
-        if is_lib {
+        if is_onnxruntime_lib(&name) {
             let mut buf = Vec::new();
             entry
                 .read_to_end(&mut buf)
@@ -173,6 +207,30 @@ fn extract_lib(archive: &[u8]) -> Result<Vec<u8>> {
         }
     }
     bail!("libonnxruntime not found in onnxruntime archive")
+}
+
+/// Extract `onnxruntime.dll` from the Windows `.zip` asset.
+fn extract_lib_zip(archive: &[u8]) -> Result<Vec<u8>> {
+    use std::io::Cursor;
+    let mut zip = zip::ZipArchive::new(Cursor::new(archive)).context("reading onnxruntime zip")?;
+    for i in 0..zip.len() {
+        let mut entry = zip.by_index(i).context("reading zip entry")?;
+        if !entry.is_file() {
+            continue;
+        }
+        let name = entry
+            .enclosed_name()
+            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .unwrap_or_default();
+        if is_onnxruntime_lib(&name) {
+            let mut buf = Vec::new();
+            entry.read_to_end(&mut buf).context("reading dll bytes")?;
+            if !buf.is_empty() {
+                return Ok(buf);
+            }
+        }
+    }
+    bail!("onnxruntime.dll not found in onnxruntime archive")
 }
 
 /// Download, verify, and install onnxruntime to the managed path, then point
@@ -189,16 +247,19 @@ pub fn download(progress: bool) -> Result<PathBuf> {
     let dir = managed_dir().ok_or_else(|| anyhow!("cannot resolve the icm data directory"))?;
     let lib_path = dir.join(target.lib_name);
 
-    let asset = format!("onnxruntime-{}-{ORT_VERSION}.tgz", target.asset);
+    let asset = format!(
+        "onnxruntime-{}-{ORT_VERSION}.{}",
+        target.asset, target.archive_ext
+    );
     let url = format!(
         "https://github.com/microsoft/onnxruntime/releases/download/v{ORT_VERSION}/{asset}"
     );
     if progress {
-        eprintln!("Downloading {asset} (~7 MB, one time)…");
+        eprintln!("Downloading {asset} ({}, one time)…", target.approx_size);
     }
     let bytes = download_bytes(&url)?;
     verify_sha(&bytes, target.sha256, &asset)?;
-    let lib_bytes = extract_lib(&bytes)?;
+    let lib_bytes = extract_lib(&bytes, target.archive_ext)?;
 
     std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
     // Write to a temp sibling then rename, so a concurrent reader never sees a
@@ -211,6 +272,10 @@ pub fn download(progress: bool) -> Result<PathBuf> {
         std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755))
             .context("setting permissions on onnxruntime library")?;
     }
+    // On Windows `rename` fails if the destination already exists (e.g. a forced
+    // re-download), so clear it first. Unix `rename` replaces atomically.
+    #[cfg(windows)]
+    let _ = std::fs::remove_file(&lib_path);
     std::fs::rename(&tmp, &lib_path)
         .with_context(|| format!("installing {}", lib_path.display()))?;
 
@@ -247,7 +312,10 @@ pub fn ensure_for_run(interactive: bool) -> bool {
     if activate_if_present() {
         return true;
     }
-    if !interactive || detect_target().is_none() {
+    let Some(target) = detect_target() else {
+        return false;
+    };
+    if !interactive {
         return false;
     }
     // Respect a previous decline.
@@ -258,7 +326,8 @@ pub fn ensure_for_run(interactive: bool) -> bool {
     }
     let prompt = format!(
         "Enable semantic (vector) search? This downloads ONNX Runtime {ORT_VERSION} \
-         (~7 MB, one time). Download now?"
+         ({}, one time). Download now?",
+        target.approx_size
     );
     if confirm(&prompt) {
         match download(true) {
@@ -395,7 +464,86 @@ mod tests {
         gz.write_all(&tar_bytes).unwrap();
         let tgz = gz.finish().unwrap();
 
-        let extracted = extract_lib(&tgz).expect("should find the versioned library");
+        let extracted = extract_lib(&tgz, "tgz").expect("should find the versioned library");
         assert_eq!(extracted, b"REAL-LIBRARY-BYTES");
+    }
+
+    #[test]
+    fn target_table_covers_all_supported_platforms() {
+        // Every shipped target must have a 64-hex sha, a matching archive
+        // format, and the canonical lib name ort's load-dynamic backend expects.
+        let cases = [
+            (
+                "macos",
+                "aarch64",
+                "tgz",
+                "libonnxruntime.dylib",
+                "osx-arm64",
+            ),
+            (
+                "macos",
+                "x86_64",
+                "tgz",
+                "libonnxruntime.dylib",
+                "osx-x86_64",
+            ),
+            ("linux", "x86_64", "tgz", "libonnxruntime.so", "linux-x64"),
+            (
+                "linux",
+                "aarch64",
+                "tgz",
+                "libonnxruntime.so",
+                "linux-aarch64",
+            ),
+            ("windows", "x86_64", "zip", "onnxruntime.dll", "win-x64"),
+        ];
+        for (os, arch, ext, lib, asset) in cases {
+            let t = target_for(os, arch)
+                .unwrap_or_else(|| panic!("{os}/{arch} must be a supported target"));
+            assert_eq!(t.archive_ext, ext, "{os}/{arch} archive ext");
+            assert_eq!(t.lib_name, lib, "{os}/{arch} lib name");
+            assert_eq!(t.asset, asset, "{os}/{arch} asset infix");
+            assert_eq!(t.sha256.len(), 64, "{os}/{arch} sha must be 64 hex chars");
+        }
+        // Windows-on-ARM and exotic arches are deferred (issue #345).
+        assert!(target_for("windows", "aarch64").is_none());
+        assert!(target_for("freebsd", "x86_64").is_none());
+    }
+
+    #[test]
+    fn is_onnxruntime_lib_excludes_provider_siblings() {
+        assert!(is_onnxruntime_lib("libonnxruntime.1.20.1.dylib"));
+        assert!(is_onnxruntime_lib("libonnxruntime.so.1.20.1"));
+        assert!(is_onnxruntime_lib("onnxruntime.dll"));
+        // The providers siblings must never be picked.
+        assert!(!is_onnxruntime_lib("libonnxruntime_providers_shared.dylib"));
+        assert!(!is_onnxruntime_lib("onnxruntime_providers_shared.dll"));
+        assert!(!is_onnxruntime_lib("README.md"));
+    }
+
+    #[test]
+    fn extract_lib_zip_picks_the_dll() {
+        // Build a tiny .zip mirroring the Windows asset layout: a providers
+        // sibling (must be ignored) + the real onnxruntime.dll.
+        use std::io::Cursor;
+        use zip::write::SimpleFileOptions;
+
+        let mut buf = Vec::new();
+        {
+            let mut w = zip::ZipWriter::new(Cursor::new(&mut buf));
+            let opts = SimpleFileOptions::default();
+            w.start_file(
+                "onnxruntime-win-x64-1.20.1/lib/onnxruntime_providers_shared.dll",
+                opts,
+            )
+            .unwrap();
+            w.write_all(b"PROVIDER").unwrap();
+            w.start_file("onnxruntime-win-x64-1.20.1/lib/onnxruntime.dll", opts)
+                .unwrap();
+            w.write_all(b"REAL-DLL-BYTES").unwrap();
+            w.finish().unwrap();
+        }
+        let extracted = extract_lib(&buf, "zip").expect("should find onnxruntime.dll");
+        assert_eq!(extracted, b"REAL-DLL-BYTES");
     }
 }

--- a/crates/icm-core/src/fastembed_embedder.rs
+++ b/crates/icm-core/src/fastembed_embedder.rs
@@ -25,23 +25,32 @@ fn cache_dir() -> PathBuf {
         })
 }
 
-/// Best-effort check that the onnxruntime shared library is loadable, mirroring
-/// how `ort`'s load-dynamic backend resolves it: `ORT_DYLIB_PATH` if set, else
-/// the platform default name. Used only by the load-dynamic build (issue #345)
-/// to avoid ort's panic-on-missing-runtime under `panic = "abort"`.
-#[cfg(all(unix, feature = "embeddings-dynamic"))]
-fn onnxruntime_dylib_available() -> bool {
-    use std::ffi::CString;
+/// Resolve the onnxruntime library name `ort`'s load-dynamic backend would use:
+/// `ORT_DYLIB_PATH` if set, else the platform default name.
+#[cfg(all(any(unix, windows), feature = "embeddings-dynamic"))]
+fn onnxruntime_lib_name() -> String {
     let default_name = if cfg!(target_os = "macos") {
         "libonnxruntime.dylib"
+    } else if cfg!(target_os = "windows") {
+        "onnxruntime.dll"
     } else {
         "libonnxruntime.so"
     };
-    let name = match std::env::var("ORT_DYLIB_PATH") {
+    match std::env::var("ORT_DYLIB_PATH") {
         Ok(p) if !p.is_empty() => p,
         _ => default_name.to_string(),
-    };
-    let Ok(cname) = CString::new(name) else {
+    }
+}
+
+/// Best-effort check that the onnxruntime shared library is loadable, mirroring
+/// how `ort`'s load-dynamic backend resolves it. Used only by the load-dynamic
+/// build (issue #345) to avoid ort's panic-on-missing-runtime under
+/// `panic = "abort"` — we pre-flight the load and degrade to keyword-only rather
+/// than let the process abort.
+#[cfg(all(unix, feature = "embeddings-dynamic"))]
+fn onnxruntime_dylib_available() -> bool {
+    use std::ffi::CString;
+    let Ok(cname) = CString::new(onnxruntime_lib_name()) else {
         return false;
     };
     // SAFETY: `cname` is a valid NUL-terminated C string for the duration of the
@@ -55,6 +64,43 @@ fn onnxruntime_dylib_available() -> bool {
             true
         }
     }
+}
+
+/// Windows equivalent of the pre-flight, via raw `kernel32` `LoadLibraryW`
+/// (kernel32 is always linked on MSVC, so no extra crate is needed).
+#[cfg(all(windows, feature = "embeddings-dynamic"))]
+fn onnxruntime_dylib_available() -> bool {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn LoadLibraryW(lp_lib_file_name: *const u16) -> *mut core::ffi::c_void;
+        fn FreeLibrary(h_lib_module: *mut core::ffi::c_void) -> i32;
+    }
+
+    let wide: Vec<u16> = OsStr::new(&onnxruntime_lib_name())
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    // SAFETY: `wide` is a valid NUL-terminated UTF-16 string for the duration of
+    // the call; the returned handle is only tested for null and immediately freed.
+    unsafe {
+        let handle = LoadLibraryW(wide.as_ptr());
+        if handle.is_null() {
+            false
+        } else {
+            FreeLibrary(handle);
+            true
+        }
+    }
+}
+
+/// On exotic platforms with no dlopen/LoadLibrary probe, don't block: let ort
+/// resolve the runtime itself (these targets are not shipped, issue #345).
+#[cfg(all(not(any(unix, windows)), feature = "embeddings-dynamic"))]
+fn onnxruntime_dylib_available() -> bool {
+    true
 }
 
 pub struct FastEmbedder {
@@ -151,7 +197,7 @@ impl FastEmbedder {
         // instead: if it can't be dlopen'd, return a clean error (→ keyword-only
         // search) before ort ever initializes. Static builds link onnxruntime
         // in, so this check is compiled out there.
-        #[cfg(all(unix, feature = "embeddings-dynamic"))]
+        #[cfg(feature = "embeddings-dynamic")]
         if !onnxruntime_dylib_available() {
             return Err(IcmError::Embedding(
                 "onnxruntime runtime not found for this load-dynamic build; \
@@ -290,14 +336,16 @@ mod tests {
     // unavailable — this is what lets a load-dynamic build return a clean error
     // (→ keyword-only) instead of ort aborting under `panic = "abort"`. Run with
     // `cargo test -p icm-core --features embeddings-dynamic`.
-    #[cfg(all(unix, feature = "embeddings-dynamic"))]
+    #[cfg(all(any(unix, windows), feature = "embeddings-dynamic"))]
     #[test]
     fn missing_onnxruntime_dylib_is_reported_unavailable() {
+        let bogus = if cfg!(windows) {
+            r"C:\nonexistent\icm-test\onnxruntime-does-not-exist.dll"
+        } else {
+            "/nonexistent/icm-test/libonnxruntime-does-not-exist.so"
+        };
         let prev = std::env::var("ORT_DYLIB_PATH").ok();
-        std::env::set_var(
-            "ORT_DYLIB_PATH",
-            "/nonexistent/icm-test/libonnxruntime-does-not-exist.so",
-        );
+        std::env::set_var("ORT_DYLIB_PATH", bogus);
         assert!(
             !onnxruntime_dylib_available(),
             "a non-existent ORT_DYLIB_PATH must be detected as unavailable"


### PR DESCRIPTION
## What

Closes the last unix-only gap in the load-dynamic embeddings runtime (issue #345): **Windows** now gets the same first-launch opt-in onnxruntime download and graceful degradation as macOS/Linux.

## Changes
- **`ort_runtime.rs`** — `windows/x86_64` target: `onnxruntime-win-x64-1.20.1.zip` (pinned SHA256 `78d4…5581`, verified against the real Microsoft asset), a `.zip` extractor for `onnxruntime.dll` (uses zip's safe `enclosed_name`; the `onnxruntime_providers_*.dll` siblings are excluded by an exact-name match), and a cross-platform atomic install (Windows `rename` can't overwrite). Prompt/size text is per-target: **~65 MB on Windows** (MS bundles more; we extract only the one DLL) vs ~7 MB elsewhere.
- **`fastembed_embedder.rs`** — Windows `LoadLibraryW` pre-flight (raw `kernel32` FFI, **no new crate**) mirroring the unix `dlopen` probe, so a missing/bad `onnxruntime.dll` degrades to keyword-only instead of aborting under `panic = "abort"`.
- **`zip`** — optional dep gated to `embeddings-dynamic` (`zip 2.4.2`, `deflate` only).
- **CI** — new `load-dynamic embeddings (windows)` job: builds the dynamic variant, `icm embeddings download`, asserts `status` = installed, then a **purely-semantic** recall (query shares no keyword with the stored text). This is the only trustworthy proof that the pinned onnxruntime.dll loads under ort's ABI on Windows.

## Verification (real, not diff)
- Host (macOS arm64): dynamic e2e still passes after the refactor — fresh → download → semantic recall matches. ✅
- Unit tests green: `ort_runtime` (incl. new **zip-extract** + **target-table** tests) and the core pre-flight test. ✅
- `clippy -D warnings` on dynamic + default (static) builds; `fmt` clean. ✅
- **Windows compile + e2e** are proven by the new CI job below (can't run Windows locally).

## Out of scope (still #345)
Windows-on-ARM, the homebrew-core formula submission (unix-only anyway), fastembed 4→5.