### PR TITLE
chore(deps): bump anyhow + rand to clear RUSTSEC unsound advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -1282,7 +1282,7 @@ dependencies = [
  "libc",
  "log",
  "native-tls",
- "rand 0.9.2",
+ "rand 0.9.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -2635,9 +2635,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2727,7 +2727,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_chacha",
  "simd_helpers",
  "thiserror",
@@ -3544,7 +3544,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rayon",
  "rayon-cond",
  "regex",
@@ -3811,7 +3811,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.5",
  "web-time",
 ]
 


### PR DESCRIPTION
## What
Lockfile-only bump clearing the two **fixable** `cargo audit` advisories.

| Crate | Bump | Advisory |
|---|---|---|
| anyhow | 1.0.102 → 1.0.104 | RUSTSEC-2026-0190 (`Error::downcast_mut` unsound) |
| rand | 0.9.2 → 0.9.5 | RUSTSEC-2026-0097 (unsound with a custom logger) |

Both are semver-compatible, no manifest edits — only `Cargo.lock`. ICM wasn't actually exercising the affected APIs, but the bumps are free and remove the warnings.

## Not fixable in this PR (tracked)
- **crossbeam-epoch** RUSTSEC-2026-0204 (the one hard "vulnerability") — no patched release exists (0.9.18 is latest); pulled by `fastembed → image → rayon`.
- **core2** (yanked), **number_prefix**, **paste** (unmaintained) — same `fastembed → image` chain.
  → all resolved by the **fastembed 4→5** upgrade already tracked in #345.
- **lru** RUSTSEC-2026-0002 — pinned by `ratatui 0.29` (^0.12); needs ratatui 0.29→**0.30** (breaking API), so out of scope for a hygiene bump.

## Verification (real)
- `cargo audit`: warnings **7 → 5**, anyhow(0190) + rand(0097) gone.
- Full workspace **build + clippy + test** green (static **and** load-dynamic).
- `Cargo.lock` diff is exactly two version+checksum pairs — nothing else moved.

Context: the checksum/CVE audit that prompted this confirmed the onnxruntime download pipeline (5 pinned SHA256 match the real MS assets, verify-before-install) and the release/install/upgrade integrity are all sound.