### PR TITLE
fix(mcp): protocol-pure stdout, stdin cap during read, shared project detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,6 +1506,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "toml",
  "tracing",

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1575,7 +1575,12 @@ fn main() -> Result<()> {
         unsafe { libc::signal(libc::SIGPIPE, libc::SIG_DFL) };
     }
 
+    // Logs go to stderr, never stdout: `icm serve` speaks line-framed
+    // JSON-RPC on stdout, and the default fmt writer (stdout) would let a
+    // WARN line corrupt the MCP stream (audit finding — the server logs
+    // WARNs in normal operation, e.g. embedding or auto-decay hiccups).
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env()
                 .add_directive(tracing_subscriber::filter::LevelFilter::WARN.into()),
@@ -4080,70 +4085,11 @@ fn build_hook_start_pack(store: &Store, stdin_json: &str, max_tokens: usize) -> 
     Ok(out)
 }
 
-/// Extract a project name from a git remote URL.
-/// Handles HTTPS ("https://github.com/user/repo.git"),
-/// slash-SSH ("git@github.com:user/repo.git"), and
-/// colon-only SSH ("git@host:repo.git") formats.
-fn repo_name_from_url(url: &str) -> Option<String> {
-    // rsplit('/') always yields ≥1 element; split on ':' afterwards to
-    // handle SCP-style SSH URLs that have no slash before the repo name.
-    let after_slash = url.rsplit('/').next().unwrap_or(url);
-    let name = after_slash
-        .rsplit(':')
-        .next()
-        .unwrap_or(after_slash)
-        .trim_end_matches(".git");
-    if name.is_empty() {
-        None
-    } else {
-        Some(name.to_string())
-    }
-}
-
-/// Extract a project name from a filesystem path (basename), treating empty
-/// or root paths as "no project".
-fn project_from_path(path: &str) -> Option<String> {
-    if path.is_empty() {
-        return None;
-    }
-    let p = std::path::Path::new(path);
-
-    // Try git remote get-url origin (most unique identifier)
-    if let Ok(out) = std::process::Command::new("git")
-        .args(["remote", "get-url", "origin"])
-        .current_dir(p)
-        .output()
-    {
-        if out.status.success() {
-            let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
-            if let Some(name) = repo_name_from_url(&url) {
-                return Some(name);
-            }
-        }
-    }
-
-    // For worktrees without a remote: git-common-dir returns the main repo's
-    // .git as an absolute path, so its parent basename is the real project name.
-    if let Ok(out) = std::process::Command::new("git")
-        .args(["rev-parse", "--git-common-dir"])
-        .current_dir(p)
-        .output()
-    {
-        if out.status.success() {
-            let raw = out.stdout;
-            let common = std::str::from_utf8(&raw).unwrap_or("").trim();
-            let common_path = std::path::Path::new(common);
-            if common_path.is_absolute() {
-                if let Some(name) = common_path.parent().and_then(|r| r.file_name()) {
-                    return Some(name.to_string_lossy().to_string());
-                }
-            }
-        }
-    }
-
-    // Fallback: basename of the path itself
-    p.file_name().map(|n| n.to_string_lossy().to_string())
-}
+// Project-name detection lives in icm-core (`icm_core::project`) so the MCP
+// server derives the exact same name as the CLI hooks — a divergence here
+// meant memories stored under the git-remote name were recalled under the
+// cwd basename and silently missed (audit finding).
+use icm_core::project::project_from_path;
 
 /// Extract the project name from the `cwd` field of a hook JSON payload.
 /// Returns `None` if the field is absent or yields no project name.
@@ -9864,43 +9810,9 @@ mod hook_start_tests {
         assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
     }
 
-    #[test]
-    fn project_from_path_extracts_basename() {
-        assert_eq!(
-            project_from_path("/Users/patrick/dev/rtk-ai/icm"),
-            Some("icm".into())
-        );
-        assert_eq!(
-            project_from_path("/tmp/my-project"),
-            Some("my-project".into())
-        );
-        assert_eq!(project_from_path(""), None);
-    }
-
-    #[test]
-    fn project_from_path_uses_git_remote_over_basename() {
-        let dir = tempfile::tempdir().unwrap();
-        std::process::Command::new("git")
-            .args(["init"])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
-        std::process::Command::new("git")
-            .args([
-                "remote",
-                "add",
-                "origin",
-                "https://github.com/user/myproject.git",
-            ])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
-        // tempdir basename is a random name, not "myproject" — remote must win
-        assert_eq!(
-            project_from_path(dir.path().to_str().unwrap()),
-            Some("myproject".into())
-        );
-    }
+    // project_from_path / repo_name_from_url unit tests live with the code in
+    // icm-core (`icm_core::project::tests`) since the audit moved detection
+    // there to share it with the MCP server.
 
     // Linux-only: advisory `flock` on the macOS CI runners' temp filesystem is
     // unreliable in several ways — it has both failed to refuse a second
@@ -9932,45 +9844,6 @@ mod hook_start_tests {
         assert!(third.is_some(), "acquire should succeed after release");
     }
 
-    #[test]
-    fn project_from_path_handles_ssh_remote() {
-        let dir = tempfile::tempdir().unwrap();
-        std::process::Command::new("git")
-            .args(["init"])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
-        std::process::Command::new("git")
-            .args([
-                "remote",
-                "add",
-                "origin",
-                "git@github.com:user/sshproject.git",
-            ])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
-        assert_eq!(
-            project_from_path(dir.path().to_str().unwrap()),
-            Some("sshproject".into())
-        );
-    }
-
-    #[test]
-    fn repo_name_from_url_handles_scp_ssh_without_slash() {
-        // git@host:repo.git — no slash between host and repo name
-        assert_eq!(repo_name_from_url("git@host:repo.git"), Some("repo".into()));
-        assert_eq!(
-            repo_name_from_url("git@github.com:user/repo.git"),
-            Some("repo".into())
-        );
-        assert_eq!(
-            repo_name_from_url("https://github.com/user/repo.git"),
-            Some("repo".into())
-        );
-        assert_eq!(repo_name_from_url(""), None);
-    }
-
     /// Creates a git repo named "mainproject" with a worktree at "w1".
     /// Returns `(base_tempdir, worktree_path)` — keep `base` alive for the
     /// lifetime of the test or git will clean up the underlying directory.
@@ -9997,16 +9870,6 @@ mod hook_start_tests {
             .output()
             .unwrap();
         (base, worktree)
-    }
-
-    #[test]
-    fn project_from_path_uses_main_repo_name_for_worktree() {
-        let (_base, worktree) = make_worktree();
-        // w1 basename would give "w1"; must resolve to "mainproject" instead
-        assert_eq!(
-            project_from_path(worktree.to_str().unwrap()),
-            Some("mainproject".into())
-        );
     }
 
     #[test]

--- a/crates/icm-core/Cargo.toml
+++ b/crates/icm-core/Cargo.toml
@@ -32,3 +32,6 @@ tracing = { workspace = true }
 # onnxruntime dylib (dlopen) before ort initializes. See issue #345.
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod learn;
 pub mod memoir;
 pub mod memoir_store;
 pub mod memory;
+pub mod project;
 pub mod store;
 pub mod transcript;
 pub mod transcript_store;

--- a/crates/icm-core/src/project.rs
+++ b/crates/icm-core/src/project.rs
@@ -1,0 +1,193 @@
+//! Canonical project-name detection, shared by every surface that tags or
+//! filters memories by project (CLI hooks, MCP recall, HTTP API).
+//!
+//! Audit finding: the CLI hooks derived the project from the git remote
+//! (worktree- and rename-proof) while the MCP server used the cwd basename —
+//! so a renamed checkout stored memories under one project name and recalled
+//! under another, silently returning nothing. Both sides now share this
+//! module.
+
+/// Extract a project name from a git remote URL.
+/// Handles HTTPS ("https://github.com/user/repo.git"),
+/// slash-SSH ("git@github.com:user/repo.git"), and
+/// colon-only SSH ("git@host:repo.git") formats.
+pub fn repo_name_from_url(url: &str) -> Option<String> {
+    // rsplit('/') always yields ≥1 element; split on ':' afterwards to
+    // handle SCP-style SSH URLs that have no slash before the repo name.
+    let after_slash = url.rsplit('/').next().unwrap_or(url);
+    let name = after_slash
+        .rsplit(':')
+        .next()
+        .unwrap_or(after_slash)
+        .trim_end_matches(".git");
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+/// Extract a project name from a filesystem path (basename), treating empty
+/// or root paths as "no project".
+pub fn project_from_path(path: &str) -> Option<String> {
+    if path.is_empty() {
+        return None;
+    }
+    let p = std::path::Path::new(path);
+
+    // Try git remote get-url origin (most unique identifier)
+    if let Ok(out) = std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(p)
+        .output()
+    {
+        if out.status.success() {
+            let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if let Some(name) = repo_name_from_url(&url) {
+                return Some(name);
+            }
+        }
+    }
+
+    // For worktrees without a remote: git-common-dir returns the main repo's
+    // .git as an absolute path, so its parent basename is the real project name.
+    if let Ok(out) = std::process::Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .current_dir(p)
+        .output()
+    {
+        if out.status.success() {
+            let raw = out.stdout;
+            let common = std::str::from_utf8(&raw).unwrap_or("").trim();
+            let common_path = std::path::Path::new(common);
+            if common_path.is_absolute() {
+                if let Some(name) = common_path.parent().and_then(|r| r.file_name()) {
+                    return Some(name.to_string_lossy().to_string());
+                }
+            }
+        }
+    }
+
+    // Fallback: basename of the path itself
+    p.file_name().map(|n| n.to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_from_path_extracts_basename() {
+        assert_eq!(
+            project_from_path("/Users/patrick/dev/rtk-ai/icm"),
+            Some("icm".into())
+        );
+        assert_eq!(
+            project_from_path("/tmp/my-project"),
+            Some("my-project".into())
+        );
+        assert_eq!(project_from_path(""), None);
+    }
+
+    #[test]
+    fn project_from_path_uses_git_remote_over_basename() {
+        let dir = tempfile::tempdir().unwrap();
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/user/myproject.git",
+            ])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        // tempdir basename is a random name, not "myproject" — remote must win
+        assert_eq!(
+            project_from_path(dir.path().to_str().unwrap()),
+            Some("myproject".into())
+        );
+    }
+
+    #[test]
+    fn project_from_path_handles_ssh_remote() {
+        let dir = tempfile::tempdir().unwrap();
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:user/sshproject.git",
+            ])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert_eq!(
+            project_from_path(dir.path().to_str().unwrap()),
+            Some("sshproject".into())
+        );
+    }
+
+    #[test]
+    fn repo_name_from_url_handles_scp_ssh_without_slash() {
+        // git@host:repo.git — no slash between host and repo name
+        assert_eq!(repo_name_from_url("git@host:repo.git"), Some("repo".into()));
+        assert_eq!(
+            repo_name_from_url("git@github.com:user/repo.git"),
+            Some("repo".into())
+        );
+        assert_eq!(
+            repo_name_from_url("https://github.com/user/repo.git"),
+            Some("repo".into())
+        );
+        assert_eq!(repo_name_from_url(""), None);
+    }
+
+    /// Creates a git repo named "mainproject" with a worktree at "w1".
+    /// Returns `(base_tempdir, worktree_path)` — keep `base` alive for the
+    /// lifetime of the test or git will clean up the underlying directory.
+    fn make_worktree() -> (tempfile::TempDir, std::path::PathBuf) {
+        let base = tempfile::tempdir().unwrap();
+        let main_repo = base.path().join("mainproject");
+        std::fs::create_dir(&main_repo).unwrap();
+        for args in [
+            vec!["init"],
+            vec!["config", "user.email", "test@test.com"],
+            vec!["config", "user.name", "Test"],
+            vec!["commit", "--allow-empty", "-m", "init"],
+        ] {
+            std::process::Command::new("git")
+                .args(&args)
+                .current_dir(&main_repo)
+                .output()
+                .unwrap();
+        }
+        let worktree = base.path().join("w1");
+        std::process::Command::new("git")
+            .args(["worktree", "add", "--detach", worktree.to_str().unwrap()])
+            .current_dir(&main_repo)
+            .output()
+            .unwrap();
+        (base, worktree)
+    }
+
+    #[test]
+    fn project_from_path_uses_main_repo_name_for_worktree() {
+        let (_base, worktree) = make_worktree();
+        // w1 basename would give "w1"; must resolve to "mainproject" instead
+        assert_eq!(
+            project_from_path(worktree.to_str().unwrap()),
+            Some("mainproject".into())
+        );
+    }
+}

--- a/crates/icm-mcp/src/server.rs
+++ b/crates/icm-mcp/src/server.rs
@@ -1,4 +1,4 @@
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, Read, Write};
 
 use serde_json::{json, Value};
 use tracing::{debug, error};
@@ -16,9 +16,41 @@ const PROTOCOL_VERSION: &str = "2024-11-05";
 /// Number of non-store tool calls before we nudge the agent to store.
 const STORE_NUDGE_THRESHOLD: u32 = 10;
 
-/// Maximum allowed line length (10 MB). Lines exceeding this are rejected
-/// without parsing to prevent memory exhaustion.
+/// Maximum allowed line length (10 MB). The cap is enforced *while reading*
+/// (bounded `take` + `read_until`), so an oversized line is never fully
+/// buffered — previously the whole line was allocated by `lines()` before
+/// the length check ran, defeating the cap (audit finding; same class of
+/// bug as the CLI hook-stdin fix in e551c27).
 const MAX_LINE_LEN: usize = 10 * 1024 * 1024;
+
+/// Read one `\n`-terminated line into `buf` without ever buffering more than
+/// `MAX_LINE_LEN + 1` bytes of it. Returns `Ok(None)` on EOF, `Ok(Some(true))`
+/// for a within-limit line, `Ok(Some(false))` for an oversized line (whose
+/// remainder has been drained and discarded in bounded chunks).
+fn read_capped_line(reader: &mut impl BufRead, buf: &mut Vec<u8>) -> io::Result<Option<bool>> {
+    buf.clear();
+    let n = reader
+        .take(MAX_LINE_LEN as u64 + 1)
+        .read_until(b'\n', buf)?;
+    if n == 0 {
+        return Ok(None); // EOF
+    }
+    // Oversized iff we exhausted the read budget without hitting the newline.
+    if buf.last() != Some(&b'\n') && n == MAX_LINE_LEN + 1 {
+        // Drain the rest of the line in bounded chunks so the next read
+        // starts on a fresh line.
+        let mut scratch = Vec::with_capacity(64 * 1024);
+        loop {
+            scratch.clear();
+            let m = reader.take(1024 * 1024).read_until(b'\n', &mut scratch)?;
+            if m == 0 || scratch.last() == Some(&b'\n') {
+                break;
+            }
+        }
+        return Ok(Some(false));
+    }
+    Ok(Some(true))
+}
 
 /// Run the MCP server on stdio. Blocks until stdin is closed.
 pub fn run_server(
@@ -28,31 +60,35 @@ pub fn run_server(
     auto_consolidate: AutoConsolidate,
 ) -> anyhow::Result<()> {
     let stdin = io::stdin();
+    let mut reader = stdin.lock();
     let mut stdout = io::stdout();
     let mut calls_since_store: u32 = 0;
+    let mut buf: Vec<u8> = Vec::new();
 
-    for line in stdin.lock().lines() {
-        let line = match line {
-            Ok(l) => l,
+    loop {
+        let within_limit = match read_capped_line(&mut reader, &mut buf) {
+            Ok(Some(ok)) => ok,
+            Ok(None) => break, // EOF
             Err(e) => {
                 error!("stdin read error: {e}");
                 break;
             }
         };
 
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        if line.len() > MAX_LINE_LEN {
-            error!("line too long: {} bytes (max {MAX_LINE_LEN})", line.len());
+        if !within_limit {
+            error!("line too long (max {MAX_LINE_LEN} bytes)");
             let resp = JsonRpcResponse::err(
                 Value::Null,
                 -32600,
-                format!("line too long: {} bytes (max {MAX_LINE_LEN})", line.len()),
+                format!("line too long (max {MAX_LINE_LEN} bytes)"),
             );
             write_response(&mut stdout, &resp)?;
+            continue;
+        }
+
+        let line_owned = String::from_utf8_lossy(&buf);
+        let line = line_owned.trim();
+        if line.is_empty() {
             continue;
         }
 

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -1227,11 +1227,13 @@ fn tool_recall(
     // `recall_context` path (extract.rs) so MCP-side recall can't leak
     // memories from other projects. Caller can override via the explicit
     // `project` arg (empty string disables the filter); otherwise we
-    // derive it from the server's cwd.
+    // derive it from the server's cwd via the shared icm-core detection
+    // (git remote first) — the CLI hooks store under that name, so a raw
+    // cwd basename would silently miss on renamed checkouts (audit finding).
     let project_arg = get_str(args, "project");
     let cwd_project = std::env::current_dir()
         .ok()
-        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()));
+        .and_then(|p| icm_core::project::project_from_path(&p.to_string_lossy()));
     let project: Option<String> = match project_arg {
         Some("") => None,
         Some(p) => Some(p.to_string()),


### PR DESCRIPTION
## 3 fixes MCP issus de l'audit complet

1. **Logs tracing → stderr** (`main.rs`) — le writer par défaut est stdout, partagé avec le JSON-RPC ligne-par-ligne de `icm serve` ; un WARN en fonctionnement normal (« embedding failed », « auto-decay failed ») pouvait corrompre le flux MCP.
2. **Cap stdin appliqué PENDANT la lecture** (`server.rs`) — `lines()` allouait la ligne entière avant le test 10 MB (même classe de bug que le fix hook CLI e551c27). Désormais : `take` borné + `read_until`, reste de ligne drainé par chunks bornés → une ligne de plusieurs GB ne peut plus épuiser la mémoire.
3. **Détection projet partagée** (`icm_core::project`) — le MCP filtrait les recalls sur le **basename du cwd** alors que les hooks CLI stockent sous le **nom du remote git** : un checkout renommé ratait silencieusement ses recalls. Les deux surfaces utilisent maintenant le même module (remote → worktree → basename), tests unitaires déplacés avec le code (worktree, SSH, SCP).

## Vérification (réelle)
E2E sur le binaire : session JSON-RPC pipée avec `initialize` → `store` → **ligne de 12 MB** → `ping` :
- la ligne surdimensionnée reçoit `-32600` sans être bufferisée, **le serveur survit** et répond au ping ✅
- stdout = 100 % JSON valide (vérifié ligne par ligne), le log ERROR part sur stderr ✅

10 tests projet verts dans icm-core (dont worktree + remotes SSH), 78 tests icm-mcp verts, workspace + clippy `-D warnings` + fmt clean.