### PR TITLE
ci: fix pr-target-check, compile web feature, lifecycle e2e, postgres service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,10 @@ jobs:
       - name: Run postgres integration tests
         env:
           ICM_POSTGRES_URL: postgres://icm:icm@127.0.0.1:55432/icm
+          # Backend selection is a RUNTIME switch (default: sqlite). Without
+          # this the no-default-features build errors out asking for the
+          # sqlite feature before ever touching postgres.
+          ICM_DB_BACKEND: postgres
         run: |
           cargo test -p icm-store --no-default-features --features postgres \
             --test postgres_backend -- --nocapture 2>&1 | tee pg.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets -- -D warnings
+      # The `web` feature is off by default and was never compiled anywhere in
+      # CI — a breakage in web.rs would ship unnoticed (audit finding).
+      - name: Check non-default `web` feature compiles
+        run: cargo clippy -p icm-cli --features web --all-targets -- -D warnings
 
   # ─── Parallel gates (require code to compile) ───
 
@@ -138,6 +142,24 @@ jobs:
           ICM_CONFIG="$cfg" "$bin" --db "$db" recall "a fast animal leaping above a sleepy canine" | grep -qi fox \
             && echo "OK: downloaded onnxruntime loads under ort and embeds" \
             || { echo "FAIL: semantic search did not work with the downloaded runtime"; exit 1; }
+      - name: Lifecycle e2e (store → recall → decay → prune)
+        # The full memory lifecycle was only covered by unit tests — nothing
+        # proved the shipped binary chains it end-to-end (audit finding). A
+        # medium-importance memory decayed to 0.05 must fall to prune at 0.5,
+        # and recall must no longer return it.
+        run: |
+          bin=target/debug/icm
+          db="$RUNNER_TEMP/life.db"
+          "$bin" --no-embeddings --db "$db" store -t lifecycle -c "lifecycle probe alpha"
+          "$bin" --no-embeddings --db "$db" recall alpha | grep -qi "lifecycle probe alpha" \
+            || { echo "FAIL: stored memory not recalled"; exit 1; }
+          "$bin" --no-embeddings --db "$db" decay -f 0.05
+          "$bin" --no-embeddings --db "$db" prune -t 0.5
+          if "$bin" --no-embeddings --db "$db" recall alpha | grep -qi "lifecycle probe alpha"; then
+            echo "FAIL: memory survived decay+prune"; exit 1
+          else
+            echo "OK: lifecycle store → recall → decay → prune verified end-to-end"
+          fi
 
   # Same load-dynamic variant on Windows (issue #345): the onnxruntime asset is a
   # `.zip` (not the unix `.tgz`) and the runtime is `onnxruntime.dll`, so this
@@ -191,6 +213,45 @@ jobs:
           ICM_CONFIG="$cfg" "$bin" --db "$db" recall "a fast animal leaping above a sleepy canine" | grep -qi fox \
             && echo "OK: downloaded onnxruntime.dll loads under ort and embeds" \
             || { echo "FAIL: semantic search did not work with the downloaded runtime"; exit 1; }
+
+  # The postgres backend ships in the DEFAULT binary but its integration
+  # tests skip without ICM_POSTGRES_URL, which no workflow ever set — the
+  # backend had zero CI execution (audit finding). pgvector/pgvector matches
+  # the image the test header documents. (opensearch: same gap, heavier
+  # container — tracked separately.)
+  postgres-backend:
+    name: postgres backend tests
+    needs: clippy
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: icm
+          POSTGRES_PASSWORD: icm
+          POSTGRES_DB: icm
+        ports:
+          - 55432:5432
+        options: >-
+          --health-cmd "pg_isready -U icm"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run postgres integration tests
+        env:
+          ICM_POSTGRES_URL: postgres://icm:icm@127.0.0.1:55432/icm
+        run: |
+          cargo test -p icm-store --no-default-features --features postgres \
+            --test postgres_backend -- --nocapture 2>&1 | tee pg.log
+          test "${PIPESTATUS[0]}" -eq 0 || exit 1
+          # The skip guard must NOT have fired — prove the tests actually ran.
+          if grep -q "skipping: ICM_POSTGRES_URL not set" pg.log; then
+            echo "FAIL: tests skipped despite the service container"; exit 1
+          fi
 
   security:
     name: security scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,8 +249,11 @@ jobs:
           # sqlite feature before ever touching postgres.
           ICM_DB_BACKEND: postgres
         run: |
+          # --test-threads=1: both tests migrate the same shared database, and
+          # concurrent `CREATE EXTENSION IF NOT EXISTS vector` races in
+          # Postgres (duplicate-key on the catalog) — seen flaking in CI.
           cargo test -p icm-store --no-default-features --features postgres \
-            --test postgres_backend -- --nocapture 2>&1 | tee pg.log
+            --test postgres_backend -- --nocapture --test-threads=1 2>&1 | tee pg.log
           test "${PIPESTATUS[0]}" -eq 0 || exit 1
           # The skip guard must NOT have fired — prove the tests actually ran.
           if grep -q "skipping: ICM_POSTGRES_URL not set" pg.log; then

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -7,11 +7,20 @@ on:
 jobs:
   check-target:
     runs-on: ubuntu-latest
+    # The default GITHUB_TOKEN is read-only; without these the addLabels call
+    # 403s ("Resource not accessible by integration") and the job could never
+    # succeed — even on a genuinely wrong-base PR (audit finding).
+    permissions:
+      pull-requests: write
+      issues: write
     # Only flag PRs targeting main that don't come from develop. develop→main
-    # PRs are the maintainer release path and must not be flagged.
+    # PRs are the maintainer release path, and release-please's version-bump
+    # PRs (head `release-please--branches--main--…`) legitimately target main
+    # too — they were flagged (then 403'd) on every release, e.g. #343/#349.
     if: >-
       github.event.pull_request.base.ref == 'main' &&
-      github.event.pull_request.head.ref != 'develop'
+      github.event.pull_request.head.ref != 'develop' &&
+      !startsWith(github.event.pull_request.head.ref, 'release-please--')
     steps:
       - name: Add wrong-base label and comment
         uses: actions/github-script@v7


### PR DESCRIPTION
## 4 fixes « CI truth » issus de l'audit

1. **`pr-target-check` ne pouvait JAMAIS réussir** — pas de bloc `permissions:` (token read-only → 403 sur `addLabels`, vérifié dans les logs des runs #343/#349) **et** pas d'exemption release-please (leurs PRs de bump ciblent légitimement main). Fix : permissions `pull-requests`/`issues: write` + `!startsWith(head.ref, 'release-please--')`.
2. **Feature `web` jamais compilée en CI** (639 lignes de web.rs) → step clippy dédié (vérifié passant en local).
3. **E2E lifecycle** : `store → recall → decay -f 0.05 → prune -t 0.5 → recall vide` — la chaîne complète n'était couverte qu'en unitaire. Validé en local avant push (`Decay applied… / Pruned 1 memories… / OK pruned`).
4. **Job `postgres-backend`** avec service `pgvector/pgvector:pg16` : le backend postgres est **dans le binaire par défaut** mais ses tests d'intégration se skippaient sans `ICM_POSTGRES_URL` (jamais défini) — zéro exécution CI. Le job échoue aussi si le guard de skip se déclenche (les skips silencieux ne peuvent pas revenir). opensearch = même gap, container plus lourd, suivi séparément.

## Vérification
- YAML validé, lifecycle e2e + clippy web passés en local avant push.
- Le vrai test de #1 sera la prochaine PR release-please (le job sera *skipped* au lieu de *fail*).