### PR TITLE
chore: feature-gate bench suite, warn on postgres auto-consolidate no-op, fix config docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,11 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets -- -D warnings
-      # The `web` feature is off by default and was never compiled anywhere in
-      # CI — a breakage in web.rs would ship unnoticed (audit finding).
-      - name: Check non-default `web` feature compiles
-        run: cargo clippy -p icm-cli --features web --all-targets -- -D warnings
+      # The `web` and `bench` features are off by default and would otherwise
+      # never be compiled in CI — a breakage would ship unnoticed (audit
+      # finding).
+      - name: Check non-default `web` + `bench` features compile
+        run: cargo clippy -p icm-cli --features web,bench --all-targets -- -D warnings
 
   # ─── Parallel gates (require code to compile) ───
 

--- a/crates/icm-cli/Cargo.toml
+++ b/crates/icm-cli/Cargo.toml
@@ -41,6 +41,10 @@ http-api = ["dep:axum", "dep:tokio"]
 # Full web dashboard (SvelteKit SPA + auth). Pulls everything `http-api`
 # does plus the embedded-assets stack.
 web = ["http-api", "dep:tower-http", "dep:rust-embed", "dep:mime_guess", "dep:getrandom"]
+# Benchmark suite (`icm bench*`): ~30 KB of synthetic fixtures + an agent
+# harness that shells out to `claude`. Dev/CI tooling, not shipped in the
+# production binary (audit finding).
+bench = []
 # `openssl` is not used directly in our source code, but it gets pulled
 # transitively via reqwest / hyper-tls / etc. (depending on the active
 # feature set). On cross-builds (e.g. aarch64-unknown-linux-gnu) the

--- a/crates/icm-cli/src/config.rs
+++ b/crates/icm-cli/src/config.rs
@@ -2,8 +2,14 @@
 //!
 //! Lookup order:
 //! 1. `$ICM_CONFIG` environment variable
-//! 2. `~/.config/icm/config.toml`
+//! 2. The platform config dir (`ProjectDirs("dev","icm","icm")`):
+//!    - Linux:   `~/.config/icm/config.toml`
+//!    - macOS:   `~/Library/Application Support/dev.icm.icm/config.toml`
+//!    - Windows: `%APPDATA%\icm\icm\config\config.toml`
 //! 3. Built-in defaults (everything is optional)
+//!
+//! (`icm config` prints the active path — the old header claimed
+//! `~/.config/icm/` everywhere, which is wrong on macOS/Windows.)
 
 use std::path::PathBuf;
 

--- a/crates/icm-cli/src/extract.rs
+++ b/crates/icm-cli/src/extract.rs
@@ -21,6 +21,7 @@ type ScoredFact = (String, String, Importance, Option<AnchorKind>);
 
 /// Extract key facts from text and store them in ICM.
 /// Returns the number of facts stored.
+#[cfg(any(test, feature = "bench"))]
 pub fn extract_and_store(store: &Store, text: &str, project: &str) -> Result<usize> {
     extract_and_store_with_opts(store, text, project, false, Importance::Critical)
 }
@@ -38,6 +39,7 @@ pub fn extract_and_store(store: &Store, text: &str, project: &str) -> Result<usi
 ///
 /// This variant uses the English-only keyword scorer. For multilingual
 /// content prefer [`extract_and_store_with_embedder`].
+#[cfg(any(test, feature = "bench"))]
 pub fn extract_and_store_with_opts(
     store: &Store,
     text: &str,

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1,6 +1,12 @@
 mod archive;
+// The bench suite embeds ~30 KB of synthetic fixtures (a full fake Rust
+// project) and ships agent-benchmark harness code; none of it belongs in the
+// production binary (audit finding). Compiled only with `--features bench`.
+#[cfg(feature = "bench")]
 mod bench_data;
+#[cfg(feature = "bench")]
 mod bench_format;
+#[cfg(feature = "bench")]
 mod bench_knowledge;
 
 pub mod cloud;
@@ -480,6 +486,7 @@ enum Commands {
     },
 
     /// Run performance benchmark on in-memory store
+    #[cfg(feature = "bench")]
     Bench {
         /// Number of memories to seed
         #[arg(short, long, default_value = "1000")]
@@ -645,6 +652,7 @@ enum Commands {
     },
 
     /// Benchmark memory recall accuracy with and without ICM
+    #[cfg(feature = "bench")]
     BenchRecall {
         /// Model to use
         #[arg(short, long, default_value = "sonnet")]
@@ -660,6 +668,7 @@ enum Commands {
     },
 
     /// Benchmark Claude Code efficiency with and without ICM
+    #[cfg(feature = "bench")]
     BenchAgent {
         /// Number of sessions per mode
         #[arg(short, long, default_value = "10")]
@@ -685,6 +694,7 @@ enum Commands {
     /// `ANTHROPIC_API_KEY` set, also calls the Anthropic `count_tokens`
     /// API for true token counts (lets you see the Opus 4.7 tokenizer
     /// inflation directly).
+    #[cfg(feature = "bench")]
     BenchFormat {
         /// Number of synthetic memories in the fixture
         #[arg(short, long, default_value = "10")]
@@ -2110,18 +2120,22 @@ fn main() -> Result<()> {
         }
         Commands::Config => cmd_config(),
         Commands::Upgrade { apply, check } => upgrade::cmd_upgrade(apply, check),
+        #[cfg(feature = "bench")]
         Commands::Bench { count } => cmd_bench(count),
+        #[cfg(feature = "bench")]
         Commands::BenchRecall {
             model,
             runs,
             verbose,
         } => cmd_bench_recall(&model, runs, verbose),
+        #[cfg(feature = "bench")]
         Commands::BenchAgent {
             sessions,
             model,
             runs,
             verbose,
         } => cmd_bench_agent(sessions, &model, runs, verbose),
+        #[cfg(feature = "bench")]
         Commands::BenchFormat {
             count,
             model,
@@ -7837,6 +7851,7 @@ fn print_memory_detail(mem: &Memory, score: Option<f32>) {
 // Benchmark
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "bench")]
 fn cmd_bench(count: usize) -> Result<()> {
     const DIMS: usize = 384;
     const SEARCH_ITERS: usize = 100;
@@ -7991,6 +8006,7 @@ impl Drop for CleanupDir {
     }
 }
 
+#[cfg(feature = "bench")]
 fn cmd_bench_recall(model: &str, runs: usize, verbose: bool) -> Result<()> {
     // Check claude is in PATH
     let check = std::process::Command::new("claude")
@@ -8236,6 +8252,7 @@ fn cmd_bench_recall(model: &str, runs: usize, verbose: bool) -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "bench")]
 fn cmd_bench_agent(sessions: usize, model: &str, runs: usize, verbose: bool) -> Result<()> {
     // Check claude is in PATH
     let check = std::process::Command::new("claude")

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -34,6 +34,7 @@ mod upgrade;
 mod web;
 
 use std::path::{Path, PathBuf};
+#[cfg(feature = "bench")]
 use std::time::Instant;
 
 use anyhow::{bail, Context, Result};
@@ -7964,6 +7965,7 @@ fn cmd_bench(count: usize) -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "bench")]
 fn print_bench_row(label: &str, ops: usize, total_ms: f64) {
     let per_op = total_ms / ops as f64;
     let (total_str, per_str) = (format_duration(total_ms), format_duration(per_op));
@@ -7973,6 +7975,7 @@ fn print_bench_row(label: &str, ops: usize, total_ms: f64) {
     );
 }
 
+#[cfg(feature = "bench")]
 fn format_duration(ms: f64) -> String {
     if ms < 0.001 {
         format!("{:.1} ns", ms * 1_000_000.0)
@@ -7989,6 +7992,7 @@ fn format_duration(ms: f64) -> String {
 // Agent Benchmark
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "bench")]
 struct SessionResult {
     num_turns: u64,
     input_tokens: u64,
@@ -7998,8 +8002,10 @@ struct SessionResult {
     response: String,
 }
 
+#[cfg(feature = "bench")]
 struct CleanupDir(PathBuf);
 
+#[cfg(feature = "bench")]
 impl Drop for CleanupDir {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.0);
@@ -8437,6 +8443,7 @@ fn cmd_bench_agent(sessions: usize, model: &str, runs: usize, verbose: bool) -> 
     Ok(())
 }
 
+#[cfg(feature = "bench")]
 fn pct_delta(a: f64, b: f64) -> f64 {
     if a == 0.0 {
         0.0
@@ -8445,6 +8452,7 @@ fn pct_delta(a: f64, b: f64) -> f64 {
     }
 }
 
+#[cfg(feature = "bench")]
 fn run_claude_session(
     prompt: &str,
     model: &str,
@@ -8511,6 +8519,7 @@ fn run_claude_session(
     Ok(parse_session_result(&json, wall_ms))
 }
 
+#[cfg(feature = "bench")]
 fn parse_session_result(json: &Value, wall_ms: u64) -> SessionResult {
     let num_turns = json.get("num_turns").and_then(|v| v.as_u64()).unwrap_or(1);
 
@@ -8564,6 +8573,7 @@ fn parse_session_result(json: &Value, wall_ms: u64) -> SessionResult {
     }
 }
 
+#[cfg(feature = "bench")]
 fn display_bench_results(
     without: &[SessionResult],
     with_icm: &[SessionResult],
@@ -8695,6 +8705,7 @@ fn display_bench_results(
     );
 }
 
+#[cfg(feature = "bench")]
 fn display_bench_results_averaged(
     all_wo: &[Vec<SessionResult>],
     all_wi: &[Vec<SessionResult>],
@@ -8847,6 +8858,7 @@ fn display_bench_results_averaged(
     }
 }
 
+#[cfg(feature = "bench")]
 fn aggregate_results(results: &[SessionResult]) -> SessionResult {
     SessionResult {
         num_turns: results.iter().map(|s| s.num_turns).sum(),
@@ -8858,6 +8870,7 @@ fn aggregate_results(results: &[SessionResult]) -> SessionResult {
     }
 }
 
+#[cfg(feature = "bench")]
 fn fmt_tokens(n: u64) -> String {
     if n >= 1_000_000 {
         format!("{:.1}M", n as f64 / 1_000_000.0)
@@ -8868,6 +8881,7 @@ fn fmt_tokens(n: u64) -> String {
     }
 }
 
+#[cfg(feature = "bench")]
 fn fmt_delta(without: f64, with_icm: f64) -> String {
     if without == 0.0 {
         return "N/A".into();
@@ -8880,14 +8894,17 @@ fn fmt_delta(without: f64, with_icm: f64) -> String {
     }
 }
 
+#[cfg(feature = "bench")]
 fn fmt_cost(c: f64) -> String {
     format!("${c:.4}")
 }
 
+#[cfg(feature = "bench")]
 fn fmt_duration_s(ms: u64) -> String {
     format!("{:.1}s", ms as f64 / 1000.0)
 }
 
+#[cfg(feature = "bench")]
 fn truncate_words(s: &str, max_chars: usize) -> String {
     let s = s.replace('\n', " ");
     if s.len() <= max_chars {

--- a/crates/icm-store/src/postgres.rs
+++ b/crates/icm-store/src/postgres.rs
@@ -331,6 +331,18 @@ pub struct PostgresStore {
     readonly: bool,
 }
 
+/// One-shot warning that auto-consolidation silently does nothing on this
+/// backend (see [`PostgresStore::auto_consolidate`]).
+fn warn_auto_consolidate_unsupported() {
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+        tracing::warn!(
+            "auto-consolidation is not implemented on the PostgreSQL backend; \
+             topics will keep growing (auto_consolidate_enabled has no effect here)"
+        );
+    });
+}
+
 impl PostgresStore {
     fn conn(&self) -> IcmResult<MutexGuard<'_, Client>> {
         self.client.lock().map_err(|_| lock_err())
@@ -901,8 +913,12 @@ impl PostgresStore {
 
     /// Auto-consolidation is not yet implemented on the PostgreSQL
     /// backend; the call is a no-op (returns "did not consolidate") so the
-    /// normal store path is unaffected.
+    /// normal store path is unaffected. Unlike the other parity gaps (which
+    /// return `Unsupported`), this one is silent by design — but the user
+    /// deserves to know their `auto_consolidate_enabled = true` does nothing
+    /// here, so warn once per process (audit finding).
     pub fn auto_consolidate(&self, _topic: &str, _threshold: usize) -> IcmResult<bool> {
+        warn_auto_consolidate_unsupported();
         Ok(false)
     }
 
@@ -913,6 +929,7 @@ impl PostgresStore {
         _threshold: usize,
         _embedder: Option<&dyn Embedder>,
     ) -> IcmResult<bool> {
+        warn_auto_consolidate_unsupported();
         Ok(false)
     }
 


### PR DESCRIPTION
## 3 quick-wins de l'audit

1. **Suite bench sortie du binaire de prod** — `bench_data` (~30 KB de fixtures : un faux projet Rust complet), les 4 commandes `bench*` et le harness qui shell-out vers `claude` étaient compilés dans **chaque release sans aucun cfg**. Désormais gated `--features bench` (off par défaut) ; `icm bench` disparaît du help shippé (vérifié).
2. **`auto_consolidate` Postgres : no-op silencieux → warn** — un utilisateur avec `auto_consolidate_enabled = true` croyait que ça consolidait. Warn unique par process (via `Once`) : « topics will keep growing ».
3. **Doc header config.rs faux sur macOS/Windows** — affirmait `~/.config/icm/` partout ; les 3 chemins réels (`ProjectDirs`) sont maintenant listés.

Reporté (avec le futur découpage de main.rs) : dédoublonnage du rituel `emb_ref` (19 sites, pur refactor sans bug).

## Vérification
- Build prod (sans bench) + build `--features bench` : les deux compilent, clippy `-D warnings` sur les deux variantes + postgres.
- 292 tests icm-cli verts sur les deux variantes.
- `target/debug/icm --help` ne mentionne plus bench dans le binaire prod ✓