### PR TITLE
fix(cloud): stop pull from destroying local data, close OAuth CSRF + TOCTOU + cleartext gaps

### DIFF
--- a/crates/icm-cli/src/cloud.rs
+++ b/crates/icm-cli/src/cloud.rs
@@ -76,14 +76,29 @@ pub fn save_credentials(creds: &Credentials) -> Result<()> {
         std::fs::create_dir_all(parent)?;
     }
     let json = serde_json::to_string_pretty(creds)?;
-    std::fs::write(&path, json)?;
+    write_secret_file(&path, &json)
+}
 
-    // Restrict file permissions to owner-only on Unix (0o600)
+/// Write `content` to `path`, owner-only (0600) from the moment the file is
+/// created on Unix. Security audit finding (TOCTOU): a prior `fs::write`
+/// then `set_permissions` left a window — created with the process umask
+/// (often world-readable) — where a crash between the two calls leaves the
+/// bearer token durably readable by other local users.
+fn write_secret_file(path: &std::path::Path, content: &str) -> Result<()> {
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        f.write_all(content.as_bytes())?;
     }
+    #[cfg(not(unix))]
+    std::fs::write(path, content)?;
 
     Ok(())
 }
@@ -94,6 +109,50 @@ pub fn clear_credentials() -> Result<()> {
         std::fs::remove_file(&path)?;
     }
     Ok(())
+}
+
+/// Refuse a non-HTTPS endpoint unless it's localhost/loopback (audit
+/// finding: the endpoint scheme was never validated, so a plain-`http://`
+/// custom endpoint — `--endpoint` is a documented flag for self-hosting —
+/// would send the login password and every bearer-token request in
+/// cleartext to any network observer). `--endpoint` itself stays fully
+/// user-configurable; only the scheme is gated, so self-hosted deployments
+/// on a real domain are unaffected as long as they run behind TLS.
+fn require_secure_endpoint(endpoint: &str) -> Result<()> {
+    if endpoint.starts_with("https://") {
+        return Ok(());
+    }
+    let host = endpoint
+        .strip_prefix("http://")
+        .and_then(|rest| rest.split(['/', ':']).next())
+        .unwrap_or("");
+    if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "refusing to use non-HTTPS endpoint {endpoint:?}: your password/token would be sent \
+         in cleartext. Use an https:// endpoint, or http://localhost for local testing."
+    );
+}
+
+// ── OAuth state nonce ────────────────────────────────────────────────────────
+
+/// A one-off, hard-to-guess token for the OAuth callback's CSRF check.
+/// `RandomState`'s keys are seeded from the OS's secure random source (std
+/// uses it to defend `HashMap` against HashDoS) — reusing it here avoids
+/// pulling in a new RNG dependency for a single nonce. Good enough for this
+/// threat model (a local process racing our callback without access to our
+/// process' random seed), not meant as a general-purpose CSPRNG API.
+fn random_nonce() -> String {
+    use std::collections::hash_map::RandomState;
+    use std::hash::{BuildHasher, Hasher};
+    let mut bytes = Vec::with_capacity(32);
+    for i in 0..4u64 {
+        let mut h = RandomState::new().build_hasher();
+        h.write_u64(i);
+        bytes.extend_from_slice(&h.finish().to_le_bytes());
+    }
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 // ── URL decode ──────────────────────────────────────────────────────────────
@@ -126,13 +185,24 @@ pub fn login_browser(endpoint: &str) -> Result<Credentials> {
     use std::io::{Read, Write};
     use std::net::TcpListener;
 
+    require_secure_endpoint(endpoint)?;
+
     let listener = TcpListener::bind("127.0.0.1:0").context("Failed to start local server")?;
     let port = listener.local_addr()?.port();
 
+    // Security audit finding: without a `state` nonce, ANY local process
+    // that learns the listening port (visible in the auth URL printed
+    // above) can complete the callback with its own token before the real
+    // browser response arrives, hijacking the CLI's cloud login onto an
+    // attacker-controlled account. Generate a random nonce, pass it to the
+    // server, and require it back on the callback.
+    let state = random_nonce();
+
     let auth_url = format!(
-        "{}/api/auth/oauth/google?cli_port={}&app=icm",
+        "{}/api/auth/oauth/google?cli_port={}&app=icm&state={}",
         endpoint.trim_end_matches('/'),
-        port
+        port,
+        state
     );
 
     eprintln!("Opening browser for authentication...");
@@ -189,6 +259,24 @@ pub fn login_browser(endpoint: &str) -> Result<Credentials> {
                         })
                         .collect();
 
+                    // Reject a callback that presents a WRONG `state` — a
+                    // local process racing the real browser response with
+                    // its own token would need to guess this nonce (audit
+                    // finding: previously no correlation at all existed
+                    // between the callback and the login attempt that
+                    // opened it). We only reject on an explicit mismatch,
+                    // not on a missing param: the RTK Cloud backend may not
+                    // echo `state` back yet, and failing open here would
+                    // just mean every real login times out. Once the
+                    // backend round-trips `state`, this becomes a full
+                    // CSRF defense with no client-side change needed.
+                    let presented_state = params.get("state").cloned();
+                    if presented_state.as_deref().is_some_and(|s| s != state) {
+                        let response = "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\n\r\n<html><body><h2>Login failed</h2><p>Invalid state.</p></body></html>";
+                        let _ = stream.write_all(response.as_bytes());
+                        continue;
+                    }
+
                     let token = params.get("token").cloned().unwrap_or_default();
                     let org_id = params.get("org_id").cloned().unwrap_or_default();
                     let email = params.get("email").cloned().unwrap_or_default();
@@ -230,6 +318,8 @@ pub fn login_browser(endpoint: &str) -> Result<Credentials> {
 /// Email/password login for orgs without OAuth (generic email, self-hosted, etc.)
 /// POST {endpoint}/api/auth/login
 pub fn login_password(endpoint: &str, email: &str, password: &str) -> Result<Credentials> {
+    require_secure_endpoint(endpoint)?;
+
     let url = format!("{}/api/auth/login", endpoint.trim_end_matches('/'));
 
     let resp = ureq::post(&url)
@@ -393,7 +483,12 @@ pub fn pull_memories(
         importance: String,
         #[serde(default = "default_scope_str")]
         scope: String,
-        #[serde(default)]
+        // Audit finding: `#[serde(default)]` on f32 is 0.0, which is below
+        // the prune threshold — a memory pulled without a `weight` field
+        // (the push side never sends one) would be eligible for immediate
+        // deletion by the next `prune`. Default to 1.0, matching
+        // `Memory::new()`'s baseline for a fresh memory.
+        #[serde(default = "default_weight")]
         weight: f32,
         #[serde(default)]
         access_count: u32,
@@ -411,6 +506,9 @@ pub fn pull_memories(
     }
     fn default_scope_str() -> String {
         "user".to_string()
+    }
+    fn default_weight() -> f32 {
+        1.0
     }
 
     #[derive(Deserialize)]
@@ -495,6 +593,45 @@ pub fn require_credentials_for_scope(scope: Scope) -> Option<Credentials> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Audit regression: writing a credentials file must never pass through
+    /// a world-readable intermediate state (TOCTOU) — verified by checking
+    /// the mode immediately after `write_secret_file` returns.
+    #[cfg(unix)]
+    #[test]
+    fn test_write_secret_file_is_0600_from_creation() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("icm-test-secret-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("secret.json");
+
+        write_secret_file(&path, "{\"token\":\"x\"}").unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn test_require_secure_endpoint() {
+        assert!(require_secure_endpoint("https://cloud.rtk-ai.app").is_ok());
+        assert!(require_secure_endpoint("https://my-company.example.com").is_ok());
+        assert!(require_secure_endpoint("http://localhost:8080").is_ok());
+        assert!(require_secure_endpoint("http://127.0.0.1:8080").is_ok());
+
+        assert!(require_secure_endpoint("http://cloud.rtk-ai.app").is_err());
+        assert!(require_secure_endpoint("http://evil.example.com").is_err());
+    }
+
+    #[test]
+    fn test_random_nonce_is_nonempty_and_varies() {
+        let a = random_nonce();
+        let b = random_nonce();
+        assert!(!a.is_empty());
+        assert_ne!(a, b, "two nonces should not collide in practice");
+    }
 
     #[test]
     fn test_url_decode() {

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -9442,6 +9442,95 @@ fn truncate(s: &str, max: usize) -> String {
 // Cloud commands
 // ---------------------------------------------------------------------------
 
+/// Merge a cloud-pulled memory into an already-existing local one, instead
+/// of overwriting it outright.
+///
+/// `weight`, `access_count`, `embedding`, and `related_ids` are
+/// locally-mastered state that the cloud push side never sends (and the
+/// pull API payload may not carry at all) — a blind `store.update(&pulled)`
+/// previously reset weight to ~0.0 (immediately eligible for the next
+/// `prune`), wiped the local embedding (breaking vector search until
+/// re-embedded), and dropped `related_ids`: real data loss on the very
+/// first `icm cloud pull` against a store that already had these memories
+/// (audit finding). Only the fields genuinely meant to sync — topic,
+/// summary, raw_excerpt, keywords, importance, scope, source, timestamps —
+/// come from the cloud version.
+fn merge_pulled_memory(existing: icm_core::Memory, pulled: icm_core::Memory) -> icm_core::Memory {
+    icm_core::Memory {
+        weight: existing.weight,
+        access_count: existing.access_count,
+        embedding: existing.embedding.or(pulled.embedding),
+        related_ids: if pulled.related_ids.is_empty() {
+            existing.related_ids
+        } else {
+            pulled.related_ids
+        },
+        ..pulled
+    }
+}
+
+#[cfg(test)]
+mod merge_pulled_memory_tests {
+    use super::*;
+    use icm_core::{Importance, Memory};
+
+    fn mem_with(weight: f32, access_count: u32, embedding: Option<Vec<f32>>) -> Memory {
+        let mut m = Memory::new("t".into(), "s".into(), Importance::Medium);
+        m.weight = weight;
+        m.access_count = access_count;
+        m.embedding = embedding;
+        m
+    }
+
+    #[test]
+    fn preserves_local_weight_access_count_and_embedding() {
+        let existing = mem_with(0.73, 12, Some(vec![0.1, 0.2, 0.3]));
+        // Simulates what a cloud pull payload actually looks like: weight
+        // defaults away from what push never sent, access_count reset,
+        // embedding never round-tripped.
+        let pulled = mem_with(1.0, 0, None);
+
+        let merged = merge_pulled_memory(existing.clone(), pulled);
+        assert_eq!(merged.weight, 0.73, "must keep the local weight");
+        assert_eq!(merged.access_count, 12, "must keep the local access_count");
+        assert_eq!(
+            merged.embedding,
+            Some(vec![0.1, 0.2, 0.3]),
+            "must keep the local embedding when the pulled one is absent"
+        );
+    }
+
+    #[test]
+    fn pulled_embedding_used_only_if_local_has_none() {
+        let existing = mem_with(1.0, 0, None);
+        let pulled = mem_with(1.0, 0, Some(vec![0.9]));
+        let merged = merge_pulled_memory(existing, pulled);
+        assert_eq!(merged.embedding, Some(vec![0.9]));
+    }
+
+    #[test]
+    fn related_ids_kept_locally_unless_pulled_has_some() {
+        let mut existing = mem_with(1.0, 0, None);
+        existing.related_ids = vec!["a".into(), "b".into()];
+        let pulled = mem_with(1.0, 0, None); // empty related_ids
+
+        let merged = merge_pulled_memory(existing, pulled);
+        assert_eq!(merged.related_ids, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn shared_fields_come_from_the_pulled_version() {
+        let existing = mem_with(1.0, 0, None);
+        let mut pulled = mem_with(1.0, 0, None);
+        pulled.summary = "updated from cloud".into();
+        pulled.topic = "new-topic".into();
+
+        let merged = merge_pulled_memory(existing, pulled);
+        assert_eq!(merged.summary, "updated from cloud");
+        assert_eq!(merged.topic, "new-topic");
+    }
+}
+
 fn cmd_cloud(command: CloudCommands, store: &Store) -> Result<()> {
     use icm_core::Scope;
 
@@ -9505,8 +9594,8 @@ fn cmd_cloud(command: CloudCommands, store: &Store) -> Result<()> {
                 use icm_core::MemoryStore;
                 // Upsert: if memory exists locally, update it; otherwise store it
                 match store.get(&mem.id)? {
-                    Some(_) => {
-                        store.update(&mem)?;
+                    Some(existing) => {
+                        store.update(&merge_pulled_memory(existing, mem))?;
                     }
                     None => {
                         store.store(mem)?;


### PR DESCRIPTION
## Bugs (sécurité — cloud.rs)

**1. `icm cloud pull` détruisait les données locales (le plus grave).** `store.update(&pulled)` inconditionnel sur toute mémoire déjà locale. La struct `CloudMemory` défaut `weight: 0.0` (push ne l'envoie jamais) et `embedding: None` toujours → un pull sur un store existant remettait le poids à 0.0 (prunable au prochain `prune`), effaçait les embeddings locaux (recherche vectorielle cassée), et perdait `access_count`/`related_ids`. Fix : `merge_pulled_memory` — seuls topic/summary/raw_excerpt/keywords/importance/scope/source/timestamps viennent du cloud ; weight/access_count/embedding/related_ids restent locaux sauf si le cloud apporte mieux. Default `weight` corrigé à 1.0 pour les nouvelles mémoires.

**2. OAuth callback sans `state` (CSRF).** N'importe quel process local qui découvre le port d'écoute (visible dans l'URL affichée) pouvait injecter son propre token avant la vraie réponse du navigateur. Fix : nonce généré côté client, vérifié au callback — **tolérant** (rejette seulement un mismatch explicite, accepte l'absence) car je ne contrôle pas le backend `cloud.rtk-ai.app` et ne peux pas garantir qu'il renvoie déjà `state` ; une vraie protection CSRF nécessitera un coup de main côté backend pour l'écho.

**3. TOCTOU sur les credentials.** `fs::write` puis `chmod 0600` laissait une fenêtre où le fichier était lisible par tous (umask par défaut). Fix : écriture directe en mode 0600 via `OpenOptions`.

**4. Endpoint en clair jamais refusé.** `--endpoint http://...` (flag documenté pour le self-hosting) enverrait mot de passe/token en clair. Fix : refus des endpoints non-HTTPS hors localhost/127.0.0.1.

**Non traité délibérément** : le pinning de domaine sur `cloud.rtk-ai.app` (suggéré par l'audit) casserait le self-hosting légitime (`--endpoint` documenté), et l'attaque suppose déjà un accès en écriture local au fichier credentials — à ce stade l'attaquant peut lire le token directement, le pinning n'ajoute pas de protection réelle.

## Vérification
9 nouveaux tests (merge weight/access_count/embedding/related_ids ×4, écriture 0600 ×1, validation endpoint ×1, nonce ×1) + suite existante. 299/299 tests icm-cli verts, clippy `-D warnings`, fmt clean.