### PR TITLE
fix(recall): un-invert BM25 scoring, fix dedup + importance downgrade, fix MCP filter-after-limit

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2371,7 +2371,11 @@ fn cmd_store(
                     memory.keywords.clone()
                 },
                 embedding: memory.embedding.clone(),
-                importance,
+                // Never let a near-dup merge downgrade importance — a
+                // `--importance` omission defaults to Medium and would
+                // otherwise silently demote an existing Critical memory
+                // into decay/prune eligibility (audit finding).
+                importance: icm_core::max_importance(existing.importance, importance),
                 source: existing.source,
                 related_ids: existing.related_ids,
                 scope: existing.scope,

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -51,7 +51,8 @@ pub use feedback_store::FeedbackStore;
 pub use memoir::{Concept, ConceptLink, Label, Memoir, MemoirStats, Relation};
 pub use memoir_store::MemoirStore;
 pub use memory::{
-    Importance, Memory, MemorySource, PatternCluster, Scope, StoreStats, TopicHealth,
+    max_importance, Importance, Memory, MemorySource, PatternCluster, Scope, StoreStats,
+    TopicHealth,
 };
 pub use store::{find_similar_memory, MemoryStore, DEDUP_SIMILARITY_THRESHOLD};
 pub use transcript::{Message, Role, Session, TranscriptHit, TranscriptStats};

--- a/crates/icm-core/src/memory.rs
+++ b/crates/icm-core/src/memory.rs
@@ -102,6 +102,35 @@ pub enum Importance {
     Low,
 }
 
+/// Local total order on `Importance` (Critical > High > Medium > Low).
+/// `Importance` does not implement `Ord` because the project does not want
+/// to imply a globally meaningful ordering across all uses (presentation,
+/// filtering, etc.) — this is deliberately scoped to dedup/merge decisions.
+fn importance_rank(i: Importance) -> u8 {
+    match i {
+        Importance::Critical => 4,
+        Importance::High => 3,
+        Importance::Medium => 2,
+        Importance::Low => 1,
+    }
+}
+
+/// Return the higher-priority importance. Any dedup/near-dup merge path
+/// should use this instead of blindly adopting the incoming value: a
+/// near-duplicate MCP `icm_memory_store` call defaults to `Medium` when the
+/// caller omits `importance`, and using it as-is would silently downgrade
+/// an existing `Critical` memory to `Medium` — making it eligible for decay
+/// and prune despite the "critical = never forget" contract (audit
+/// finding). "Re-store with a higher priority upgrades; it never
+/// downgrades."
+pub fn max_importance(a: Importance, b: Importance) -> Importance {
+    if importance_rank(a) >= importance_rank(b) {
+        a
+    } else {
+        b
+    }
+}
+
 impl fmt::Display for Importance {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/icm-core/src/store.rs
+++ b/crates/icm-core/src/store.rs
@@ -8,14 +8,25 @@ pub const DEDUP_SIMILARITY_THRESHOLD: f32 = 0.85;
 ///
 /// Returns the closest match and its similarity score if the score exceeds `threshold`
 /// and the match belongs to the same topic. Returns `None` otherwise.
+///
+/// Uses `search_by_embedding` (pure cosine similarity) rather than
+/// `search_hybrid`. Dedup is fundamentally a "is this the same content"
+/// question, which cosine similarity answers directly. The hybrid blend
+/// (`0.3*fts + 0.7*cosine`) is tuned for human-facing recall RANKING, not
+/// for a duplicate/not-duplicate decision — diluting an exact semantic
+/// match (cosine=1.0) with an FTS component made the 0.85 threshold nearly
+/// unreachable even for byte-identical content once the FTS side scored
+/// low (e.g. AND-joined tokens not matching), and a purely vector-side
+/// match (no shared keywords, cosine=1.0) could never exceed
+/// `0.3*0 + 0.7*1.0 = 0.70` (audit finding).
 pub fn find_similar_memory(
     store: &dyn MemoryStore,
-    embed_text: &str,
+    _embed_text: &str,
     embedding: &[f32],
     topic: &str,
     threshold: f32,
 ) -> IcmResult<Option<(Memory, f32)>> {
-    let similar = store.search_hybrid(embed_text, embedding, 1)?;
+    let similar = store.search_by_embedding(embedding, 1)?;
     Ok(similar
         .into_iter()
         .find(|(m, score)| *score > threshold && m.topic == topic))

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -1082,7 +1082,11 @@ fn tool_store(
                     }
                 },
                 embedding: Some(query_emb.clone()),
-                importance,
+                // Never let a near-dup merge downgrade importance: an MCP
+                // caller that omits `importance` defaults to Medium, which
+                // would otherwise silently demote an existing Critical
+                // memory into decay/prune eligibility (audit finding).
+                importance: icm_core::max_importance(existing.importance, importance),
                 source: existing.source.clone(),
                 related_ids: existing.related_ids.clone(),
                 updated_at: Utc::now(),
@@ -1265,10 +1269,25 @@ fn tool_recall(
         }
     };
 
+    // Audit finding: filters were applied AFTER the store already truncated
+    // to `limit` — if the top-`limit` global hits all belonged to other
+    // projects/topics, filtering left nothing and recall reported "no
+    // memories" even though relevant matches existed further down the
+    // ranked list. When any filter is active, request a much larger
+    // candidate pool so filtering has enough to work with, then truncate to
+    // the caller's requested `limit` at the very end (capped — this is a
+    // memory-scoped search, not a paginated export).
+    let filters_active = project.is_some() || topic.is_some() || keyword.is_some();
+    let query_limit = if filters_active {
+        (limit * 10).min(200)
+    } else {
+        limit
+    };
+
     // Try hybrid search if embedder is available
     if let Some(emb) = embedder {
         if let Ok(query_emb) = emb.embed_query(query) {
-            if let Ok(results) = store.search_hybrid(query, &query_emb, limit) {
+            if let Ok(results) = store.search_hybrid(query, &query_emb, query_limit) {
                 let mut scored_results = results;
                 scored_results.retain(|(m, _)| project_filter(m));
                 if let Some(t) = topic {
@@ -1288,9 +1307,9 @@ fn tool_recall(
                 // so a project-A primary hit can pull in a project-B
                 // neighbor via auto-linked `related_ids`. Re-apply the
                 // filters to `expanded` so the caller's scope is honored.
-                let max_neighbors = (limit / 3).max(1);
+                let max_neighbors = (query_limit / 3).max(1);
                 let mut expanded = store
-                    .expand_with_neighbors(&scored_results, max_neighbors, 0.5, limit)
+                    .expand_with_neighbors(&scored_results, max_neighbors, 0.5, query_limit)
                     .unwrap_or(scored_results);
                 expanded.retain(|(m, _)| project_filter(m));
                 if let Some(t) = topic {
@@ -1299,6 +1318,7 @@ fn tool_recall(
                 if let Some(kw) = keyword {
                     expanded.retain(|(m, _)| keyword_matches(&m.keywords, kw));
                 }
+                expanded.truncate(limit);
 
                 // Batch update access counts (includes expanded neighbors)
                 let ids: Vec<&str> = expanded.iter().map(|(m, _)| m.id.as_str()).collect();
@@ -1314,14 +1334,14 @@ fn tool_recall(
     }
 
     // Fallback: FTS then keywords
-    let mut results = match store.search_fts(query, limit) {
+    let mut results = match store.search_fts(query, query_limit) {
         Ok(r) => r,
         Err(e) => return ToolResult::error(format!("search error: {e}")),
     };
 
     if results.is_empty() {
         let keywords: Vec<&str> = query.split_whitespace().collect();
-        results = match store.search_by_keywords(&keywords, limit) {
+        results = match store.search_by_keywords(&keywords, query_limit) {
             Ok(r) => r,
             Err(e) => return ToolResult::error(format!("search error: {e}")),
         };
@@ -1334,6 +1354,7 @@ fn tool_recall(
     if let Some(kw) = keyword {
         results.retain(|m| keyword_matches(&m.keywords, kw));
     }
+    results.truncate(limit);
 
     // Convert to scored format with a sentinel score of 1.0 (FTS fallback
     // doesn't expose a real similarity score, but we still want the graph
@@ -2601,6 +2622,160 @@ mod tests {
         assert!(
             hits <= 20,
             "limit must clamp to the schema max of 20, got {hits} hits"
+        );
+    }
+
+    /// Audit regression: filtering was previously applied AFTER the store
+    /// already truncated results to `limit` — if every one of the top-N
+    /// global hits belonged to a different topic than the requested filter,
+    /// recall reported "no memories" even though a matching memory existed
+    /// further down the ranked list. `search_by_keywords` orders by
+    /// `weight DESC`, so 5 higher-weight "noise" memories in another topic
+    /// starve out a lower-weight matching memory in the target topic when
+    /// `limit=5` and no oversampling is applied.
+    #[test]
+    fn test_recall_topic_filter_does_not_starve_on_higher_weight_noise() {
+        let store = test_store();
+
+        // 5 noise memories, default weight 1.0, in a topic the caller is
+        // NOT asking for — these would fill the entire unfiltered top-5.
+        for i in 0..5 {
+            let r = call_tool(
+                &store,
+                None,
+                "icm_memory_store",
+                &json!({
+                    "topic": "noise",
+                    "content": format!("starvation probe filler {i}"),
+                }),
+                false,
+            );
+            assert!(!r.is_error);
+        }
+
+        // The actual target: same keyword, but lower weight and a DIFFERENT
+        // topic that the caller will filter for.
+        let store_result = call_tool(
+            &store,
+            None,
+            "icm_memory_store",
+            &json!({"topic": "target-topic", "content": "starvation probe filler needle"}),
+            false,
+        );
+        assert!(!store_result.is_error);
+        // The ID is the first whitespace-delimited token after the prefix —
+        // ULIDs never contain whitespace, but a link-count suffix
+        // (" (+N links)") could immediately follow with no other delimiter.
+        let id = store_result.content[0]
+            .text
+            .strip_prefix("Stored memory: ")
+            .and_then(|rest| rest.split_whitespace().next())
+            .map(str::to_string)
+            .expect("store result must contain an id");
+        use icm_core::MemoryStore;
+        let mut m = store
+            .get(&id)
+            .unwrap()
+            .expect("just-stored memory must exist");
+        m.weight = 0.1;
+        store.update(&m).unwrap();
+
+        let recall_result = call_tool(
+            &store,
+            None,
+            "icm_memory_recall",
+            &json!({
+                "query": "starvation probe filler",
+                "project": "",
+                "topic": "target-topic",
+                "limit": 5,
+            }),
+            false,
+        );
+        assert!(!recall_result.is_error);
+        assert!(
+            recall_result.content[0].text.contains("needle"),
+            "topic filter must not starve out a lower-weight match when \
+             higher-weight noise fills the unfiltered top-N: {}",
+            recall_result.content[0].text
+        );
+    }
+
+    /// Deterministic test-only embedder: always returns the same fixed
+    /// vector regardless of input, so any two texts are cosine-identical.
+    /// Used to force the near-dup merge path reliably without depending on
+    /// a real embedding model in unit tests.
+    struct FixedEmbedder;
+    impl Embedder for FixedEmbedder {
+        fn embed(&self, _text: &str) -> icm_core::IcmResult<Vec<f32>> {
+            Ok(vec![0.5; 384])
+        }
+        fn embed_batch(&self, texts: &[&str]) -> icm_core::IcmResult<Vec<Vec<f32>>> {
+            Ok(texts.iter().map(|_| vec![0.5; 384]).collect())
+        }
+        fn dimensions(&self) -> usize {
+            384
+        }
+    }
+
+    /// Audit regression: the near-dup merge path built the merged `Memory`
+    /// with the NEW request's `importance` verbatim. An MCP caller that
+    /// omits `importance` defaults to Medium — re-storing a near-paraphrase
+    /// of an existing Critical memory without specifying importance would
+    /// silently downgrade it to Medium, making it eligible for decay/prune
+    /// despite the "critical = never forget" contract.
+    #[test]
+    fn test_near_dup_merge_never_downgrades_importance() {
+        let store = test_store();
+        let embedder = FixedEmbedder;
+
+        let store_result = call_tool(
+            &store,
+            Some(&embedder),
+            "icm_memory_store",
+            &json!({
+                "topic": "t",
+                "content": "original critical fact",
+                "importance": "critical",
+            }),
+            false,
+        );
+        assert!(
+            !store_result.is_error,
+            "first store failed: {}",
+            store_result.content[0].text
+        );
+
+        // Re-store a "near paraphrase" (FixedEmbedder makes every text
+        // cosine-identical, so this always matches as a near-dup) WITHOUT
+        // specifying importance — defaults to Medium.
+        let update_result = call_tool(
+            &store,
+            Some(&embedder),
+            "icm_memory_store",
+            &json!({"topic": "t", "content": "original critical fact, rephrased"}),
+            false,
+        );
+        assert!(!update_result.is_error);
+        assert!(
+            update_result.content[0]
+                .text
+                .contains("Updated existing memory"),
+            "expected the near-dup merge path to trigger: {}",
+            update_result.content[0].text
+        );
+
+        use icm_core::MemoryStore;
+        let memories = store.get_by_topic("t").unwrap();
+        assert_eq!(
+            memories.len(),
+            1,
+            "near-dup should merge, not create a second row"
+        );
+        assert!(
+            matches!(memories[0].importance, icm_core::Importance::Critical),
+            "importance must not be downgraded by a near-dup merge, got {:?}",
+            memories[0].importance
         );
     }
 

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -1641,9 +1641,15 @@ impl MemoryStore for SqliteStore {
                 }) {
                     for row in rows.flatten() {
                         let (memory, rank) = row;
-                        // Normalize FTS rank (lower is better, typically negative)
-                        // Convert to 0..1 score where higher is better
-                        let score = 1.0 / (1.0 + rank.abs());
+                        // FTS5 bm25 rank is <= 0, MORE negative = MORE
+                        // relevant. `1.0 / (1.0 + |rank|)` inverted this: it
+                        // DECREASES as relevance increases (audit finding,
+                        // proven wrong e.g. rank=-4.83 (strong match) scored
+                        // 0.17 while rank=-0.2 (weak match) scored 0.83).
+                        // `|rank| / (1.0 + |rank|)` keeps the same bounded
+                        // [0,1) shape but is correctly monotonically
+                        // INCREASING in relevance.
+                        let score = rank.abs() / (1.0 + rank.abs());
                         fts_scores.insert(memory.id.clone(), score);
                         all_memories.insert(memory.id.clone(), memory);
                     }
@@ -5551,6 +5557,86 @@ mod tests {
         assert_eq!(results[0].0.topic, "rust");
         // Score should be > 0
         assert!(results[0].1 > 0.0);
+    }
+
+    /// Audit regression: `1.0 / (1.0 + rank.abs())` inverted FTS relevance —
+    /// a stronger bm25 match (more negative rank) scored LOWER than a weak
+    /// one. Neither memory has an embedding, which isolates the FTS
+    /// component of the hybrid score (vector side is 0.0 for both).
+    #[test]
+    fn test_search_hybrid_ranks_strong_fts_match_above_weak_one() {
+        let store = test_store();
+
+        // Strong match: the query term repeated, short document — bm25
+        // favors high term frequency in a short field.
+        store
+            .store(make_memory(
+                "t",
+                "database database database database database",
+            ))
+            .unwrap();
+        // Weak match: the query term appears once, diluted by many other
+        // unrelated terms — bm25 penalizes this relative to the strong doc.
+        store
+            .store(make_memory(
+                "t",
+                "we briefly touched on a database as one topic among many \
+                 entirely unrelated software engineering concerns discussed today",
+            ))
+            .unwrap();
+
+        let no_embedding = vec![0.0; 384];
+        let results = store.search_hybrid("database", &no_embedding, 5).unwrap();
+        assert_eq!(results.len(), 2);
+        let strong = results
+            .iter()
+            .find(|(m, _)| m.summary.starts_with("database database"))
+            .expect("strong match must be present");
+        let weak = results
+            .iter()
+            .find(|(m, _)| m.summary.starts_with("we briefly"))
+            .expect("weak match must be present");
+        assert!(
+            strong.1 > weak.1,
+            "strong FTS match ({}) must outscore weak match ({})",
+            strong.1,
+            weak.1
+        );
+    }
+
+    /// Audit regression: `find_similar_memory` used to compare
+    /// `DEDUP_SIMILARITY_THRESHOLD` (0.85) against the hybrid
+    /// `0.3*fts + 0.7*cosine` score. A memory found ONLY via the vector
+    /// side (no shared keywords, so fts=0) could score at most
+    /// `0.3*0 + 0.7*1.0 = 0.70` even for a byte-identical embedding —
+    /// always below 0.85, so semantic-only duplicates were never caught.
+    /// Switching to pure `search_by_embedding` (cosine) fixes this: an
+    /// identical embedding now scores ~1.0, comfortably above threshold,
+    /// regardless of keyword overlap.
+    #[test]
+    fn test_find_similar_memory_detects_purely_semantic_duplicate() {
+        let store = test_store();
+        let embedding = vec![0.42; 384];
+
+        let mut original = make_memory("t", "the quick brown fox jumps over the lazy dog");
+        original.embedding = Some(embedding.clone());
+        store.store(original).unwrap();
+
+        // Shares literally no keywords with the stored summary — the FTS
+        // component of the old hybrid comparison would be exactly 0.0.
+        let found = icm_core::find_similar_memory(
+            &store,
+            "a fast animal leaping above a sleepy canine",
+            &embedding,
+            "t",
+            icm_core::DEDUP_SIMILARITY_THRESHOLD,
+        )
+        .unwrap();
+        assert!(
+            found.is_some(),
+            "an identical embedding must be detected as a duplicate even with zero keyword overlap"
+        );
+        assert!(found.unwrap().1 > 0.99);
     }
 
     #[test]


### PR DESCRIPTION
## 4 bugs couplés du moteur de recall/dedup — corrigés ensemble

Comme demandé : une seule PR, traités comme un tout cohérent (corriger la dédup seule aurait armé le bug de downgrade d'importance, jusque-là masqué par un seuil de dédup inatteignable).

### 1. Inversion du score BM25 (`store.rs`)
`1.0 / (1.0 + rank.abs())` diminue quand la pertinence FTS augmente (rank ≤ 0, plus négatif = plus pertinent) — prouvé faux (rank=-4.83 match fort → score 0.17 ; rank=-0.2 match faible → score 0.83). Corrigé en `rank.abs() / (1.0 + rank.abs())`, même forme bornée, mais correctement croissante avec la pertinence. Confiné au backend SQLite — postgres (`ts_rank_cd`/max_rank) et opensearch (`_score`) utilisent déjà la bonne direction nativement.

### 2. Seuil de dédup quasi mort
`find_similar_memory` comparait 0.85 au score hybride `0.3*fts + 0.7*cosine` — un duplicat purement sémantique (cosine=1.0, aucun mot-clé partagé) plafonnait à 0.70, toujours sous le seuil. Basculé sur `search_by_embedding` (cosine pur) : la dédup est fondamentalement une question "est-ce le même contenu", que le cosinus répond directement, sans dilution par un score de ranking humain.

### 3. Downgrade d'importance sur merge near-dup
Le merge near-dup (CLI + MCP) adoptait l'importance de la **nouvelle** requête verbatim — un appel MCP omettant `importance` (défaut Medium) pouvait rétrograder silencieusement une mémoire `critical` existante, la rendant éligible au decay/prune malgré le contrat "critical = jamais oublié". Fix : nouveau helper public `icm_core::max_importance` (partagé CLI+MCP), utilisé pour ne jamais downgrader.

### 4. MCP `icm_recall` : filtres appliqués après le limit
`search_hybrid`/`search_fts`/`search_by_keywords` étaient appelés avec le `limit` du caller, PUIS les filtres projet/topic/keyword étaient appliqués — si les meilleurs résultats globaux appartenaient à un autre topic/projet, tout était filtré et "no memories" était renvoyé alors que des résultats pertinents existaient plus loin dans le classement. Fix : sur-échantillonnage (`limit*10`, plafonné à 200) quand un filtre est actif, troncature finale après filtrage.

## Vérification
4 tests de régression ajoutés, chacun **prouvé** : échoue sur le code d'avant le fix, passe avec le fix.
- BM25 : match fort vs faible, direction du classement
- Dédup : duplicat purement sémantique (embedding identique, zéro mot-clé commun) détecté
- Importance : merge near-dup ne rétrograde jamais une mémoire critical
- MCP recall : le filtre topic ne meurt plus de faim face à des mémoires "bruit" de poids plus élevé dans un autre topic

Suite complète du workspace verte (0 échec), clippy `-D warnings`, fmt clean. E2E sur le binaire réel confirmé (match fort classé en premier).
