### PR TITLE
fix(uninstall): flag ambiguous markdown blocks instead of guessing, use hardened hook matcher

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -5376,7 +5376,7 @@ struct DoctorTarget {
 
 /// Inspect a single hook command string. Returns `Some((bin_path, exists))`
 /// if the command references ICM, `None` if it should be skipped.
-fn check_icm_hook_command(cmd: &str) -> Option<(&str, bool)> {
+pub(crate) fn check_icm_hook_command(cmd: &str) -> Option<(&str, bool)> {
     let bin_path = cmd.split_whitespace().next().unwrap_or("");
     // Harden against false positives (security review): require the invoked
     // *binary* to actually be an icm binary, not merely a command that mentions

--- a/crates/icm-cli/src/uninstall/discover.rs
+++ b/crates/icm-cli/src/uninstall/discover.rs
@@ -155,7 +155,7 @@ fn scan_json(
                             };
                             for h in inner {
                                 if let Some(cmd) = h.get("command").and_then(|c| c.as_str()) {
-                                    if crate::cmd_matches_icm_pattern(cmd, "icm hook") {
+                                    if crate::check_icm_hook_command(cmd).is_some() {
                                         hits.push(LocationHit {
                                             spec_label: spec.label,
                                             path: spec.path.clone(),
@@ -170,7 +170,7 @@ fn scan_json(
                         }
                         HookCommandField::BashTopLevel => {
                             if let Some(cmd) = entry.get("bash").and_then(|b| b.as_str()) {
-                                if crate::cmd_matches_icm_pattern(cmd, "icm hook") {
+                                if crate::check_icm_hook_command(cmd).is_some() {
                                     hits.push(LocationHit {
                                         spec_label: spec.label,
                                         path: spec.path.clone(),
@@ -436,6 +436,41 @@ mod tests {
             }
             _ => unreachable!(),
         }
+    }
+
+    /// Audit regression: hook detection used to accept any command
+    /// CONTAINING the substring "icm hook" — a non-ICM wrapper script that
+    /// merely mentions it (in a comment, echo, or argument to an unrelated
+    /// tool) would be wrongly flagged and stripped by `icm uninstall`. The
+    /// #342-hardened `check_icm_hook_command` requires the invoked
+    /// *binary* to actually be `icm`/`icm.exe`/`icm-post-tool*`/
+    /// `icm-pretool*`.
+    #[test]
+    fn scan_does_not_flag_a_non_icm_wrapper_that_mentions_icm_hook() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dir_context_under(tmp.path());
+        let settings = dirs.claude_dir.join("settings.json");
+        write(
+            &settings,
+            r#"{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [{"type":"command","command":"bash -c 'echo icm hook is mentioned here; /usr/bin/my-tool run'"}] }
+    ]
+  }
+}"#,
+        );
+        let specs = build_locations(&dirs);
+        let plan = scan(&specs, false).unwrap();
+        let hook_hits: Vec<_> = plan
+            .hits
+            .iter()
+            .filter(|h| matches!(h.detail, HitDetail::JsonHook { .. }))
+            .collect();
+        assert!(
+            hook_hits.is_empty(),
+            "a wrapper script that merely mentions 'icm hook' must not be flagged: {plan:#?}"
+        );
     }
 
     #[test]

--- a/crates/icm-cli/src/uninstall/formats.rs
+++ b/crates/icm-cli/src/uninstall/formats.rs
@@ -120,7 +120,7 @@ pub(crate) fn strip_json_hooks(value: &mut Value, field: HookCommandField) -> St
                     inner.retain(|h| {
                         h.get("command")
                             .and_then(|c| c.as_str())
-                            .map(|s| !crate::cmd_matches_icm_pattern(s, "icm hook"))
+                            .map(|s| crate::check_icm_hook_command(s).is_none())
                             .unwrap_or(true)
                     });
                     removed += before - inner.len();
@@ -140,7 +140,7 @@ pub(crate) fn strip_json_hooks(value: &mut Value, field: HookCommandField) -> St
                     entry
                         .get("bash")
                         .and_then(|b| b.as_str())
-                        .map(|s| !crate::cmd_matches_icm_pattern(s, "icm hook"))
+                        .map(|s| crate::check_icm_hook_command(s).is_none())
                         .unwrap_or(true)
                 });
                 removed += before - event_arr.len();
@@ -349,11 +349,13 @@ pub(crate) fn apply_yaml_continue(content: &str) -> String {
 // =========================================================================
 
 /// Result of `strip_markdown_block`: either a rewritten string, the
-/// signal to delete the file (block was the only content), or a no-op.
+/// signal to delete the file (block was the only content), a no-op, or an
+/// ambiguous case that needs manual review rather than a guess.
 pub(crate) enum MarkdownOutcome {
     NoOp,
     Rewrite(String),
     DeleteFile,
+    Ambiguous { reason: String },
 }
 
 pub(crate) fn strip_markdown_block(content: &str) -> MarkdownOutcome {
@@ -362,16 +364,32 @@ pub(crate) fn strip_markdown_block(content: &str) -> MarkdownOutcome {
     let Some(start) = content.find(START) else {
         return MarkdownOutcome::NoOp;
     };
-    let end = content
-        .find(END)
-        .map(|o| o + END.len())
-        .unwrap_or(content.len());
-    let before = &content[..start];
-    let after = if end <= content.len() {
-        &content[end..]
-    } else {
-        ""
+    // Audit finding: a missing (or user-edited-away) END marker used to
+    // fall back to `content.len()` — treating everything from START to the
+    // end of the file as "the block" to strip, up to and including
+    // deleting the WHOLE FILE if nothing preceded START. A marker that
+    // ended up before START (e.g. from manual editing) hit the same
+    // `end <= content.len()` path and silently duplicated content instead.
+    // Neither case can be resolved by guessing — flag it for manual review
+    // instead, matching the `Ambiguous` contract every other stripper here
+    // already uses.
+    let Some(end_marker_at) = content.find(END) else {
+        return MarkdownOutcome::Ambiguous {
+            reason: "found <!-- icm:start --> but no matching <!-- icm:end --> \
+                     (the file may have been edited by hand)"
+                .to_string(),
+        };
     };
+    if end_marker_at < start {
+        return MarkdownOutcome::Ambiguous {
+            reason: "<!-- icm:end --> appears before <!-- icm:start --> \
+                     (the file may have been edited by hand)"
+                .to_string(),
+        };
+    }
+    let end = end_marker_at + END.len();
+    let before = &content[..start];
+    let after = &content[end..];
     if before.trim().is_empty() && after.trim().is_empty() {
         return MarkdownOutcome::DeleteFile;
     }
@@ -464,6 +482,7 @@ pub(crate) fn rewrite_markdown(path: &std::path::Path) -> Result<StripResult> {
                 .with_context(|| format!("cannot delete {}", path.display()))?;
             Ok(StripResult::DeleteFile)
         }
+        MarkdownOutcome::Ambiguous { reason } => Ok(StripResult::Ambiguous { reason }),
     }
 }
 
@@ -676,12 +695,39 @@ mcpServers:
         assert!(matches!(strip_markdown_block(src), MarkdownOutcome::NoOp));
     }
 
+    /// Audit regression: a missing END marker used to fall back to
+    /// `content.len()`, treating everything after START — including the
+    /// user's own content — as part of the block to strip. Here that would
+    /// have deleted "my own notes below, please keep these" outright.
+    #[test]
+    fn strip_markdown_block_is_ambiguous_when_end_marker_is_missing() {
+        let src = "intro\n<!-- icm:start -->\nblock\nmy own notes below, please keep these\n";
+        match strip_markdown_block(src) {
+            MarkdownOutcome::Ambiguous { .. } => {}
+            other => panic!("expected Ambiguous, got {other:?}"),
+        }
+    }
+
+    /// Audit regression: an END marker appearing before START (e.g. from
+    /// manual editing) hit the same `end <= content.len()` path and
+    /// silently duplicated the in-between region into both `before` and
+    /// `after` instead of being flagged.
+    #[test]
+    fn strip_markdown_block_is_ambiguous_when_end_precedes_start() {
+        let src = "<!-- icm:end -->\nstuff\n<!-- icm:start -->\nblock\n";
+        match strip_markdown_block(src) {
+            MarkdownOutcome::Ambiguous { .. } => {}
+            other => panic!("expected Ambiguous, got {other:?}"),
+        }
+    }
+
     impl std::fmt::Debug for MarkdownOutcome {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             match self {
                 MarkdownOutcome::NoOp => write!(f, "NoOp"),
                 MarkdownOutcome::Rewrite(_) => write!(f, "Rewrite(..)"),
                 MarkdownOutcome::DeleteFile => write!(f, "DeleteFile"),
+                MarkdownOutcome::Ambiguous { reason } => write!(f, "Ambiguous({reason})"),
             }
         }
     }


### PR DESCRIPTION
## 2 bugs uninstall issus de l'audit

### 1. Marqueur `<!-- icm:end -->` manquant/inversé — suppression jusqu'à EOF ou fichier entier
`strip_markdown_block` retombait sur `content.len()` quand le marqueur END était absent, traitant tout depuis START jusqu'à la fin du fichier comme "le bloc" à supprimer — jusqu'à supprimer le fichier entier si rien ne précédait START. Un END trouvé avant START (édition manuelle) suivait le même chemin et dupliquait silencieusement du contenu. Aucun des deux cas ne peut être résolu par déduction — les deux retournent maintenant `Ambiguous` (le même contrat que tous les autres strippers du module) au lieu de muter le fichier.

### 2. Détection de hooks trop large ET trop étroite
`discover.rs`/`formats.rs` utilisaient `cmd_matches_icm_pattern`, dont le premier check est un simple `cmd.contains("icm hook")` — un wrapper non-ICM qui mentionne juste "icm hook" (commentaire, echo, argument d'un autre outil) était marqué à tort. `icm hook disable` a déjà un matcher durci pour exactement ce problème (`check_icm_hook_command`, issu de la revue sécurité #342) qui exige que le *binaire invoqué* soit réellement `icm`/`icm.exe`/`icm-post-tool*`/`icm-pretool*`. Exposé (`pub(crate)`) et branché sur les deux fichiers — corrige aussi l'angle inverse noté dans l'audit (les hooks legacy `icm-pretool`/`icm-post-tool` n'étaient pas reconnus), puisque ce matcher couvre déjà les deux variantes de binaire.

## Vérification

4 nouveaux tests de régression (2 cas ambigus markdown, 1 faux-positif wrapper, plus un arm manquant dans l'impl `Debug` de test), chacun vérifié : échoue sur le code d'avant le fix, passe avec le fix. Suite complète du workspace verte (0 échec), clippy `-D warnings`, fmt clean.
