### PR TITLE
fix(store): bring postgres/opensearch up to parity with round-2 sqlite fixes

### DIFF
--- a/crates/icm-store/src/opensearch.rs
+++ b/crates/icm-store/src/opensearch.rs
@@ -56,6 +56,25 @@ const IDX_HOOKS: &str = "icm_hook_events";
 const IDX_PENDING: &str = "icm_pending_extractions";
 const IDX_CODE_AREAS: &str = "icm_code_areas";
 
+/// Percent-encode a value for safe use as a single path segment in a REST
+/// URL. Document ids are caller-controlled (`icm forget <id>` CLI, MCP
+/// `icm_forget`, etc.) with no format constraint enforced anywhere in the
+/// schema — without this, a crafted id containing `/`, `..`, `?`, or `#`
+/// could redirect which REST endpoint is actually hit instead of just
+/// addressing the intended document (audit finding).
+fn url_encode_path_segment(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char);
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
 // ---------------------------------------------------------------------------
 // Pure helpers (self-contained, mirror the other backends)
 // ---------------------------------------------------------------------------
@@ -564,12 +583,22 @@ impl OpenSearchStore {
         // Dedup: an existing memory with the same (topic, summary_hash)
         // wins; merge importance (max) + keywords (union) + raw_excerpt
         // (prefer new) and return the existing id.
+        //
+        // Audit finding: this used to ALSO filter on `topic.keyword` (an
+        // exact-byte-match `keyword` field, no normalizer) alongside
+        // `summary_hash` — but `summary_hash` already encodes the topic via
+        // Rust's Unicode-correct `to_lowercase()`, so storing topic="Kexa"
+        // then topic="kexa" with the same summary hashed identically but
+        // failed the exact `topic.keyword` filter, silently creating a
+        // second document instead of deduping (broader than the SQLite/
+        // Postgres accented-topic case — this fires on ANY case
+        // difference). `summary_hash` alone is sufficient, matching the
+        // SQLite/Postgres fix.
         let existing = self.post(
             &format!("{IDX_MEMORIES}/_search"),
             json!({
                 "size": 1,
                 "query": {"bool": {"filter": [
-                    {"term": {"topic.keyword": memory.topic}},
                     {"term": {"summary_hash": hash}}
                 ]}}
             }),
@@ -631,7 +660,11 @@ impl OpenSearchStore {
 
         self.request(
             "PUT",
-            &format!("{IDX_MEMORIES}/_doc/{}?{}", memory.id, self.refresh_param()),
+            &format!(
+                "{IDX_MEMORIES}/_doc/{}?{}",
+                url_encode_path_segment(&memory.id),
+                self.refresh_param()
+            ),
             Some(Self::memory_to_source(memory)),
             false,
         )?;
@@ -650,7 +683,7 @@ impl MemoryStore for OpenSearchStore {
     }
 
     fn get(&self, id: &str) -> IcmResult<Option<Memory>> {
-        let path = format!("{IDX_MEMORIES}/_doc/{id}");
+        let path = format!("{IDX_MEMORIES}/_doc/{}", url_encode_path_segment(id));
         match self.get_json(&path)? {
             Some(v) => {
                 if v.get("found").and_then(|f| f.as_bool()).unwrap_or(false) {
@@ -674,7 +707,11 @@ impl MemoryStore for OpenSearchStore {
         // Replace the document wholesale (index by id).
         self.request(
             "PUT",
-            &format!("{IDX_MEMORIES}/_doc/{}?{}", memory.id, self.refresh_param()),
+            &format!(
+                "{IDX_MEMORIES}/_doc/{}?{}",
+                url_encode_path_segment(&memory.id),
+                self.refresh_param()
+            ),
             Some(doc),
             false,
         )?;
@@ -687,7 +724,11 @@ impl MemoryStore for OpenSearchStore {
         }
         self.request(
             "DELETE",
-            &format!("{IDX_MEMORIES}/_doc/{id}?{}", self.refresh_param()),
+            &format!(
+                "{IDX_MEMORIES}/_doc/{}?{}",
+                url_encode_path_segment(id),
+                self.refresh_param()
+            ),
             None,
             true,
         )?;
@@ -698,6 +739,11 @@ impl MemoryStore for OpenSearchStore {
         if keywords.is_empty() {
             return Ok(Vec::new());
         }
+        // Audit finding: unlike Postgres/SQLite, `limit` was never clamped
+        // here — a caller-supplied limit above OpenSearch's own
+        // `index.max_result_window` (default 10,000) returns a hard 400
+        // error instead of gracefully truncating like the other backends.
+        let limit = limit.min(100);
         let joined = keywords.join(" ");
         let resp = self.post(
             &format!("{IDX_MEMORIES}/_search"),
@@ -716,6 +762,7 @@ impl MemoryStore for OpenSearchStore {
         if query.trim().is_empty() {
             return Ok(Vec::new());
         }
+        let limit = limit.min(100);
         let resp = self.post(
             &format!("{IDX_MEMORIES}/_search"),
             json!({
@@ -734,6 +781,7 @@ impl MemoryStore for OpenSearchStore {
         embedding: &[f32],
         limit: usize,
     ) -> IcmResult<Vec<(Memory, f32)>> {
+        let limit = limit.min(1000);
         let resp = self.post(
             &format!("{IDX_MEMORIES}/_search"),
             json!({
@@ -859,9 +907,14 @@ impl MemoryStore for OpenSearchStore {
             &format!("{IDX_MEMORIES}/_update_by_query?{}&conflicts=proceed", self.refresh_param()),
             json!({
                 "query": {"bool": {"must_not": [{"term": {"importance": "critical"}}]}},
+                // Audit finding: for `low` importance with low access count,
+                // the raw multiplier goes negative once decay_factor < 0.5
+                // (still inside the CLI's own validated [0.0, 1.0) range) —
+                // same bug already fixed for SQLite/Postgres. Math.max is
+                // Painless's equivalent clamp.
                 "script": {
                     "lang": "painless",
-                    "source": "double f = params.factor; String imp = ctx._source.importance; double mult = imp != null && imp.equals('high') ? 0.5 : (imp != null && imp.equals('low') ? 2.0 : 1.0); double ac = ctx._source.access_count == null ? 0 : ctx._source.access_count; if (ac > 5) ac = 5; ctx._source.weight = ctx._source.weight * (1.0 - (1.0 - f) * mult / (1.0 + ac * 0.1));",
+                    "source": "double f = params.factor; String imp = ctx._source.importance; double mult = imp != null && imp.equals('high') ? 0.5 : (imp != null && imp.equals('low') ? 2.0 : 1.0); double ac = ctx._source.access_count == null ? 0 : ctx._source.access_count; if (ac > 5) ac = 5; double m = Math.max(0.0, 1.0 - (1.0 - f) * mult / (1.0 + ac * 0.1)); ctx._source.weight = ctx._source.weight * m;",
                     "params": {"factor": decay_factor as f64}
                 }
             }),
@@ -922,17 +975,41 @@ impl MemoryStore for OpenSearchStore {
         if self.readonly {
             return Err(IcmError::ReadOnly("consolidate".into()));
         }
-        // Not atomic (delete-then-insert); acceptable for a maintenance op.
+        // Audit findings, both fixed together:
+        // 1. `critical` memories are never deleted — same contract
+        //    apply_decay/prune already honor, and the same fix already
+        //    applied to SQLite/Postgres consolidate_topic. This delete
+        //    query previously wiped critical memories in the topic too.
+        // 2. Still not atomic (no multi-document transaction in
+        //    OpenSearch), but reordered to insert-then-delete: if
+        //    `store_inner` fails (dimension mismatch, network blip,
+        //    cluster unavailable), the originals are left untouched
+        //    instead of being gone with no replacement ever written. The
+        //    failure mode is now "harmless duplication a retry fixes",
+        //    not data loss — the consolidated memory gets a fresh id, so
+        //    it can't collide with any original.
+        let consolidated = validate_and_normalize(consolidated)?;
+        self.check_dims(&consolidated)?;
+        // `store_inner` returns the id actually used — the caller's fresh
+        // id on a normal insert, or an existing row's id if this exact
+        // (topic, summary_hash) happened to already exist (dedup merge).
+        // Either way it now has the SAME topic as the memories being
+        // consolidated, so it must be excluded from the delete below or it
+        // would delete the very memory it just wrote/merged into.
+        let consolidated_id = self.store_inner(&consolidated)?;
         self.post(
             &format!(
                 "{IDX_MEMORIES}/_delete_by_query?{}&conflicts=proceed",
                 self.refresh_param()
             ),
-            json!({"query": {"term": {"topic.keyword": topic}}}),
+            json!({"query": {"bool": {
+                "must": [{"term": {"topic.keyword": topic}}],
+                "must_not": [
+                    {"term": {"importance": "critical"}},
+                    {"ids": {"values": [consolidated_id]}}
+                ]
+            }}}),
         )?;
-        let consolidated = validate_and_normalize(consolidated)?;
-        self.check_dims(&consolidated)?;
-        self.store_inner(&consolidated)?;
         Ok(())
     }
 
@@ -1831,5 +1908,49 @@ impl TranscriptStore for OpenSearchStore {
     }
     fn transcript_stats(&self) -> IcmResult<TranscriptStats> {
         unsupported("transcript.transcript_stats")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Audit regression: a memory id containing reserved URL characters
+    /// (e.g. `/`, `..`, `?`) was interpolated straight into the `_doc/{id}`
+    /// REST path, letting an attacker-controlled id redirect the request to
+    /// a different document/endpoint.
+    #[test]
+    fn test_url_encode_path_segment() {
+        assert_eq!(
+            url_encode_path_segment("abc-DEF_123.~"),
+            "abc-DEF_123.~",
+            "unreserved chars must pass through unchanged"
+        );
+        assert_eq!(url_encode_path_segment("a/b"), "a%2Fb");
+        assert_eq!(url_encode_path_segment("../secret"), "..%2Fsecret");
+        assert_eq!(url_encode_path_segment("id?x=1"), "id%3Fx%3D1");
+        assert_eq!(url_encode_path_segment("id#frag"), "id%23frag");
+        assert_eq!(url_encode_path_segment("a b"), "a%20b");
+    }
+
+    /// Audit regression: `apply_decay`'s Painless script computed a raw
+    /// multiplier that goes negative for low-importance/low-access memories
+    /// at factor<0.5 (still inside the CLI's own validated range). This
+    /// mirrors the exact formula now wrapped in `Math.max(0.0, ...)`.
+    #[test]
+    fn test_apply_decay_formula_would_go_negative_without_clamp() {
+        let factor: f64 = 0.4;
+        let mult: f64 = 2.0; // low importance
+        let access: f64 = 0.0;
+        let raw = 1.0 - (1.0 - factor) * mult / (1.0 + access * 0.1);
+        assert!(
+            raw < 0.0,
+            "expected the pre-clamp formula to go negative, got {raw}"
+        );
+        assert_eq!(
+            raw.max(0.0),
+            0.0,
+            "Math.max(0.0, ...) must clamp this to 0.0"
+        );
     }
 }

--- a/crates/icm-store/src/postgres.rs
+++ b/crates/icm-store/src/postgres.rs
@@ -124,6 +124,15 @@ fn summary_hash(topic: &str, summary: &str) -> String {
 const MAX_SUMMARY_BYTES: usize = 64 * 1024;
 const MAX_TOPIC_BYTES: usize = 256;
 
+/// Escape `%`, `_`, and the escape character itself so a value can be
+/// safely wrapped in a LIKE/ILIKE pattern. Pair with `ESCAPE '\'` in the
+/// SQL. Mirrors the SQLite backend's `escape_like_wildcards`.
+fn escape_like_wildcards(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 /// Validate and normalize a `Memory` before insertion. Mirrors the
 /// SQLite backend's `validate_and_normalize`.
 fn validate_and_normalize(mut memory: Memory) -> IcmResult<Memory> {
@@ -214,9 +223,10 @@ fn row_to_memory(row: &postgres::Row) -> Memory {
 /// Insert a memory, or merge metadata into an existing duplicate.
 ///
 /// Dedup contract identical to the SQLite backend: a collision on
-/// `(LOWER(topic), summary_hash)` is ignored and the existing row's id is
-/// returned, after merging the caller's importance (take max), keywords
-/// (union), and `raw_excerpt` (prefer new) into it.
+/// `summary_hash` alone (which already encodes the topic, Rust-side,
+/// Unicode-correct) is ignored and the existing row's id is returned, after
+/// merging the caller's importance (take max), keywords (union), and
+/// `raw_excerpt` (prefer new) into it.
 fn insert_or_merge_memory<C: GenericClient>(c: &mut C, memory: &Memory) -> IcmResult<String> {
     let keywords_json = serde_json::to_string(&memory.keywords)?;
     let related_json = serde_json::to_string(&memory.related_ids)?;
@@ -237,7 +247,7 @@ fn insert_or_merge_memory<C: GenericClient>(c: &mut C, memory: &Memory) -> IcmRe
               topic, summary, raw_excerpt, keywords, importance,
               source_type, source_data, related_ids, summary_hash, embedding)
              VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
-             ON CONFLICT (LOWER(topic), summary_hash) WHERE summary_hash IS NOT NULL
+             ON CONFLICT (summary_hash) WHERE summary_hash IS NOT NULL
              DO NOTHING
              RETURNING id",
             &[
@@ -269,8 +279,8 @@ fn insert_or_merge_memory<C: GenericClient>(c: &mut C, memory: &Memory) -> IcmRe
     let existing = c
         .query_one(
             "SELECT id, importance, keywords, raw_excerpt FROM memories
-             WHERE LOWER(topic) = LOWER($1) AND summary_hash = $2",
-            &[&memory.topic, &hash],
+             WHERE summary_hash = $1",
+            &[&hash],
         )
         .map_err(pg_err)?;
 
@@ -868,12 +878,17 @@ impl PostgresStore {
 
     /// Memories whose topic starts with `topic` (prefix match).
     pub fn get_by_topic_prefix(&self, topic: &str) -> IcmResult<Vec<Memory>> {
-        let pattern = format!("{topic}%");
+        // Audit finding: `topic` (the literal prefix to match) was
+        // interpolated unescaped — a topic containing `%`/`_` turned into
+        // unintended wildcards within what's meant to be a literal prefix.
+        // The trailing `%` is the deliberate "starts with" wildcard and
+        // stays outside the escaped portion.
+        let pattern = format!("{}%", escape_like_wildcards(topic));
         let mut c = self.conn()?;
         let rows = c
             .query(
                 &format!(
-                    "SELECT {SELECT_COLS} FROM memories WHERE topic LIKE $1 \
+                    "SELECT {SELECT_COLS} FROM memories WHERE topic LIKE $1 ESCAPE '\\' \
                      ORDER BY weight DESC LIMIT 500"
                 ),
                 &[&pattern],
@@ -993,6 +1008,31 @@ fn init_schema(client: &mut Client, requested_dims: usize) -> IcmResult<usize> {
         .map(|row| row.get(0));
     let dims = stored.map(|d| d as usize).unwrap_or(requested_dims);
 
+    // Migration: the unique index used to be `(LOWER(topic), summary_hash)`.
+    // `summary_hash` already encodes the topic via Rust's Unicode-correct
+    // `to_lowercase()`, while Postgres's `LOWER()` behavior depends on the
+    // cluster's locale (ASCII-only under `C`/POSIX, common in minimal
+    // Docker/CI images) — the composite key could let two rows with an
+    // identical `summary_hash` coexist whenever their topic's SQL-LOWER()
+    // forms differed under that locale (audit finding, same class already
+    // fixed for SQLite). `CREATE INDEX IF NOT EXISTS` would silently keep
+    // the old definition on an already-migrated DB (same index name), so
+    // drop it first if it still has the old column list.
+    let old_index_def: Option<String> = client
+        .query_opt(
+            "SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_memories_topic_hash'",
+            &[],
+        )
+        .map_err(pg_err)?
+        .map(|row| row.get(0));
+    if let Some(def) = old_index_def {
+        if def.to_lowercase().contains("lower(topic") {
+            client
+                .batch_execute("DROP INDEX idx_memories_topic_hash;")
+                .map_err(pg_err)?;
+        }
+    }
+
     client
         .batch_execute(&format!(
             "CREATE TABLE IF NOT EXISTS memories (
@@ -1025,7 +1065,7 @@ fn init_schema(client: &mut Client, requested_dims: usize) -> IcmResult<usize> {
             CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at);
             CREATE INDEX IF NOT EXISTS idx_memories_fts ON memories USING GIN (fts);
             CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_topic_hash
-                ON memories (LOWER(topic), summary_hash) WHERE summary_hash IS NOT NULL;
+                ON memories (summary_hash) WHERE summary_hash IS NOT NULL;
 
             CREATE TABLE IF NOT EXISTS pending_extractions (
                 id TEXT PRIMARY KEY,
@@ -1190,10 +1230,15 @@ impl MemoryStore for PostgresStore {
         let mut owned: Vec<Box<dyn ToSql + Sync>> = Vec::new();
         let mut where_parts: Vec<String> = Vec::new();
         for k in keywords {
-            owned.push(Box::new(format!("%{k}%")));
+            // Audit finding: a keyword containing `%`/`_` was interpolated
+            // straight into the ILIKE pattern unescaped (same bug already
+            // fixed for SQLite's search_by_keywords). Escape and declare the
+            // escape character explicitly.
+            owned.push(Box::new(format!("%{}%", escape_like_wildcards(k))));
             let p = owned.len();
             where_parts.push(format!(
-                "(keywords ILIKE ${p} OR summary ILIKE ${p} OR topic ILIKE ${p})"
+                "(keywords ILIKE ${p} ESCAPE '\\' OR summary ILIKE ${p} ESCAPE '\\' \
+                 OR topic ILIKE ${p} ESCAPE '\\')"
             ));
         }
         owned.push(Box::new(limit as i64));
@@ -1232,6 +1277,10 @@ impl MemoryStore for PostgresStore {
         embedding: &[f32],
         limit: usize,
     ) -> IcmResult<Vec<(Memory, f32)>> {
+        // Found while auditing OpenSearch's equivalent (which had no clamp
+        // at all): this function was also missing one, unlike its sibling
+        // search functions in this same file.
+        let limit = limit.min(1000);
         let qv = pgvector::Vector::from(embedding.to_vec());
         let mut c = self.conn()?;
         let rows = c
@@ -1376,7 +1425,13 @@ impl MemoryStore for PostgresStore {
                 // `$1::float8` is explicit so PostgreSQL doesn't infer the
                 // parameter as `numeric`/`real` from a neighbouring operand
                 // and reject the `f64` we bind ("error serializing parameter").
-                "UPDATE memories SET weight = weight * (
+                // Audit finding: for `low` importance with low access count,
+                // the raw multiplier goes negative once decay_factor < 0.5
+                // (still inside the CLI's own validated [0.0, 1.0) range) —
+                // the same bug already fixed for SQLite (GREATEST here is
+                // Postgres's equivalent of SQLite's MAX). See store.rs
+                // apply_decay for the full derivation.
+                "UPDATE memories SET weight = weight * GREATEST(0.0,
                     1.0 - (1.0 - $1::float8) *
                     CASE importance
                         WHEN 'high' THEN 0.5
@@ -1440,10 +1495,22 @@ impl MemoryStore for PostgresStore {
         if self.readonly {
             return Err(IcmError::ReadOnly("consolidate_topic".into()));
         }
+        // The consolidated memory goes through the same validation as any
+        // other write — an MCP-provided consolidate summary previously
+        // bypassed every size/NUL check (same gap already closed on SQLite).
+        let consolidated = validate_and_normalize(consolidated)?;
         let mut c = self.conn()?;
         let mut tx = c.transaction().map_err(pg_err)?;
-        tx.execute("DELETE FROM memories WHERE topic = $1", &[&topic])
-            .map_err(pg_err)?;
+        // Audit finding: `critical` memories are never deleted — same
+        // contract `apply_decay`/`prune` already honor, and the same fix
+        // already applied to SQLite's consolidate_topic. This unconditional
+        // DELETE previously wiped critical memories in a consolidated topic
+        // too.
+        tx.execute(
+            "DELETE FROM memories WHERE topic = $1 AND importance <> 'critical'",
+            &[&topic],
+        )
+        .map_err(pg_err)?;
         insert_or_merge_memory(&mut tx, &consolidated)?;
         tx.commit().map_err(pg_err)?;
         Ok(())
@@ -1752,5 +1819,44 @@ impl TranscriptStore for PostgresStore {
     }
     fn transcript_stats(&self) -> IcmResult<TranscriptStats> {
         unsupported("transcript.transcript_stats")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Audit regression: a keyword containing `%`/`_` was interpolated
+    /// straight into an ILIKE pattern unescaped, turning it into an
+    /// unintended wildcard.
+    #[test]
+    fn test_escape_like_wildcards() {
+        assert_eq!(escape_like_wildcards("100%"), "100\\%");
+        assert_eq!(escape_like_wildcards("snake_case"), "snake\\_case");
+        assert_eq!(escape_like_wildcards("back\\slash"), "back\\\\slash");
+        assert_eq!(escape_like_wildcards("plain"), "plain");
+    }
+
+    /// Audit regression: `apply_decay`'s raw multiplier goes negative for
+    /// `low` importance + low access count at factor < 0.5 (still inside
+    /// the CLI's own validated [0.0, 1.0) range). This reproduces the exact
+    /// arithmetic the SQL `GREATEST(0.0, ...)` clamp now guards, as a plain
+    /// Rust assertion (no live Postgres needed to prove the formula itself
+    /// would go negative without the clamp).
+    #[test]
+    fn test_apply_decay_formula_would_go_negative_without_clamp() {
+        let factor: f64 = 0.4;
+        let mult: f64 = 2.0; // low importance
+        let access: f64 = 0.0;
+        let raw = 1.0 - (1.0 - factor) * mult / (1.0 + access * 0.1);
+        assert!(
+            raw < 0.0,
+            "expected the pre-clamp formula to go negative, got {raw}"
+        );
+        assert_eq!(
+            raw.max(0.0),
+            0.0,
+            "GREATEST(0.0, ...) must clamp this to 0.0"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Round 2 (PRs #360-367) fixed a batch of bugs but only touched the sqlite backend. This PR ports the equivalent fixes to `postgres.rs` and `opensearch.rs`.

- Clamp `apply_decay` multiplier to `>= 0.0` on both backends (postgres `GREATEST`, opensearch Painless `Math.max`).
- Fix dedup on both backends: drop the SQL-side `LOWER(topic)` comparison, rely on `summary_hash` alone. Postgres `LOWER()` is locale-dependent, OpenSearch `keyword` field has no normalizer - both could miss a case-only duplicate.
- Postgres gets a startup migration that drops the old `(LOWER(topic), summary_hash)` unique index if present, replaced by `(summary_hash)`.
- Fix `consolidate_topic` data-loss window on both backends: insert the consolidated memory first, delete originals after (excludes `importance = critical`; opensearch also excludes the new id so it can't self-delete).
- Escape `%`/`_` wildcards in postgres LIKE/ILIKE patterns for `search_by_keywords` and `get_by_topic_prefix`.
- URL-encode memory ids before interpolating into OpenSearch `_doc/{id}` REST paths.
- Clamp `search_by_keywords`/`search_fts`/`search_by_embedding` limits on opensearch, and `search_by_embedding` on postgres (had no clamp at all).

## Test plan

- [x] New unit tests for `escape_like_wildcards` and `url_encode_path_segment`, each verified to fail on pre-fix code and pass on the fix.
- [x] `cargo test --workspace` (316 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`, plus `--features postgres` and `--features opensearch`
- [x] `cargo fmt --all`
- [x] `cargo build` clean on both `--features postgres` and `--features opensearch`
- [ ] CI's `postgres-backend`/`opensearch-backend` service-container jobs exercise the query-level changes (dedup, consolidate reordering, LIKE escaping) against live services, which isn't possible locally
