### PR TITLE
fix(learn): dedupe dependency names, block workspace-member path traversal

### DIFF
--- a/crates/icm-cli/src/learn_tests.rs
+++ b/crates/icm-cli/src/learn_tests.rs
@@ -189,4 +189,102 @@ edition = "2021"
         // Old memoir should be gone
         assert!(store.get_memoir(&r1.memoir_id).unwrap().is_none());
     }
+
+    /// Audit regression: a package listed in both `workspace.dependencies`
+    /// and `dependencies` (e.g. via `{ workspace = true }`, common in real
+    /// Cargo workspaces) used to be collected twice with the same name.
+    /// `add_concept`'s underlying `UNIQUE(memoir_id, name)` constraint then
+    /// turned the second insert into a hard error, aborting the whole learn
+    /// run and losing the memoir that a prior successful learn had created.
+    #[test]
+    fn test_learn_project_dedupes_duplicate_cargo_dependency_names() {
+        let (tmp, store) = test_store();
+
+        let project_dir = tmp.path().join("dup-deps-project");
+        fs::create_dir_all(project_dir.join("src")).unwrap();
+
+        fs::write(
+            project_dir.join("Cargo.toml"),
+            r#"
+[package]
+name = "dup-deps-project"
+version = "0.1.0"
+edition = "2021"
+
+[workspace.dependencies]
+serde = "1.0"
+
+[dependencies]
+serde = { workspace = true }
+anyhow = "1"
+"#,
+        )
+        .unwrap();
+        fs::write(project_dir.join("src/lib.rs"), "pub fn hello() {}").unwrap();
+
+        let result =
+            learn_project(&store, &project_dir, None).expect("duplicate dep name must not abort");
+
+        let concepts = store.list_concepts(&result.memoir_id).unwrap();
+        let serde_count = concepts.iter().filter(|c| c.name == "serde").count();
+        assert_eq!(serde_count, 1, "serde must be deduped to a single concept");
+    }
+
+    /// Audit regression: a `workspace.members` glob pattern resolving
+    /// outside the project directory (via `../..` or a symlink) used to be
+    /// followed as-is, letting a malicious repo's manifest pull in and
+    /// expose files/directories the user never asked to learn.
+    #[test]
+    fn test_learn_project_rejects_workspace_member_path_traversal() {
+        let (tmp, store) = test_store();
+
+        // A sibling directory *outside* the project root, containing a
+        // secret the traversal must not be able to reach.
+        fs::create_dir_all(tmp.path().join("secret-outside")).unwrap();
+        fs::write(
+            tmp.path().join("secret-outside/Cargo.toml"),
+            r#"
+[package]
+name = "leaked-secret"
+version = "0.1.0"
+edition = "2021"
+description = "should never be learned"
+"#,
+        )
+        .unwrap();
+
+        let project_dir = tmp.path().join("traversal-project");
+        fs::create_dir_all(project_dir.join("src")).unwrap();
+        fs::write(
+            project_dir.join("Cargo.toml"),
+            r#"
+[package]
+name = "traversal-project"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+members = ["../secret-outside"]
+"#,
+        )
+        .unwrap();
+        fs::write(project_dir.join("src/lib.rs"), "pub fn hello() {}").unwrap();
+
+        let result = learn_project(&store, &project_dir, None).unwrap();
+
+        // The module concept name is the *directory* name ("secret-outside"),
+        // and its description is only populated by reading the escaped
+        // Cargo.toml — either is proof the traversal was followed.
+        let concepts = store.list_concepts(&result.memoir_id).unwrap();
+        assert!(
+            !concepts.iter().any(|c| c.name == "secret-outside"),
+            "workspace member outside the project root must not be learned as a module"
+        );
+        assert!(
+            !concepts
+                .iter()
+                .any(|c| c.definition.contains("should never be learned")),
+            "the escaped Cargo.toml's description must never have been read"
+        );
+    }
 }

--- a/crates/icm-core/src/learn.rs
+++ b/crates/icm-core/src/learn.rs
@@ -4,6 +4,19 @@ use crate::error::IcmResult;
 use crate::memoir::{Concept, ConceptLink, Label, Memoir, Relation};
 use crate::memoir_store::MemoirStore;
 
+/// Manifests are attacker-controlled when learning an untrusted repo; refuse
+/// to read one past this size rather than slurping an arbitrarily large file
+/// into memory (e.g. a decompression-bomb-style `Cargo.toml`).
+const MAX_MANIFEST_BYTES: u64 = 2 * 1024 * 1024;
+
+fn read_manifest_capped(path: &Path) -> Option<String> {
+    let meta = std::fs::metadata(path).ok()?;
+    if meta.len() > MAX_MANIFEST_BYTES {
+        return None;
+    }
+    std::fs::read_to_string(path).ok()
+}
+
 /// Result of learning a project.
 #[derive(Debug, Clone)]
 pub struct LearnResult {
@@ -275,7 +288,7 @@ fn scan_scripts(store: &dyn MemoirStore, memoir_id: &str, dir: &Path) -> IcmResu
 
 fn read_cargo_toml(dir: &Path) -> Option<String> {
     let path = dir.join("Cargo.toml");
-    let content = std::fs::read_to_string(&path).ok()?;
+    let content = read_manifest_capped(&path)?;
     let parsed: toml::Value = content.parse().ok()?;
 
     let pkg = parsed.get("package");
@@ -290,7 +303,9 @@ fn read_cargo_toml(dir: &Path) -> Option<String> {
     let desc = pkg
         .and_then(|p| p.get("description"))
         .and_then(|v| v.as_str())
-        .unwrap_or("");
+        .unwrap_or("")
+        .replace(['\n', '\r'], " ");
+    let desc = desc.as_str();
 
     let is_workspace = parsed.get("workspace").is_some();
     let lang = if is_workspace {
@@ -308,7 +323,7 @@ fn read_cargo_toml(dir: &Path) -> Option<String> {
 
 fn read_package_json(dir: &Path) -> Option<String> {
     let path = dir.join("package.json");
-    let content = std::fs::read_to_string(&path).ok()?;
+    let content = read_manifest_capped(&path)?;
     let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;
 
     let name = parsed
@@ -322,7 +337,9 @@ fn read_package_json(dir: &Path) -> Option<String> {
     let desc = parsed
         .get("description")
         .and_then(|v| v.as_str())
-        .unwrap_or("");
+        .unwrap_or("")
+        .replace(['\n', '\r'], " ");
+    let desc = desc.as_str();
 
     let mut info = format!("Node.js project: {name} v{version}");
     if !desc.is_empty() {
@@ -333,7 +350,7 @@ fn read_package_json(dir: &Path) -> Option<String> {
 
 fn read_pyproject_toml(dir: &Path) -> Option<String> {
     let path = dir.join("pyproject.toml");
-    let content = std::fs::read_to_string(&path).ok()?;
+    let content = read_manifest_capped(&path)?;
     let parsed: toml::Value = content.parse().ok()?;
 
     let project = parsed
@@ -350,7 +367,9 @@ fn read_pyproject_toml(dir: &Path) -> Option<String> {
     let desc = project
         .get("description")
         .and_then(|v| v.as_str())
-        .unwrap_or("");
+        .unwrap_or("")
+        .replace(['\n', '\r'], " ");
+    let desc = desc.as_str();
 
     let mut info = format!("Python project: {name} v{version}");
     if !desc.is_empty() {
@@ -361,7 +380,7 @@ fn read_pyproject_toml(dir: &Path) -> Option<String> {
 
 fn read_go_mod(dir: &Path) -> Option<String> {
     let path = dir.join("go.mod");
-    let content = std::fs::read_to_string(&path).ok()?;
+    let content = read_manifest_capped(&path)?;
 
     let module = content
         .lines()
@@ -376,24 +395,30 @@ fn read_go_mod(dir: &Path) -> Option<String> {
 // ---------------------------------------------------------------------------
 
 fn collect_dependencies(dir: &Path) -> Vec<(String, String)> {
-    if let Some(deps) = collect_cargo_deps(dir) {
-        return deps;
-    }
-    if let Some(deps) = collect_npm_deps(dir) {
-        return deps;
-    }
-    if let Some(deps) = collect_python_deps(dir) {
-        return deps;
-    }
-    if let Some(deps) = collect_go_deps(dir) {
-        return deps;
-    }
-    Vec::new()
+    let deps = collect_cargo_deps(dir)
+        .or_else(|| collect_npm_deps(dir))
+        .or_else(|| collect_python_deps(dir))
+        .or_else(|| collect_go_deps(dir))
+        .unwrap_or_default();
+    dedup_by_name(deps)
+}
+
+/// Drop later entries whose name repeats an earlier one, keeping first-seen
+/// order. Manifests commonly list the same package twice (Cargo
+/// `workspace.dependencies` + `dependencies` via `{ workspace = true }`, npm
+/// `dependencies` + `devDependencies`) and `add_concept`'s underlying
+/// `UNIQUE(memoir_id, name)` constraint turns an undeduped duplicate into a
+/// hard error that aborts the whole learn run.
+fn dedup_by_name(deps: Vec<(String, String)>) -> Vec<(String, String)> {
+    let mut seen = std::collections::HashSet::new();
+    deps.into_iter()
+        .filter(|(name, _)| seen.insert(name.clone()))
+        .collect()
 }
 
 fn collect_cargo_deps(dir: &Path) -> Option<Vec<(String, String)>> {
     let path = dir.join("Cargo.toml");
-    let content = std::fs::read_to_string(&path).ok()?;
+    let content = read_manifest_capped(&path)?;
     let parsed: toml::Value = content.parse().ok()?;
 
     let mut deps = Vec::new();
@@ -427,7 +452,7 @@ fn collect_cargo_deps(dir: &Path) -> Option<Vec<(String, String)>> {
 
 fn collect_npm_deps(dir: &Path) -> Option<Vec<(String, String)>> {
     let path = dir.join("package.json");
-    let content = std::fs::read_to_string(&path).ok()?;
+    let content = read_manifest_capped(&path)?;
     let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;
 
     let mut deps = Vec::new();
@@ -448,7 +473,7 @@ fn collect_npm_deps(dir: &Path) -> Option<Vec<(String, String)>> {
 
 fn collect_python_deps(dir: &Path) -> Option<Vec<(String, String)>> {
     let path = dir.join("pyproject.toml");
-    let content = std::fs::read_to_string(&path).ok()?;
+    let content = read_manifest_capped(&path)?;
     let parsed: toml::Value = content.parse().ok()?;
 
     let mut deps = Vec::new();
@@ -496,7 +521,7 @@ fn collect_python_deps(dir: &Path) -> Option<Vec<(String, String)>> {
 
 fn collect_go_deps(dir: &Path) -> Option<Vec<(String, String)>> {
     let path = dir.join("go.mod");
-    let content = std::fs::read_to_string(&path).ok()?;
+    let content = read_manifest_capped(&path)?;
 
     let mut deps = Vec::new();
     let mut in_require = false;
@@ -512,6 +537,13 @@ fn collect_go_deps(dir: &Path) -> Option<Vec<(String, String)>> {
         }
         if in_require {
             let parts: Vec<&str> = trimmed.split_whitespace().collect();
+            if parts.len() >= 2 {
+                let name = parts[0].rsplit('/').next().unwrap_or(parts[0]);
+                deps.push((name.to_string(), parts[1].to_string()));
+            }
+        } else if let Some(rest) = trimmed.strip_prefix("require ") {
+            // Single-line form: `require example.com/foo v1.2.3` (no parens).
+            let parts: Vec<&str> = rest.split_whitespace().collect();
             if parts.len() >= 2 {
                 let name = parts[0].rsplit('/').next().unwrap_or(parts[0]);
                 deps.push((name.to_string(), parts[1].to_string()));
@@ -546,7 +578,7 @@ fn collect_modules(dir: &Path) -> Vec<(String, String)> {
 
 fn collect_rust_workspace_members(dir: &Path) -> Option<Vec<(String, String)>> {
     let path = dir.join("Cargo.toml");
-    let content = std::fs::read_to_string(&path).ok()?;
+    let content = read_manifest_capped(&path)?;
     let parsed: toml::Value = content.parse().ok()?;
 
     let members = parsed
@@ -568,12 +600,14 @@ fn collect_rust_workspace_members(dir: &Path) -> Option<Vec<(String, String)>> {
 
                 // Try to read the member's Cargo.toml for description
                 let member_cargo = member_path.join("Cargo.toml");
-                let desc = if let Ok(mc) = std::fs::read_to_string(&member_cargo) {
+                let desc = if let Some(mc) = read_manifest_capped(&member_cargo) {
                     if let Ok(mp) = mc.parse::<toml::Value>() {
                         mp.get("package")
                             .and_then(|p| p.get("description"))
                             .and_then(|v| v.as_str())
-                            .map(|d| format!("Rust crate: {name} — {d}"))
+                            .map(|d| {
+                                format!("Rust crate: {name} — {}", d.replace(['\n', '\r'], " "))
+                            })
                             .unwrap_or_else(|| format!("Rust crate: {name}"))
                     } else {
                         format!("Rust crate: {name}")
@@ -594,7 +628,16 @@ fn collect_rust_workspace_members(dir: &Path) -> Option<Vec<(String, String)>> {
 }
 
 fn expand_workspace_glob(dir: &Path, pattern: &str) -> Vec<PathBuf> {
-    if pattern.contains('*') {
+    // Manifest-declared members (Cargo `workspace.members`, npm `workspaces`) are
+    // attacker-controlled when learning an untrusted repo. Reject anything that
+    // resolves (after following symlinks) outside `dir` — this also unifies
+    // symlink handling between the glob and non-glob branches below, since
+    // canonicalize() follows symlinks in both cases.
+    let Ok(canonical_dir) = dir.canonicalize() else {
+        return Vec::new();
+    };
+
+    let candidates = if pattern.contains('*') {
         // Simple glob: "crates/*" → list directories in crates/
         let prefix = pattern.trim_end_matches("/*").trim_end_matches("/*");
         let parent = dir.join(prefix);
@@ -614,12 +657,21 @@ fn expand_workspace_glob(dir: &Path, pattern: &str) -> Vec<PathBuf> {
         } else {
             Vec::new()
         }
-    }
+    };
+
+    candidates
+        .into_iter()
+        .filter(|p| {
+            p.canonicalize()
+                .map(|c| c.starts_with(&canonical_dir))
+                .unwrap_or(false)
+        })
+        .collect()
 }
 
 fn collect_npm_workspaces(dir: &Path) -> Option<Vec<(String, String)>> {
     let path = dir.join("package.json");
-    let content = std::fs::read_to_string(&path).ok()?;
+    let content = read_manifest_capped(&path)?;
     let parsed: serde_json::Value = serde_json::from_str(&content).ok()?;
 
     let workspaces = parsed.get("workspaces").and_then(|w| w.as_array())?;


### PR DESCRIPTION
## Summary

- Dedupe `collect_dependencies` by name before it reaches `add_concept`. `concepts` has `UNIQUE(memoir_id, name)`, and a duplicate (e.g. a package in both `workspace.dependencies` and `dependencies` via `{ workspace = true }`, or npm's `dependencies` + `devDependencies`) aborted the whole learn run - real data loss since the old memoir is already deleted by the time the crash happens.
- `expand_workspace_glob` now canonicalizes every candidate member path and rejects anything outside the project root. `workspace.members`/npm `workspaces` come from an attacker-controlled manifest when learning an untrusted repo; a `../../etc`-style entry (or an escaping symlink) used to be followed as-is. This also unifies the previously-inconsistent symlink handling between the glob and non-glob branches.
- 2 MiB read cap on manifest files (`Cargo.toml`, `package.json`, `pyproject.toml`, `go.mod`).
- Flatten embedded newlines in manifest `description` fields before storing them as concept definitions (same injection class already fixed in `recall_context`/`build_consolidate_prompt`).
- `collect_go_deps` now also parses the single-line `require module version` form, not just the parenthesized block.

## Test plan

- [x] New regression tests `test_learn_project_dedupes_duplicate_cargo_dependency_names` and `test_learn_project_rejects_workspace_member_path_traversal`, each verified to fail on pre-fix code and pass on the fix.
- [x] `cargo test --workspace` (318 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] Manual end-to-end smoke test: built the CLI and ran `icm learn --dir . --db <tmp>` against this repo itself (a real Cargo workspace), then `icm memoir show`, `icm store`, `icm recall` - all worked correctly.
