### PR TITLE
fix(memoir): escape LIKE wildcards, cap refine definition, escape DOT export

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -9191,6 +9191,15 @@ fn cmd_memoir_inspect(
 
 // confidence_color and confidence_bar are now methods on Concept in icm-core
 
+/// Escape a value for embedding inside a DOT string literal (`"..."`).
+/// Every value interpolated into DOT export (memoir/concept/relation names)
+/// is user-chosen and must not be able to break out of its literal - an
+/// unescaped `"` would inject arbitrary DOT attributes/statements into the
+/// exported graph (audit finding).
+fn dot_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 fn cmd_memoir_export(store: &Store, memoir_name: &str, format: &str) -> Result<()> {
     let memoir = resolve_memoir(store, memoir_name)?;
     let concepts = store.list_concepts(&memoir.id)?;
@@ -9249,19 +9258,20 @@ fn cmd_memoir_export(store: &Store, memoir_name: &str, format: &str) -> Result<(
             println!("{}", serde_json::to_string_pretty(&output)?);
         }
         "dot" => {
-            println!("digraph \"{}\" {{", memoir.name);
+            println!("digraph \"{}\" {{", dot_escape(&memoir.name));
             println!("  rankdir=LR;");
             println!("  node [shape=box, style=\"rounded,filled\", fillcolor=white];");
             println!();
             for c in &concepts {
-                let escaped_def = c.definition.replace('"', "\\\"");
+                let escaped_def = dot_escape(&c.definition);
+                let escaped_name = dot_escape(&c.name);
                 let color = c.confidence_color();
                 println!(
                     "  \"{}\" [tooltip=\"{}\" fillcolor=\"{}\" label=\"{}\\n({:.0}%)\"];",
-                    c.name,
+                    escaped_name,
                     escaped_def,
                     color,
-                    c.name,
+                    escaped_name,
                     c.confidence * 100.0
                 );
             }
@@ -9274,7 +9284,10 @@ fn cmd_memoir_export(store: &Store, memoir_name: &str, format: &str) -> Result<(
                     let pw = 0.5 + l.weight * 2.0;
                     println!(
                         "  \"{}\" -> \"{}\" [label=\"{}\" penwidth={:.1}];",
-                        src, tgt, l.relation, pw
+                        dot_escape(src),
+                        dot_escape(tgt),
+                        dot_escape(&l.relation.to_string()),
+                        pw
                     );
                 }
             }
@@ -11822,6 +11835,20 @@ mod cmd_memoir_tests {
         make_memoir(&s, "m");
         add_concept(&s, "m", "c", "some definition");
         cmd_memoir_export(&s, "m", "dot").unwrap();
+    }
+
+    /// Audit regression: DOT export escaped the concept `definition`
+    /// (tooltip) but not the memoir/concept/relation names themselves. A
+    /// name containing a `"` broke out of its DOT string literal and
+    /// injected arbitrary attributes/statements into the exported graph.
+    #[test]
+    fn dot_escape_neutralizes_quotes_and_backslashes() {
+        assert_eq!(
+            dot_escape(r#"evil" fillcolor=red] //"#),
+            r#"evil\" fillcolor=red] //"#
+        );
+        assert_eq!(dot_escape(r"back\slash"), r"back\\slash");
+        assert_eq!(dot_escape("plain"), "plain");
     }
 
     // Unsupported format must surface the format name in the error.

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -1914,6 +1914,12 @@ fn tool_memoir_refine(store: &Store, args: &Value) -> ToolResult {
         Some(d) => d,
         None => return ToolResult::error("missing required field: definition".into()),
     };
+    if definition.len() > 10_000 {
+        return ToolResult::error(format!(
+            "definition too long: {} chars (max 10000)",
+            definition.len()
+        ));
+    }
 
     let memoir = match resolve_memoir(store, memoir_name) {
         Ok(m) => m,
@@ -2217,19 +2223,29 @@ fn tool_memoir_export(store: &Store, args: &Value) -> ToolResult {
             )
         }
         "dot" => {
+            // Every value below is caller-controlled (memoir/concept names,
+            // definitions, relation labels) and lands inside a DOT string
+            // literal. Escape backslash-then-quote on all of them, not just
+            // the definition tooltip, or a name containing `"` breaks out of
+            // its literal and injects arbitrary DOT attributes/statements.
+            fn dot_escape(s: &str) -> String {
+                s.replace('\\', "\\\\").replace('"', "\\\"")
+            }
+
             let mut out = format!(
                 "digraph \"{}\" {{\n  rankdir=LR;\n  node [shape=box, style=\"rounded,filled\", fillcolor=white];\n\n",
-                memoir.name
+                dot_escape(&memoir.name)
             );
             for c in &concepts {
-                let escaped = c.definition.replace('"', "\\\"");
+                let escaped_def = dot_escape(&c.definition);
+                let escaped_name = dot_escape(&c.name);
                 let color = c.confidence_color();
                 out.push_str(&format!(
                     "  \"{}\" [tooltip=\"{}\" fillcolor=\"{}\" label=\"{}\\n({:.0}%)\"];\n",
-                    c.name,
-                    escaped,
+                    escaped_name,
+                    escaped_def,
                     color,
-                    c.name,
+                    escaped_name,
                     c.confidence * 100.0
                 ));
             }
@@ -2242,7 +2258,10 @@ fn tool_memoir_export(store: &Store, args: &Value) -> ToolResult {
                     let pw = 0.5 + l.weight * 2.0;
                     out.push_str(&format!(
                         "  \"{}\" -> \"{}\" [label=\"{}\" penwidth={:.1}];\n",
-                        src, tgt, l.relation, pw
+                        dot_escape(src),
+                        dot_escape(tgt),
+                        dot_escape(&l.relation.to_string()),
+                        pw
                     ));
                 }
             }
@@ -3339,6 +3358,83 @@ mod tests {
             let list = call_tool(&store, None, "icm_memoir_list", &json!({}), false);
             assert!(!list.is_error);
         }
+    }
+
+    /// Audit regression: `icm_memoir_add_concept` caps `definition` at 10,000
+    /// chars, but `icm_memoir_refine` (which also writes a `definition`) had
+    /// no cap at all.
+    #[test]
+    fn test_memoir_refine_definition_too_long_rejected() {
+        let store = test_store();
+        let create = call_tool(
+            &store,
+            None,
+            "icm_memoir_create",
+            &json!({"name": "cap-test", "description": "test"}),
+            false,
+        );
+        assert!(!create.is_error);
+        let add = call_tool(
+            &store,
+            None,
+            "icm_memoir_add_concept",
+            &json!({"memoir": "cap-test", "name": "c1", "definition": "short"}),
+            false,
+        );
+        assert!(!add.is_error);
+
+        let too_long = "x".repeat(10_001);
+        let result = call_tool(
+            &store,
+            None,
+            "icm_memoir_refine",
+            &json!({"memoir": "cap-test", "name": "c1", "definition": too_long}),
+            false,
+        );
+        assert!(result.is_error, "an oversized definition must be rejected");
+    }
+
+    /// Audit regression: DOT export escaped the concept `definition`
+    /// (tooltip) but not the concept `name` itself. A name containing a `"`
+    /// broke out of its DOT string literal and injected arbitrary
+    /// attributes/statements into the exported graph.
+    #[test]
+    fn test_memoir_dot_export_escapes_quotes_in_concept_name() {
+        let store = test_store();
+        let create = call_tool(
+            &store,
+            None,
+            "icm_memoir_create",
+            &json!({"name": "dot-test", "description": "test"}),
+            false,
+        );
+        assert!(!create.is_error);
+        let add = call_tool(
+            &store,
+            None,
+            "icm_memoir_add_concept",
+            &json!({
+                "memoir": "dot-test",
+                "name": "evil\" fillcolor=red] //",
+                "definition": "d"
+            }),
+            false,
+        );
+        assert!(!add.is_error);
+
+        let export = call_tool(
+            &store,
+            None,
+            "icm_memoir_export",
+            &json!({"name": "dot-test", "format": "dot"}),
+            false,
+        );
+        assert!(!export.is_error);
+        let text = &export.content[0].text;
+        assert!(
+            !text.contains("\"evil\" fillcolor=red] //\""),
+            "unescaped quote let the concept name break out of its DOT string literal: {text}"
+        );
     }
 
     #[test]

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -2451,15 +2451,18 @@ impl MemoirStore for SqliteStore {
         label: &Label,
         limit: usize,
     ) -> IcmResult<Vec<Concept>> {
-        // Search JSON labels column using LIKE with the serialized label pattern
+        // Search JSON labels column using LIKE with the serialized label pattern.
+        // namespace/value come from the caller (MCP tool args) and can contain
+        // %/_ ; escape them so they can't turn into unintended wildcards.
         let pattern = format!(
             "%\"namespace\":\"{}\"%\"value\":\"{}\"%",
-            label.namespace, label.value
+            escape_like_wildcards(&label.namespace),
+            escape_like_wildcards(&label.value)
         );
 
         let sql = format!(
             "SELECT {CONCEPT_COLS} FROM concepts
-             WHERE memoir_id = ?1 AND labels LIKE ?2
+             WHERE memoir_id = ?1 AND labels LIKE ?2 ESCAPE '\\'
              ORDER BY confidence DESC
              LIMIT ?3"
         );
@@ -5571,6 +5574,34 @@ mod tests {
             .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].name, "es");
+    }
+
+    /// Audit regression: the label pattern built by `search_concepts_by_label`
+    /// interpolated `namespace`/`value` into a LIKE pattern unescaped, so a
+    /// literal `_` in a search value acted as a SQL "any single char"
+    /// wildcard instead of matching only that exact character.
+    #[test]
+    fn test_search_concepts_by_label_escapes_wildcards() {
+        let store = test_store();
+        let m_id = store.create_memoir(make_memoir("proj")).unwrap();
+
+        let mut c1 = make_concept(&m_id, "c1", "def1");
+        c1.labels = vec![Label::new("domain", "test")];
+        store.add_concept(c1).unwrap();
+
+        let mut c2 = make_concept(&m_id, "c2", "def2");
+        c2.labels = vec![Label::new("domain", "text")];
+        store.add_concept(c2).unwrap();
+
+        // "te_t" is not the literal value of either concept, but with an
+        // unescaped `_` it matches both "test" and "text" as a wildcard.
+        let results = store
+            .search_concepts_by_label(&m_id, &Label::new("domain", "te_t"), 10)
+            .unwrap();
+        assert!(
+            results.is_empty(),
+            "unescaped '_' wildcard matched unrelated label values: {results:?}"
+        );
     }
 
     // === Vector search tests ===


### PR DESCRIPTION
## Summary

- `search_concepts_by_label` built its LIKE pattern from the caller's `namespace`/`value` with no escaping. A value containing `%` or `_` acted as an unintended SQL wildcard instead of matching only that exact string. Reuses the existing `escape_like_wildcards` + `ESCAPE '\'` pattern already applied to `search_by_keywords`.
- `icm_memoir_refine` had no cap on `definition`, unlike `icm_memoir_add_concept`'s existing 10,000 char cap on the same field. Added the matching cap.
- DOT export escaped the concept `definition` (tooltip) but not the memoir name, concept names, or relation labels - any of those containing a `"` broke out of its DOT string literal and could inject arbitrary attributes/statements into the exported graph. Found and fixed **two** independent copies of this bug: the `icm-mcp` tool (`tool_memoir_export`) and the CLI's own duplicated `cmd_memoir_export` (the CLI one only surfaced during manual smoke testing, since it isn't reachable through the MCP test suite).

## Test plan

- [x] New regression tests (`test_search_concepts_by_label_escapes_wildcards`, `test_memoir_refine_definition_too_long_rejected`, `test_memoir_dot_export_escapes_quotes_in_concept_name`, `dot_escape_neutralizes_quotes_and_backslashes`), each verified to fail on pre-fix code and pass on the fix.
- [x] `cargo test --workspace` (317 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] Manual end-to-end smoke test: built the CLI and ran `icm memoir create/add-concept/refine/export` with a concept name containing a literal `"` - confirmed the DOT output now escapes it correctly (this is what caught the second, CLI-only copy of the bug).
