### PR TITLE
fix(web): block CSRF on decay/prune/consolidate, fix credentials TOCTOU

### DIFF
--- a/crates/icm-cli/src/cloud.rs
+++ b/crates/icm-cli/src/cloud.rs
@@ -84,7 +84,7 @@ pub fn save_credentials(creds: &Credentials) -> Result<()> {
 /// then `set_permissions` left a window — created with the process umask
 /// (often world-readable) — where a crash between the two calls leaves the
 /// bearer token durably readable by other local users.
-fn write_secret_file(path: &std::path::Path, content: &str) -> Result<()> {
+pub(crate) fn write_secret_file(path: &std::path::Path, content: &str) -> Result<()> {
     #[cfg(unix)]
     {
         use std::io::Write;

--- a/crates/icm-cli/src/web.rs
+++ b/crates/icm-cli/src/web.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use axum::{
     body::Body,
     extract::{Path, Query, State},
-    http::{header, Request, StatusCode},
+    http::{header, Method, Request, StatusCode},
     middleware::{self, Next},
     response::{Html, IntoResponse, Json, Response},
     routing::{delete, get, post},
@@ -17,6 +17,8 @@ use serde::{Deserialize, Serialize};
 
 use icm_core::{FeedbackStore, MemoirStore, MemoryStore};
 use icm_store::Store;
+
+use crate::cloud::write_secret_file;
 
 use crate::config::WebConfig;
 use crate::truncate_at_char_boundary;
@@ -81,19 +83,17 @@ pub fn resolve_password(cfg: &WebConfig) -> Result<String> {
         .map_err(|e| anyhow::anyhow!("failed to generate password: {e}"))?;
     let generated: String = buf.iter().map(|b| format!("{b:02x}")).collect();
 
-    // Save to credentials file
+    // Save to credentials file. Owner-only (0600) from the moment the file
+    // is created on Unix — the prior fs::write-then-set_permissions left a
+    // window where the freshly-generated dashboard password was readable
+    // under the process umask (often world-readable) before the chmod ran
+    // (audit finding, same TOCTOU class already fixed in cloud.rs).
     if let Some(ref path) = cred_path {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).ok();
         }
         let entry = format!("ICM_WEB_PASSWORD={generated}\n");
-        std::fs::write(path, &entry).ok();
-        // Restrict permissions on Unix
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).ok();
-        }
+        let _ = write_secret_file(path, &entry);
     }
 
     // Don't print the password to stderr — it would land in CI logs, shell
@@ -122,6 +122,63 @@ fn credentials_path() -> Option<std::path::PathBuf> {
 // Basic Auth middleware
 // ---------------------------------------------------------------------------
 
+/// Mutating dashboard routes that take no request body: `/api/health/decay`,
+/// `/api/health/prune`, `/api/topics/{name}/consolidate`. Basic Auth
+/// credentials are auto-reattached by the browser cross-origin (unlike a
+/// Bearer token, which JS must explicitly set), so a plain HTML form on
+/// another origin can POST to these without any preflight and ride the
+/// victim's cached credentials — CSRF (audit finding). `DELETE
+/// /api/memories/{id}` isn't exploitable this way: a non-simple method
+/// triggers a CORS preflight, which fails here since no CorsLayer is
+/// mounted.
+fn is_csrf_sensitive_post(method: &Method, path: &str) -> bool {
+    if method != Method::POST {
+        return false;
+    }
+    path == "/api/health/decay"
+        || path == "/api/health/prune"
+        || (path.starts_with("/api/topics/") && path.ends_with("/consolidate"))
+}
+
+/// Host portion of an `Origin`/`Referer` header value (strips scheme and
+/// any path/port-following segments left by a naive strip).
+fn header_host(v: &str) -> Option<&str> {
+    v.strip_prefix("http://")
+        .or_else(|| v.strip_prefix("https://"))
+        .map(|rest| rest.split(['/', '?', '#']).next().unwrap_or(rest))
+}
+
+/// Whether this request is same-origin, judged from `Origin` (preferred) or
+/// `Referer` (fallback — some browsers omit `Origin` on same-origin POSTs).
+/// Browsers always attach at least one of these on a cross-origin POST, so
+/// requests carrying neither are treated as a non-browser client (curl,
+/// scripts) using Basic Auth directly, not a forged browser request, and are
+/// allowed through.
+fn is_same_origin(req: &Request<Body>) -> bool {
+    let Some(host) = req
+        .headers()
+        .get(header::HOST)
+        .and_then(|v| v.to_str().ok())
+    else {
+        return false;
+    };
+    if let Some(origin) = req
+        .headers()
+        .get(header::ORIGIN)
+        .and_then(|v| v.to_str().ok())
+    {
+        return header_host(origin) == Some(host);
+    }
+    if let Some(referer) = req
+        .headers()
+        .get(header::REFERER)
+        .and_then(|v| v.to_str().ok())
+    {
+        return header_host(referer) == Some(host);
+    }
+    true
+}
+
 async fn auth_middleware(
     State(state): State<AppState>,
     req: Request<Body>,
@@ -130,6 +187,17 @@ async fn auth_middleware(
     // /health is public
     if req.uri().path() == "/health" {
         return next.run(req).await;
+    }
+
+    // Basic Auth credentials are auto-reattached by the browser cross-origin
+    // (unlike a Bearer token, which JS must explicitly set), so a plain HTML
+    // form on another origin can POST to these mutating, bodyless endpoints
+    // without any preflight and ride the victim's cached credentials — CSRF
+    // (audit finding). `DELETE /api/memories/{id}` isn't exploitable this
+    // way: a non-simple method triggers a CORS preflight, which fails here
+    // since no CorsLayer is mounted.
+    if is_csrf_sensitive_post(req.method(), req.uri().path()) && !is_same_origin(&req) {
+        return (StatusCode::FORBIDDEN, "cross-origin request rejected").into_response();
     }
 
     let authorized = req
@@ -696,5 +764,62 @@ mod tests {
             store.stats().is_ok(),
             "store must remain usable after poison"
         );
+    }
+
+    #[test]
+    fn is_csrf_sensitive_post_matches_only_the_mutating_bodyless_routes() {
+        assert!(is_csrf_sensitive_post(&Method::POST, "/api/health/decay"));
+        assert!(is_csrf_sensitive_post(&Method::POST, "/api/health/prune"));
+        assert!(is_csrf_sensitive_post(
+            &Method::POST,
+            "/api/topics/my-topic/consolidate"
+        ));
+        // Different method or path: not covered by this check.
+        assert!(!is_csrf_sensitive_post(&Method::GET, "/api/health/decay"));
+        assert!(!is_csrf_sensitive_post(&Method::POST, "/api/memories"));
+        assert!(!is_csrf_sensitive_post(
+            &Method::DELETE,
+            "/api/memories/abc"
+        ));
+    }
+
+    /// Audit regression: `api_topic_consolidate`/`api_decay`/`api_prune`
+    /// took no request body, so Basic Auth's browser-side credential
+    /// auto-reattachment let a plain cross-origin HTML form POST to them
+    /// and ride the victim's cached credentials (CSRF) — these three POSTs
+    /// don't trigger a CORS preflight, unlike the DELETE route.
+    #[test]
+    fn is_same_origin_rejects_cross_origin_and_accepts_matching_or_absent() {
+        let req = |origin: Option<&str>, referer: Option<&str>| {
+            let mut b = Request::builder()
+                .method(Method::POST)
+                .header(header::HOST, "127.0.0.1:8787");
+            if let Some(o) = origin {
+                b = b.header(header::ORIGIN, o);
+            }
+            if let Some(r) = referer {
+                b = b.header(header::REFERER, r);
+            }
+            b.body(Body::empty()).unwrap()
+        };
+
+        // A forged cross-origin form POST carries an Origin that doesn't
+        // match Host — must be rejected.
+        assert!(!is_same_origin(&req(Some("http://evil.example"), None)));
+        // Legit same-origin fetch() from the dashboard itself.
+        assert!(is_same_origin(&req(Some("http://127.0.0.1:8787"), None)));
+        // Some browsers omit Origin on same-origin POSTs; Referer must
+        // still be checked and matched.
+        assert!(is_same_origin(&req(
+            None,
+            Some("http://127.0.0.1:8787/dashboard")
+        )));
+        assert!(!is_same_origin(&req(
+            None,
+            Some("http://evil.example/lure")
+        )));
+        // Neither header: a non-browser client (curl/scripts) using Basic
+        // Auth directly, not a forged browser request — allowed.
+        assert!(is_same_origin(&req(None, None)));
     }
 }


### PR DESCRIPTION
## Summary

- `api_decay`, `api_prune`, and `api_topic_consolidate` are mutating POST routes that take no request body, so they never trigger a CORS preflight. Browsers auto-reattach cached Basic Auth credentials to same-target-origin requests regardless of which page issued them, so a plain cross-origin HTML form could POST to these and ride the victim's session - CSRF. `DELETE /api/memories/{id}` is not exploitable this way (a non-simple method triggers a preflight, which fails since no `CorsLayer` is mounted).
- Fixed via Origin/Referer validation in `auth_middleware`: reject the three sensitive POSTs when `Origin` or `Referer` is present and doesn't match the request's own `Host`. Requests carrying neither header (curl/scripts using Basic Auth directly) are allowed, since a browser always attaches at least one of these on a real cross-origin POST.
- Considered a custom `X-Requested-With` header check instead, but that requires the SvelteKit frontend to send it, and I have no npm/node available to rebuild the committed `web/dist/` bundle - shipping a source-only change there would desync the source and the binary-embedded build. Origin/Referer validation needs no frontend change.
- `resolve_password`'s auto-generated dashboard password had the same TOCTOU as `cloud.rs`'s credentials file before that was fixed: written via `fs::write` then `chmod`'d after, leaving a window where it's readable under the process umask. Now reuses `cloud.rs`'s `write_secret_file` (0600 from creation), which already has its own regression test.

## Test plan

- [x] New regression tests for `is_csrf_sensitive_post` and `is_same_origin`, each verified to fail on pre-fix code and pass on the fix.
- [x] `cargo test --workspace` (319 passed) and `cargo test -p icm-cli --features web` (322 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` and `cargo clippy -p icm-cli --features web,bench --all-targets -- -D warnings` (matches CI's own invocation)
- [x] `cargo fmt --all`
- [x] Manual end-to-end smoke test against the running dashboard with curl:
  - unauthenticated POST -> 401
  - authenticated, no Origin (curl-style client) -> allowed
  - authenticated with a forged cross-origin `Origin` -> 403
  - authenticated with a matching same-origin `Origin` -> allowed
  - other endpoints (`/api/stats`, `DELETE /api/memories/{id}`) unaffected
