### PR TITLE
fix(summarizer): fix subprocess pipe-deadlock in CLI-shelling providers

### DIFF
--- a/crates/icm-cli/src/summarizer.rs
+++ b/crates/icm-cli/src/summarizer.rs
@@ -136,41 +136,76 @@ fn run_cli(binary: &str, args: &[&str], stdin_payload: &str, timeout: Duration) 
         .spawn()
         .with_context(|| format!("failed to spawn '{binary}' — is it on PATH?"))?;
 
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(stdin_payload.as_bytes())
-            .with_context(|| format!("writing prompt to {binary} stdin"))?;
-    }
+    // Audit finding: writing the whole stdin payload synchronously BEFORE
+    // reading anything is the classic subprocess pipe-deadlock. OS pipe
+    // buffers are small (~16-64 KiB); if the child writes enough to stdout
+    // or stderr before it has fully drained stdin, the child blocks on its
+    // own full output pipe while we're blocked mid-write on stdin — and
+    // that hang has NO timeout coverage, since the poll loop below never
+    // starts running until write_all returns. Write stdin and drain
+    // stdout/stderr concurrently on separate threads instead, so no single
+    // pipe filling up can block another.
+    let mut stdin = child.stdin.take();
+    let stdin_payload = stdin_payload.to_string();
+    let stdin_binary = binary.to_string();
+    let writer = std::thread::spawn(move || -> Result<()> {
+        if let Some(mut stdin) = stdin.take() {
+            stdin
+                .write_all(stdin_payload.as_bytes())
+                .with_context(|| format!("writing prompt to {stdin_binary} stdin"))?;
+        }
+        Ok(())
+    });
+
+    let mut stdout_pipe = child.stdout.take();
+    let stdout_reader = std::thread::spawn(move || {
+        use std::io::Read;
+        let mut buf = String::new();
+        if let Some(s) = stdout_pipe.as_mut() {
+            let _ = s.read_to_string(&mut buf);
+        }
+        buf
+    });
+
+    let mut stderr_pipe = child.stderr.take();
+    let stderr_reader = std::thread::spawn(move || {
+        use std::io::Read;
+        let mut buf = String::new();
+        if let Some(s) = stderr_pipe.as_mut() {
+            let _ = s.read_to_string(&mut buf);
+        }
+        buf
+    });
 
     // Naïve wait with timeout: poll try_wait. Fine for short summarization
-    // jobs; if we ever need true cancellation we'd switch to a thread + kill.
+    // jobs — cancellation on timeout is handled below via kill().
     let deadline = std::time::Instant::now() + timeout;
-    loop {
+    let status = loop {
         if let Some(status) = child.try_wait()? {
-            let mut stdout = String::new();
-            let mut stderr = String::new();
-            if let Some(mut s) = child.stdout.take() {
-                use std::io::Read;
-                s.read_to_string(&mut stdout).ok();
-            }
-            if let Some(mut s) = child.stderr.take() {
-                use std::io::Read;
-                s.read_to_string(&mut stderr).ok();
-            }
-            if !status.success() {
-                bail!(
-                    "{binary} exited with {status}: {}",
-                    stderr.lines().next().unwrap_or("(no stderr)"),
-                );
-            }
-            return Ok(stdout);
+            break status;
         }
         if std::time::Instant::now() > deadline {
             let _ = child.kill();
+            let _ = child.wait();
             bail!("{binary} timed out after {:?}", timeout);
         }
         std::thread::sleep(Duration::from_millis(50));
+    };
+
+    // A broken-pipe write error (child exited before reading all of stdin,
+    // e.g. because it errored early) shouldn't fail an otherwise-successful
+    // run — only the exit status and stdout/stderr below determine that.
+    let _ = writer.join();
+    let stdout = stdout_reader.join().unwrap_or_default();
+    let stderr = stderr_reader.join().unwrap_or_default();
+
+    if !status.success() {
+        bail!(
+            "{binary} exited with {status}: {}",
+            stderr.lines().next().unwrap_or("(no stderr)"),
+        );
     }
+    Ok(stdout)
 }
 
 pub struct ClaudeCliSummarizer;
@@ -591,5 +626,51 @@ mod tests {
             "world"
         );
         assert_eq!(trim_response("clean\n".into()), "clean");
+    }
+
+    /// Audit regression: `run_cli` used to write the whole stdin payload
+    /// synchronously before reading anything — the classic subprocess
+    /// pipe-deadlock. A child that writes enough to stdout to fill its OS
+    /// pipe buffer *before* draining stdin blocks on its own output; if our
+    /// stdin payload is also larger than the stdin pipe's buffer, our
+    /// write_all() blocks too, and neither side ever unblocks the other.
+    /// That hang had no timeout coverage at all (the poll loop never even
+    /// started running). Bound the wait via a channel + recv_timeout rather
+    /// than actually risking an indefinite hang in the test itself: on the
+    /// pre-fix code this fails cleanly with "deadlocked" instead of hanging
+    /// the test binary forever.
+    #[test]
+    #[cfg(unix)]
+    fn run_cli_does_not_deadlock_when_child_writes_stdout_before_draining_stdin() {
+        // Larger than any common OS pipe buffer (typically 16-64 KiB) on
+        // both the stdout child writes first and the stdin we send.
+        let big_payload = "x".repeat(300_000);
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = run_cli(
+                "sh",
+                &["-c", "head -c 300000 /dev/zero; cat >/dev/null"],
+                &big_payload,
+                Duration::from_secs(20),
+            );
+            let _ = tx.send(result.map(|s| s.len()));
+        });
+        match rx.recv_timeout(Duration::from_secs(10)) {
+            Ok(result) => assert!(result.is_ok(), "run_cli should succeed: {result:?}"),
+            Err(_) => panic!(
+                "run_cli deadlocked: no response within 10s (child stuck writing stdout, \
+                 parent stuck writing stdin)"
+            ),
+        }
+    }
+
+    /// Sanity check for the normal, small-payload path (typical LLM CLI
+    /// usage) alongside the deadlock regression above — the concurrency
+    /// refactor must not have broken the common case.
+    #[test]
+    #[cfg(unix)]
+    fn run_cli_echoes_stdin_to_stdout_on_the_happy_path() {
+        let out = run_cli("cat", &[], "hello world", Duration::from_secs(5)).unwrap();
+        assert_eq!(out, "hello world");
     }
 }


### PR DESCRIPTION
## Summary

Round 4 audit (fourth multi-agent pass, this time targeting the MCP transport, import/archive/upgrade, the persistent HTTP API, and the extraction pipeline).

`run_cli` (used by the Claude/Codex/Gemini CLI-shelling summarizer providers) wrote the whole stdin payload synchronously before reading anything - the classic subprocess pipe-deadlock. OS pipe buffers are small (typically 16-64 KiB). If the child writes enough to stdout or stderr before it has fully drained stdin, the child blocks on its own full output pipe while we're blocked mid-write on stdin, and neither side ever unblocks the other. That hang had **zero timeout coverage** - the poll/timeout loop never started running until `write_all` returned, so a triggering payload hangs forever, not just for the configured timeout.

Default payload sizes already reach this: `build_consolidate_prompt` caps at 20K chars and `extract-pending`'s joined prompt (default `--limit 10`, each row capped at 8KB) reaches ~80KB - both comfortably past a 16-64KB pipe buffer.

Fixed by writing stdin and draining stdout/stderr concurrently on separate threads, so no single pipe filling up can block another. The existing poll-based wait-with-timeout loop is unchanged.

**Out of scope (lower priority, not fixed here):** `extract-pending`'s joined prompt (`main.rs`) has no aggregate size cap across all rows, only a per-row cap - this is what makes the deadlock easily reachable at default settings, but the concurrency fix above removes the size-dependent failure mode entirely, so an aggregate cap is now a cost-control nicety rather than a correctness fix.

## Test plan

- [x] New regression test that reproduces the exact deadlock condition (a child that writes 300KB to stdout before ever touching stdin, given a 300KB stdin payload) with a bounded outer wait via channel + `recv_timeout`, so the test itself can't hang forever even against the pre-fix code - it fails cleanly with "deadlocked" instead. Verified to fail on pre-fix code and pass on the fix.
- [x] Added a second test for the normal small-payload happy path (`cat` echo) to confirm the concurrency refactor didn't break typical usage.
- [x] `cargo test --workspace` (324 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
