### PR TITLE
fix(mcp): respond to JSON-RPC requests with an explicit null id

### DIFF
--- a/crates/icm-mcp/src/protocol.rs
+++ b/crates/icm-mcp/src/protocol.rs
@@ -9,10 +9,27 @@ use serde_json::Value;
 pub struct JsonRpcMessage {
     #[allow(dead_code)]
     pub jsonrpc: String,
+    /// Audit finding: plain `Option<Value>` can't distinguish an *absent*
+    /// `id` field (a Notification — no response expected) from an id that's
+    /// *explicitly* `null` (a legal, if discouraged, Request per JSON-RPC
+    /// 2.0 — the server must still reply, with `id: null`). Both used to
+    /// deserialize to `None` and get silently dropped as if they were
+    /// Notifications, leaving a client that sent `"id": null` hanging
+    /// forever with no response. `deserialize_some` + `#[serde(default)]`
+    /// is the standard "double Option" idiom: missing → `None` (via
+    /// default), present-as-null → `Some(Value::Null)`.
+    #[serde(default, deserialize_with = "deserialize_some")]
     pub id: Option<Value>,
     pub method: Option<String>,
     #[serde(default)]
     pub params: Option<Value>,
+}
+
+fn deserialize_some<'de, D>(deserializer: D) -> Result<Option<Value>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Value::deserialize(deserializer).map(Some)
 }
 
 #[derive(Debug, Serialize)]
@@ -106,6 +123,34 @@ impl ToolResult {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// Audit regression: a Request with `"id": null` (legal per JSON-RPC
+    /// 2.0, if discouraged) must still be recognized as a Request needing a
+    /// response — not conflated with a Notification (missing `id`
+    /// entirely), which gets no response at all.
+    #[test]
+    fn json_rpc_message_distinguishes_explicit_null_id_from_missing_id() {
+        let with_null_id: JsonRpcMessage =
+            serde_json::from_value(json!({"jsonrpc": "2.0", "id": null, "method": "ping"}))
+                .unwrap();
+        assert_eq!(
+            with_null_id.id,
+            Some(Value::Null),
+            "explicit `\"id\": null` must deserialize to Some(Null), not None, \
+             or the server silently drops the request as a Notification"
+        );
+
+        let without_id: JsonRpcMessage =
+            serde_json::from_value(json!({"jsonrpc": "2.0", "method": "ping"})).unwrap();
+        assert_eq!(
+            without_id.id, None,
+            "a genuinely absent id field must still deserialize to None (Notification)"
+        );
+
+        let with_real_id: JsonRpcMessage =
+            serde_json::from_value(json!({"jsonrpc": "2.0", "id": 7, "method": "ping"})).unwrap();
+        assert_eq!(with_real_id.id, Some(json!(7)));
+    }
 
     #[test]
     fn test_tool_result_text() {


### PR DESCRIPTION
## Summary

Round 4 audit (fourth multi-agent pass, this time targeting the MCP
transport, import/archive/upgrade, the persistent HTTP API, and the
extraction pipeline).

`JsonRpcMessage.id` was a plain `Option<Value>`, which can't distinguish
an absent id field (a Notification - no response expected) from an id
that's explicitly null (a legal, if discouraged, Request per JSON-RPC
2.0 - the server must still reply, with id: null). Both deserialized
to None and got silently dropped as if they were Notifications, so a
client sending "id": null would hang forever waiting for a response
that never comes.

Fixed with the standard "double Option" serde idiom: a custom
deserialize_with that always wraps a present value in Some (even
Value::Null), paired with #[serde(default)] so a genuinely missing
field still falls back to None. No server.rs changes needed - the
existing `match msg.id { Some(id) => ..., None => continue }`
dispatch already does the right thing once id correctly distinguishes
the two cases.

Also considered adding a catch_unwind boundary around tool dispatch,
per the audit's other finding (no panic isolation, combined with
`panic = "abort"` in the release profile meaning a single future
panic anywhere in a tool handler would kill the whole server process).
Did not implement it: under panic = "abort", catch_unwind cannot
catch anything at all - the process aborts synchronously at the panic
site before any unwinding/catching logic runs. Adding it would work
in dev/test builds (unwind) but silently do nothing in the actual
shipped release binary, which is worse than the status quo since it
creates false confidence. True panic isolation here would need a
process boundary (a persistent worker subprocess per tool call, or
similar), which is a much larger architectural change - out of scope.
No live trigger currently exists (grepped tools.rs for unwrap/expect/
panic! on production paths; all matches are inside #[cfg(test)]).

## Test plan

- [x] New regression test verifying `id:null`/missing-id/real-id all deserialize correctly, verified to fail on pre-fix code (both `id:null` and missing-id collapsed to `None`) and pass on the fix.
- [x] `cargo test --workspace` (322 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] Manual end-to-end smoke test: sent `id:1`, `id:null`, and no-id requests into the running `icm serve` MCP server over stdio - got exactly 2 responses (for `id:1` and `id:null`, the latter with `"id":null` in the response), zero response for the true notification.
