### PR TITLE
fix(cli): harden upgrade binary write and import directory walk

### DIFF
--- a/crates/icm-cli/src/import.rs
+++ b/crates/icm-cli/src/import.rs
@@ -381,21 +381,39 @@ const IMPORT_EXTENSIONS: &[&str] = &["json", "jsonl", "txt", "md"];
 
 fn collect_importable_files(path: &Path) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
-    collect_recursive(path, &mut files)?;
+    let canonical_root = path
+        .canonicalize()
+        .with_context(|| format!("resolving {}", path.display()))?;
+    collect_recursive(path, &canonical_root, &mut files)?;
     files.sort();
     Ok(files)
 }
 
-fn collect_recursive(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+fn collect_recursive(dir: &Path, canonical_root: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
     for entry in std::fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
         let entry = entry?;
         let path = entry.path();
+        // Audit finding: symlink-following with no containment check let a
+        // directory tree containing a symlink to elsewhere on disk get
+        // silently walked and its files imported as memories, outside the
+        // tree the user pointed at. Canonicalize and require containment
+        // within the originally-requested root (same pattern as
+        // learn.rs::expand_workspace_glob, round 3 #369) - this also
+        // naturally handles symlink loops, since a loop's canonicalized
+        // target is unreachable (the OS's own ELOOP limit surfaces as an
+        // Err here, which we skip rather than recursing into).
+        let Ok(canonical) = path.canonicalize() else {
+            continue;
+        };
+        if !canonical.starts_with(canonical_root) {
+            continue;
+        }
         if path.is_dir() {
             let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
             if name.starts_with('.') || name == "node_modules" || name == "__pycache__" {
                 continue;
             }
-            collect_recursive(&path, files)?;
+            collect_recursive(&path, canonical_root, files)?;
         } else {
             let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
             if IMPORT_EXTENSIONS.contains(&ext) {
@@ -741,5 +759,34 @@ mod tests {
         // Recall
         let results = store.search_fts("SQLite decision", 5).unwrap();
         assert!(!results.is_empty(), "should recall imported facts");
+    }
+
+    /// Audit regression: `collect_recursive` followed symlinks with no
+    /// containment check, so a directory tree containing a symlink to
+    /// elsewhere on disk got silently walked and its files imported as
+    /// memories - outside the tree the user pointed the import at.
+    #[test]
+    #[cfg(unix)]
+    fn collect_importable_files_does_not_follow_symlinks_outside_the_root() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // A file outside the import root that must never be reached.
+        let outside_dir = tmp.path().join("outside");
+        std::fs::create_dir_all(&outside_dir).unwrap();
+        std::fs::write(outside_dir.join("secret.md"), "should never be imported").unwrap();
+
+        // The import root, containing a symlink pointing at `outside`.
+        let root = tmp.path().join("import-root");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("real.md"), "this one is fine").unwrap();
+        std::os::unix::fs::symlink(&outside_dir, root.join("escape-link")).unwrap();
+
+        let files = collect_importable_files(&root).unwrap();
+        assert_eq!(
+            files.len(),
+            1,
+            "must only collect the real file inside the root, not the symlinked escape: {files:?}"
+        );
+        assert!(files[0].ends_with("real.md"));
     }
 }

--- a/crates/icm-cli/src/upgrade.rs
+++ b/crates/icm-cli/src/upgrade.rs
@@ -4,7 +4,7 @@
 //! against the release's `checksums.txt`, and replaces the running binary.
 
 use std::io::{Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
 use sha2::{Digest, Sha256};
@@ -109,6 +109,41 @@ fn extract_binary(archive: &[u8], is_zip: bool) -> Result<Vec<u8>> {
     bail!("binary {BINARY_NAME} not found in archive")
 }
 
+/// Write the downloaded (already SHA256-verified) binary to `path`,
+/// refusing to follow a pre-existing symlink there.
+///
+/// Audit finding: `File::create` is `O_CREAT|O_TRUNC` with no `O_EXCL` - it
+/// follows an existing symlink at `path`. If an attacker with write access
+/// to this directory pre-places a symlink pointing elsewhere, the verified
+/// download gets written through it, clobbering an unrelated file (not
+/// RCE - the payload is the legitimate SHA256-verified binary - but a real
+/// file-clobber/DoS gap, the same TOCTOU class already hardened in
+/// `cloud.rs::write_secret_file`). Remove any existing entry first via
+/// `symlink_metadata` (which reports the symlink itself, not its target) so
+/// a stale symlink or a leftover from an interrupted previous upgrade
+/// doesn't get followed, then open with `create_new` (`O_EXCL`) so even an
+/// attacker racing a fresh symlink into the gap fails the open rather than
+/// getting followed.
+fn write_new_binary(path: &Path, content: &[u8]) -> Result<()> {
+    if std::fs::symlink_metadata(path).is_ok() {
+        std::fs::remove_file(path)
+            .with_context(|| format!("cannot remove stale {}", path.display()))?;
+    }
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .with_context(|| format!("cannot create {}", path.display()))?;
+    f.write_all(content)
+        .with_context(|| format!("cannot write {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(())
+}
+
 /// Run the upgrade flow: fetch latest, verify checksum, replace binary.
 pub fn cmd_upgrade(apply: bool, check_only: bool) -> Result<()> {
     let current_version = env!("CARGO_PKG_VERSION");
@@ -195,18 +230,8 @@ pub fn cmd_upgrade(apply: bool, check_only: bool) -> Result<()> {
 
     eprintln!("Installing to {}...", current_exe.display());
 
-    // Write new binary to .new
-    {
-        let mut f = std::fs::File::create(&new_path)
-            .with_context(|| format!("cannot create {}", new_path.display()))?;
-        f.write_all(&new_binary)
-            .with_context(|| format!("cannot write {}", new_path.display()))?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&new_path, std::fs::Permissions::from_mode(0o755))?;
-        }
-    }
+    // Write new binary to .new.
+    write_new_binary(&new_path, &new_binary)?;
 
     // Atomic swap: rename old → .old, new → current
     if backup_path.exists() {
@@ -225,4 +250,48 @@ pub fn cmd_upgrade(apply: bool, check_only: bool) -> Result<()> {
 
     eprintln!("Successfully upgraded to {latest_version}");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Audit regression: `File::create` follows a symlink pre-placed at
+    /// the target path, letting an attacker with write access to the
+    /// directory redirect the verified-download write elsewhere. The fix
+    /// must remove any existing entry (symlink or stale leftover) first
+    /// and never write through a symlink.
+    #[test]
+    #[cfg(unix)]
+    fn write_new_binary_does_not_follow_a_preexisting_symlink() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let victim = tmp.path().join("victim.txt");
+        std::fs::write(&victim, "untouched").unwrap();
+
+        let target = tmp.path().join("icm.new");
+        std::os::unix::fs::symlink(&victim, &target).unwrap();
+
+        write_new_binary(&target, b"verified binary content").unwrap();
+
+        // The symlink must be gone, replaced by a real file...
+        assert!(
+            std::fs::symlink_metadata(&target)
+                .unwrap()
+                .file_type()
+                .is_file(),
+            "target must be a regular file, not still a symlink"
+        );
+        assert_eq!(std::fs::read(&target).unwrap(), b"verified binary content");
+        // ...and the symlink's old target must be untouched.
+        assert_eq!(std::fs::read_to_string(&victim).unwrap(), "untouched");
+    }
+
+    /// Sanity check for the normal case: no pre-existing entry at all.
+    #[test]
+    fn write_new_binary_creates_a_fresh_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let target = tmp.path().join("icm.new");
+        write_new_binary(&target, b"payload").unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"payload");
+    }
 }


### PR DESCRIPTION
## Summary

Round 4 audit (fourth multi-agent pass, this time targeting the MCP
transport, import/archive/upgrade, the persistent HTTP API, and the
extraction pipeline).

- `upgrade.rs`: `File::create` (`O_CREAT|O_TRUNC`, no `O_EXCL`) followed an
  existing symlink at the .new install path. An attacker with write
  access to the exe's own directory could pre-place a symlink there,
  redirecting the verified-download write to clobber an unrelated
  file - not RCE (the payload is the legitimate SHA256-verified
  binary), but a real file-clobber/DoS gap, the same TOCTOU class
  already hardened in cloud.rs::write_secret_file. Extracted the
  write into write_new_binary(), which now removes any existing
  entry first (via symlink_metadata, so it sees the symlink itself
  rather than following it) and opens with create_new (O_EXCL), so
  even an attacker racing a fresh symlink into the gap fails the
  open instead of getting followed.
- import.rs: collect_recursive followed symlinks with no containment
  check. A directory tree passed to `icm import <dir>` containing a
  symlink to elsewhere on disk got silently walked, and its files
  imported as memories - outside the tree the user pointed at.
  Canonicalize every candidate path and require containment within
  the originally-requested root (same pattern as
  learn.rs::expand_workspace_glob, round 3 #369) - this also
  naturally handles symlink loops, since a loop's canonicalized
  target is unreachable and the resulting Err is skipped rather than
  recursed into.

## Test plan

- [x] New regression tests for both fixes, each verified to fail on pre-fix code and pass on the fix.
- [x] `cargo test --workspace` (325 passed; one unrelated `perf_fts_search_100` timing flake under parallel load, confirmed to pass in isolation and on a clean re-run)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] Manual end-to-end smoke test: ran `icm import` against a real directory containing a symlink escaping to a sibling directory - only the legitimate file was imported, the symlinked secret never reached the store.
