### PR TITLE
fix(uninstall): don't silently skip the --purge-data safety check

### DIFF
--- a/crates/icm-cli/src/uninstall/discover.rs
+++ b/crates/icm-cli/src/uninstall/discover.rs
@@ -54,6 +54,12 @@ pub(crate) struct RemovalPlan {
     pub scan_dir_hits: Vec<LocationHit>,
     /// Reserved for the `icm serve` process detector (a later commit).
     pub processes: Vec<RunningProcess>,
+    /// Set when process detection isn't implemented on this platform
+    /// (Windows/BSD/other). An empty `processes` list is otherwise
+    /// indistinguishable from "confirmed nothing running" — audit finding:
+    /// without this flag, `--purge-data` silently skipped its one safeguard
+    /// against WAL corruption on those platforms, even without `-y`.
+    pub process_detection_unsupported: bool,
 }
 
 impl RemovalPlan {

--- a/crates/icm-cli/src/uninstall/mod.rs
+++ b/crates/icm-cli/src/uninstall/mod.rs
@@ -95,7 +95,9 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
     // corruption risk). Skip it otherwise — most users run in
     // --mode standard which never spawns `icm serve`.
     if opts.purge_data {
-        plan.processes = process::detect_icm_serve();
+        let detection = process::detect_icm_serve();
+        plan.processes = detection.processes;
+        plan.process_detection_unsupported = detection.unsupported;
     }
 
     // --- Read-only modes ---
@@ -159,14 +161,26 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
         // Refuse to purge while `icm serve` is running unless the user
         // explicitly opted in via `-y`. Serve keeps the SQLite DB open
         // via WAL; deleting underneath it can corrupt cross-session
-        // neighbour processes.
-        if !plan.processes.is_empty() && !opts.yes {
+        // neighbour processes. Audit finding: process detection isn't
+        // implemented on every platform (Windows/BSD) and can fail even
+        // where it is (e.g. `/proc` unreadable) — `process_detection_unsupported`
+        // must gate this the same as "a process was found," or an empty
+        // list silently defeats the only safeguard here.
+        if should_refuse_purge(&plan, opts.yes) {
             println!();
-            println!(
-                "Refusing to --purge-data: {} `icm serve` process(es) detected. \
-                Stop them with `pkill -f 'icm serve'` (or pass -y to override at your own risk).",
-                plan.processes.len()
-            );
+            if plan.process_detection_unsupported {
+                println!(
+                    "Refusing to --purge-data: `icm serve` process detection isn't \
+                    supported on this platform, so we can't confirm none is running. \
+                    Stop any `icm serve` process yourself, then pass -y to override."
+                );
+            } else {
+                println!(
+                    "Refusing to --purge-data: {} `icm serve` process(es) detected. \
+                    Stop them with `pkill -f 'icm serve'` (or pass -y to override at your own risk).",
+                    plan.processes.len()
+                );
+            }
             for p in &plan.processes {
                 println!("  pid={:<6} {}", p.pid, p.cmdline);
             }
@@ -177,6 +191,13 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
                     "WARNING: {} `icm serve` process(es) still running — \
                     purging the DB anyway because -y was passed.",
                     plan.processes.len()
+                );
+            } else if plan.process_detection_unsupported {
+                println!();
+                println!(
+                    "WARNING: process detection isn't supported on this platform — \
+                    purging the DB anyway because -y was passed. Make sure `icm serve` \
+                    isn't running."
                 );
             }
             let purge_outcomes = mutate::purge_data(&plan, &mut backup_session);
@@ -196,4 +217,48 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
         after.total_hits(),
     );
     Ok(exit)
+}
+
+/// Whether `--purge-data` must refuse: a live `icm serve` was detected, or
+/// detection wasn't possible at all (audit finding — an empty process list
+/// is otherwise indistinguishable from "confirmed nothing running"), and
+/// the user hasn't passed `-y` to override.
+fn should_refuse_purge(plan: &discover::RemovalPlan, yes: bool) -> bool {
+    (!plan.processes.is_empty() || plan.process_detection_unsupported) && !yes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::uninstall::discover::RunningProcess;
+
+    #[test]
+    fn should_refuse_purge_when_a_process_is_detected() {
+        let mut plan = discover::RemovalPlan::default();
+        plan.processes.push(RunningProcess {
+            pid: 1234,
+            cmdline: "icm serve".into(),
+        });
+        assert!(should_refuse_purge(&plan, false));
+        assert!(!should_refuse_purge(&plan, true), "-y must override");
+    }
+
+    /// Audit regression: detection-unsupported must refuse by default, the
+    /// same as a confirmed-running process — not be treated as "confirmed
+    /// nothing running" just because the list happens to be empty.
+    #[test]
+    fn should_refuse_purge_when_detection_is_unsupported() {
+        let plan = discover::RemovalPlan {
+            process_detection_unsupported: true,
+            ..Default::default()
+        };
+        assert!(should_refuse_purge(&plan, false));
+        assert!(!should_refuse_purge(&plan, true), "-y must override");
+    }
+
+    #[test]
+    fn should_not_refuse_purge_when_confirmed_clean() {
+        let plan = discover::RemovalPlan::default();
+        assert!(!should_refuse_purge(&plan, false));
+    }
 }

--- a/crates/icm-cli/src/uninstall/process.rs
+++ b/crates/icm-cli/src/uninstall/process.rs
@@ -14,16 +14,60 @@
 
 use super::discover::RunningProcess;
 
-/// Return every process whose command line contains `"icm serve"`. The
-/// caller's own PID is filtered out so an `icm uninstall` invocation
-/// doesn't flag itself.
-pub(crate) fn detect_icm_serve() -> Vec<RunningProcess> {
-    detect_inner()
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|p| p.pid != std::process::id())
-        .filter(|p| p.cmdline.contains("icm serve"))
-        .collect()
+/// Result of a process-detection attempt.
+pub(crate) struct ProcessDetection {
+    pub processes: Vec<RunningProcess>,
+    /// Detection wasn't possible — either an unsupported platform (the
+    /// `detect_inner` stub below) or a runtime failure on a supported one
+    /// (e.g. `/proc` unreadable, `ps` failed to spawn). Audit finding: an
+    /// empty `processes` list is otherwise indistinguishable from
+    /// "confirmed nothing running," silently defeating the one safeguard
+    /// `--purge-data` has against WAL corruption from a live `icm serve`.
+    /// Callers must treat this the same as "something might be running."
+    pub unsupported: bool,
+}
+
+/// Detect running `icm serve` processes. The caller's own PID is filtered
+/// out so an `icm uninstall` invocation doesn't flag itself.
+pub(crate) fn detect_icm_serve() -> ProcessDetection {
+    match detect_inner() {
+        Some(procs) => {
+            let processes = procs
+                .into_iter()
+                .filter(|p| p.pid != std::process::id())
+                .filter(|p| is_icm_serve_cmdline(&p.cmdline))
+                .collect();
+            ProcessDetection {
+                processes,
+                unsupported: false,
+            }
+        }
+        None => ProcessDetection {
+            processes: Vec::new(),
+            unsupported: true,
+        },
+    }
+}
+
+/// Whether `cmdline` looks like an `icm serve` invocation. Audit finding:
+/// a raw `cmdline.contains("icm serve")` has a false-negative (any flag
+/// between the binary and the subcommand, e.g. `icm --db /x serve`, breaks
+/// the contiguous substring) and a false-positive (any unrelated process
+/// whose argv happens to contain that literal text, e.g. `grep 'icm
+/// serve' log.txt`). Instead: the first token's basename must be exactly
+/// `icm` (allowing a `.exe` suffix), and some later token must be exactly
+/// `serve`.
+fn is_icm_serve_cmdline(cmdline: &str) -> bool {
+    let mut tokens = cmdline.split_whitespace();
+    let Some(argv0) = tokens.next() else {
+        return false;
+    };
+    let basename = argv0.rsplit(['/', '\\']).next().unwrap_or(argv0);
+    let basename = basename.strip_suffix(".exe").unwrap_or(basename);
+    if basename != "icm" {
+        return false;
+    }
+    tokens.any(|t| t == "serve")
 }
 
 #[cfg(target_os = "linux")]
@@ -91,10 +135,12 @@ fn detect_inner() -> Option<Vec<RunningProcess>> {
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 fn detect_inner() -> Option<Vec<RunningProcess>> {
-    // Windows/BSD/other: no detection in this PR. Uninstall still works;
-    // the report just won't surface a warning. A follow-up can add
-    // `sysinfo` or `tasklist` integration.
-    Some(Vec::new())
+    // Windows/BSD/other: no detection in this PR. `None` (not `Some(vec![])`)
+    // — the caller treats this as "detection unavailable," which
+    // --purge-data must handle the same as "something might be running"
+    // rather than silently assuming the coast is clear (audit finding). A
+    // follow-up can add `sysinfo` or `tasklist` integration.
+    None
 }
 
 #[cfg(test)]
@@ -106,10 +152,42 @@ mod tests {
         // We can't assert on the *content* (the test runner's own pid
         // would show up in /proc), but the function must succeed and the
         // self-PID filter must hold.
-        let procs = detect_icm_serve();
-        for p in &procs {
+        let detection = detect_icm_serve();
+        for p in &detection.processes {
             assert_ne!(p.pid, std::process::id());
-            assert!(p.cmdline.contains("icm serve"));
+            assert!(is_icm_serve_cmdline(&p.cmdline));
         }
+    }
+
+    /// Audit regression: a raw substring check (`cmdline.contains("icm
+    /// serve")`) missed `icm --db /x serve` (a flag between binary and
+    /// subcommand breaks the contiguous substring) and falsely matched an
+    /// unrelated process like `grep 'icm serve' log.txt`.
+    #[test]
+    fn is_icm_serve_cmdline_matches_only_the_real_thing() {
+        assert!(is_icm_serve_cmdline("icm serve"));
+        assert!(is_icm_serve_cmdline("icm serve --http 127.0.0.1:11435"));
+        assert!(is_icm_serve_cmdline(
+            "icm --db /x/memories.db serve --compact"
+        ));
+        assert!(is_icm_serve_cmdline("/usr/local/bin/icm serve"));
+        assert!(is_icm_serve_cmdline("C:\\Users\\pat\\bin\\icm.exe serve"));
+
+        assert!(!is_icm_serve_cmdline("grep 'icm serve' log.txt"));
+        assert!(!is_icm_serve_cmdline("icm decay"));
+        assert!(!is_icm_serve_cmdline(""));
+    }
+
+    /// Audit regression: on an unsupported platform, detection used to
+    /// return `Ok(vec![])`, indistinguishable from "confirmed nothing
+    /// running" — silently defeating --purge-data's one safeguard against
+    /// WAL corruption even without `-y`. The `unsupported` flag lets the
+    /// caller refuse by default instead.
+    #[test]
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    fn detect_icm_serve_reports_unsupported_on_unsupported_platforms() {
+        let detection = detect_icm_serve();
+        assert!(detection.unsupported);
+        assert!(detection.processes.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Round 5 audit (fifth multi-agent pass, targeting hook command handlers,
install/uninstall config-mutation logic, and remaining CLI commands -
areas rounds 1-4 hadn't covered).

- On Windows/BSD (and on any platform if the detection call itself
  fails, e.g. /proc unreadable), process detection returned Ok(vec![]),
  identical to "confirmed no icm serve running." --purge-data's only
  safeguard against WAL corruption from a live icm serve gates on
  exactly that emptiness check, so detection failing silently defeated
  it - even without -y. Added a distinct `unsupported` flag threaded
  through RemovalPlan; --purge-data now refuses by default when
  detection wasn't possible, the same as when a process is actually
  found, with a message telling the user to check manually before
  passing -y.
- The process-match itself was a raw `cmdline.contains("icm serve")`:
  false-negative on any flag between binary and subcommand (e.g.
  `icm --db /x serve`, common since users can pass --db), false-
  positive on any unrelated process whose argv happens to contain that
  literal text (e.g. `grep 'icm serve' log.txt`). Replaced with a
  token-based check: first token's basename must be exactly `icm`
  (allowing a .exe suffix), and some later token must be exactly
  `serve`.

## Test plan

- [x] New regression tests for both fixes (the refuse-decision extracted into a small pure function so detection-unsupported and confirmed-running cases can be tested without a real process), each verified to fail on pre-fix code and pass on the fix.
- [x] `cargo test --workspace` (332 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] Manual smoke test: `icm uninstall --purge-data --audit` on macOS (a supported platform) - confirmed no regression in the normal case, no spurious warning.
