### PR TITLE
fix(hooks): cap inline extraction input size

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -3486,9 +3486,11 @@ fn cmd_hook_post(
     // (a malicious tool could emit decision-keyword text to poison wake-up).
     // Pass the embedder so non-English content is also scored: the keyword
     // scorer is English-only and would silently drop FR/DE/etc. facts.
+    // Also cap the input size — see cap_tool_output_for_inline_extraction.
+    let capped_inline = cap_tool_output_for_inline_extraction(tool_output);
     match extract::extract_and_store_with_embedder(
         store,
-        tool_output,
+        capped_inline,
         &project,
         store_raw,
         icm_core::Importance::Medium,
@@ -3861,6 +3863,20 @@ pub(crate) fn truncate_tail_at_char_boundary(s: &str, max_bytes: usize) -> &str 
         start += 1;
     }
     &s[start..]
+}
+
+/// Audit finding: the inline (default, provider=none) PostToolUse extraction
+/// path ran sentence-splitting + keyword/semantic scoring over the ENTIRE
+/// tool output with no cap, unlike the async LLM path just above it (capped
+/// at 8 KB "to keep the queue reasonable"). A single large tool output (a
+/// verbose build/test log, a `cat` of a big file) could synchronously block
+/// the next PostToolUse hook for far longer than the already-noted ~3.7s
+/// typical cost, with only the outer 32 MB stdin cap as a backstop. Larger
+/// than the async path's cap since inline extraction is the path most
+/// installs actually experience in-session, and losing extraction quality
+/// would be more noticeable here.
+pub(crate) fn cap_tool_output_for_inline_extraction(tool_output: &str) -> &str {
+    truncate_tail_at_char_boundary(tool_output, 16_384)
 }
 
 /// UserPromptSubmit hook (Layer 2): inject recalled context at the start of each prompt.
@@ -9888,6 +9904,28 @@ mod hook_start_tests {
         assert!(p.contains("## Recent decisions"));
         assert!(p.contains("use SQLite for storage"));
         assert!(p.contains("fixed the spawn loop"));
+    }
+
+    /// Audit regression: the inline (default) PostToolUse extraction path
+    /// ran sentence-splitting + keyword/semantic scoring over the ENTIRE
+    /// tool output with no cap at all, unlike the async LLM path (capped at
+    /// 8 KB). A single large tool output could synchronously block the
+    /// next PostToolUse hook for far longer than normal.
+    #[test]
+    fn cap_tool_output_for_inline_extraction_bounds_large_input() {
+        let huge = "x".repeat(1_000_000);
+        let capped = cap_tool_output_for_inline_extraction(&huge);
+        assert!(
+            capped.len() <= 16_384,
+            "inline extraction input must be bounded, got {} bytes",
+            capped.len()
+        );
+    }
+
+    #[test]
+    fn cap_tool_output_for_inline_extraction_is_a_noop_for_small_input() {
+        let small = "short tool output";
+        assert_eq!(cap_tool_output_for_inline_extraction(small), small);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Round 5 audit (fifth multi-agent pass, targeting hook command handlers,
install/uninstall config-mutation logic, and remaining CLI commands).

The inline (default, provider=none) PostToolUse extraction path ran
sentence-splitting plus keyword/semantic scoring over the ENTIRE tool
output with no cap at all, unlike the async LLM path just above it in
the same function - explicitly capped at 8 KB "to keep the queue
reasonable." This path's own comment already notes it costs ~3.7s for
a typical input; a single large tool output (a verbose build/test log,
a `cat` of a big file) can drive that far higher, synchronously
blocking the next PostToolUse hook for the whole session. Only the
outer 32 MB stdin cap bounded it at all.

Extracted the cap into cap_tool_output_for_inline_extraction (16 KB -
larger than the async path's cap since inline extraction is the
default path most installs actually experience in-session, and losing
extraction quality would be more noticeable here) so it's directly
testable without needing to fork a subprocess with piped stdin (the
surrounding cmd_hook_post reads real stdin, making it hard to unit
test as a whole).

## Test plan

- [x] New regression tests verifying the cap bounds large input and is a no-op for normal-sized input, verified to fail on pre-fix code and pass on the fix.
- [x] `cargo test --workspace` (330 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] Manual smoke test: `icm hook post` with a 500 KB tool output via a real piped stdin payload - confirmed extraction still runs and completes quickly.
