### PR TITLE
fix(cli): write config/backup/manifest files atomically

### DIFF
--- a/crates/icm-cli/src/install_manifest.rs
+++ b/crates/icm-cli/src/install_manifest.rs
@@ -119,7 +119,7 @@ impl InstallManifest {
                 .with_context(|| format!("cannot create {}", parent.display()))?;
         }
         let json = serde_json::to_string_pretty(self)?;
-        std::fs::write(path, json)
+        crate::uninstall::atomic_write(path, json.as_bytes())
             .with_context(|| format!("cannot write manifest {}", path.display()))?;
         Ok(())
     }

--- a/crates/icm-cli/src/uninstall/backup.rs
+++ b/crates/icm-cli/src/uninstall/backup.rs
@@ -157,7 +157,7 @@ impl BackupSession {
         };
         let path = self.root.join("manifest.json");
         let json = serde_json::to_string_pretty(&manifest)?;
-        std::fs::write(&path, json)
+        super::atomic_write(&path, json.as_bytes())
             .with_context(|| format!("cannot write manifest {}", path.display()))?;
         Ok(())
     }

--- a/crates/icm-cli/src/uninstall/formats.rs
+++ b/crates/icm-cli/src/uninstall/formats.rs
@@ -421,7 +421,8 @@ pub(crate) fn rewrite_json_mcp(path: &std::path::Path, dotted_key: &str) -> Resu
     let result = strip_json_mcp_server(&mut value, dotted_key);
     if matches!(result, StripResult::Removed { .. }) {
         let out = serde_json::to_string_pretty(&value)?;
-        std::fs::write(path, out).with_context(|| format!("cannot write {}", path.display()))?;
+        super::atomic_write(path, out.as_bytes())
+            .with_context(|| format!("cannot write {}", path.display()))?;
     }
     Ok(result)
 }
@@ -434,7 +435,8 @@ pub(crate) fn rewrite_json_hooks(
     let result = strip_json_hooks(&mut value, field);
     if matches!(result, StripResult::Removed { .. }) {
         let out = serde_json::to_string_pretty(&value)?;
-        std::fs::write(path, out).with_context(|| format!("cannot write {}", path.display()))?;
+        super::atomic_write(path, out.as_bytes())
+            .with_context(|| format!("cannot write {}", path.display()))?;
     }
     Ok(result)
 }
@@ -450,7 +452,8 @@ pub(crate) fn rewrite_toml(
     let result = strip_toml_table(&mut value, table, entry);
     if matches!(result, StripResult::Removed { .. }) {
         let out = toml::to_string(&value)?;
-        std::fs::write(path, out).with_context(|| format!("cannot write {}", path.display()))?;
+        super::atomic_write(path, out.as_bytes())
+            .with_context(|| format!("cannot write {}", path.display()))?;
     }
     Ok(result)
 }
@@ -461,7 +464,7 @@ pub(crate) fn rewrite_yaml_continue(path: &std::path::Path) -> Result<StripResul
     let result = strip_yaml_continue(&content);
     if matches!(result, StripResult::Removed { .. }) {
         let new_content = apply_yaml_continue(&content);
-        std::fs::write(path, new_content)
+        super::atomic_write(path, new_content.as_bytes())
             .with_context(|| format!("cannot write {}", path.display()))?;
     }
     Ok(result)
@@ -473,7 +476,7 @@ pub(crate) fn rewrite_markdown(path: &std::path::Path) -> Result<StripResult> {
     match strip_markdown_block(&content) {
         MarkdownOutcome::NoOp => Ok(StripResult::NoOp),
         MarkdownOutcome::Rewrite(new) => {
-            std::fs::write(path, new)
+            super::atomic_write(path, new.as_bytes())
                 .with_context(|| format!("cannot write {}", path.display()))?;
             Ok(StripResult::Removed { removed: 1 })
         }

--- a/crates/icm-cli/src/uninstall/mod.rs
+++ b/crates/icm-cli/src/uninstall/mod.rs
@@ -21,6 +21,21 @@ pub(crate) mod process;
 pub(crate) mod report;
 pub(crate) mod scan_dir;
 
+/// Write `content` to `path` atomically: write to a temp file in the same
+/// directory, then rename over the target. A crash or kill mid-write
+/// leaves either the old file fully intact or the new one fully written —
+/// never a truncated/corrupted file (audit finding: `formats.rs`/
+/// `backup.rs` both used plain `fs::write`, truncate-then-write, which can
+/// leave the user's real settings.json/config.toml or our own backup
+/// manifest half-written on a crash).
+pub(crate) fn atomic_write(path: &std::path::Path, content: &[u8]) -> std::io::Result<()> {
+    let mut tmp_name = path.file_name().unwrap_or_default().to_os_string();
+    tmp_name.push(".icm-tmp");
+    let tmp_path = path.with_file_name(tmp_name);
+    std::fs::write(&tmp_path, content)?;
+    std::fs::rename(&tmp_path, path)
+}
+
 /// CLI surface for `icm uninstall`. Kept here so the rest of the crate only
 /// imports `UninstallOpts` from this module.
 #[derive(Args, Debug, Clone)]
@@ -260,5 +275,48 @@ mod tests {
     fn should_not_refuse_purge_when_confirmed_clean() {
         let plan = discover::RemovalPlan::default();
         assert!(!should_refuse_purge(&plan, false));
+    }
+
+    #[test]
+    fn atomic_write_replaces_content_and_leaves_no_temp_file() {
+        let dir =
+            std::env::temp_dir().join(format!("icm-atomic-write-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("target.txt");
+        std::fs::write(&path, "v1").unwrap();
+
+        atomic_write(&path, b"v2").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "v2");
+        assert!(!path.with_file_name("target.txt.icm-tmp").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Audit finding: plain `fs::write` truncates the destination before
+    /// writing, so a write failure mid-way corrupts the existing file. The
+    /// atomic version must leave the original file fully intact if the
+    /// (separate) temp file write fails, since the destination is only ever
+    /// touched by the final `rename`.
+    #[test]
+    fn atomic_write_preserves_original_when_temp_write_fails() {
+        let dir =
+            std::env::temp_dir().join(format!("icm-atomic-write-fail-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("target.txt");
+        std::fs::write(&path, "original").unwrap();
+        // Force the temp-file write to fail by pre-occupying its path with
+        // a directory instead of a plain file.
+        let tmp_path = path.with_file_name("target.txt.icm-tmp");
+        std::fs::create_dir_all(&tmp_path).unwrap();
+
+        let result = atomic_write(&path, b"new content");
+
+        assert!(result.is_err(), "write into a directory must fail");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "original",
+            "destination must be untouched when the temp write fails"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
## Summary

- `uninstall/formats.rs`, `uninstall/backup.rs`, and `install_manifest.rs` all persisted their files via plain `fs::write` (truncate-then-write). A crash or kill mid-write left either the user's real `settings.json`/`config.toml`, our uninstall backup manifest, or `install-manifest.json` half-written and corrupted.
- Added a shared `atomic_write` helper in `uninstall/mod.rs`: write to a temp file in the same directory, then `rename` over the target. A crash between the two steps leaves either the old file fully intact or the new one fully written — never a truncated result.
- Applied it at all three affected write sites.

## Test plan

- [x] New regression tests for `atomic_write` itself: content replacement + no leftover temp file on success, and original file preserved untouched when the temp-file write fails (simulated by pre-occupying the temp path with a directory).
- [x] Verified fail-before/pass-after: reverted `atomic_write` to plain `fs::write` and confirmed the "preserves original on failure" test fails; restored the fix and confirmed it passes.
- [x] `cargo test --workspace --all-features` (722 passed), `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all` (clean).
- [x] Real end-to-end smoke test: `icm init` → `icm init --force` (rewrite path) → `icm uninstall -y` against a scratch `$HOME`, verifying `settings.json`, `install-manifest.json`, and the uninstall backup's `manifest.json` are all valid JSON after every write.
