### PR TITLE
fix(store): dedupe existing duplicate summary_hash rows before the unique index migration

### DIFF
--- a/crates/icm-store/src/schema.rs
+++ b/crates/icm-store/src/schema.rs
@@ -159,6 +159,24 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
                 .map_err(db_err)?;
         }
     }
+    // Audit finding: any DB that hit the accented-topic dedup bug the old
+    // composite index let through (see comment above) already has two or
+    // more rows sharing one non-null `summary_hash`. `CREATE UNIQUE INDEX`
+    // below would then fail outright with a UNIQUE constraint error,
+    // propagating up through `init_db_with_dims` and bricking exactly the
+    // DBs this fix was meant to repair. Deduplicate first — keep the
+    // earliest-inserted row per `summary_hash` group (lowest rowid), drop
+    // the rest. A no-op (empty scan) on any DB that never hit the bug.
+    conn.execute_batch(
+        "DELETE FROM memories
+            WHERE summary_hash IS NOT NULL
+              AND rowid NOT IN (
+                SELECT MIN(rowid) FROM memories
+                WHERE summary_hash IS NOT NULL
+                GROUP BY summary_hash
+              );",
+    )
+    .map_err(db_err)?;
     conn.execute_batch(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_topic_hash
             ON memories(summary_hash) WHERE summary_hash IS NOT NULL;",
@@ -714,6 +732,91 @@ mod tests {
         assert!(
             !sql.contains("LOWER(topic)"),
             "old composite index definition must be replaced, got: {sql}"
+        );
+    }
+
+    /// Audit regression: a DB that hit the accented-topic dedup bug (the old
+    /// composite `(LOWER(topic), summary_hash)` index let two rows share one
+    /// `summary_hash` whenever their topics' SQL-LOWER() forms differed)
+    /// already has duplicate `summary_hash` rows on disk. `CREATE UNIQUE
+    /// INDEX idx_memories_topic_hash ON memories(summary_hash)` must not
+    /// simply fail on that pre-existing duplicate — it must deduplicate
+    /// first, or the fix for the accented-dedup bug bricks exactly the DBs
+    /// it was meant to repair.
+    #[test]
+    fn test_migration_dedupes_existing_duplicate_summary_hash_before_unique_index() {
+        ensure_vec_init();
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).expect("fresh init must succeed");
+
+        // Force the DB back to the OLD composite index, as if created
+        // before the accented-dedup fix.
+        conn.execute_batch("DROP INDEX idx_memories_topic_hash;")
+            .unwrap();
+        conn.execute_batch(
+            "CREATE UNIQUE INDEX idx_memories_topic_hash
+                ON memories(LOWER(topic), summary_hash) WHERE summary_hash IS NOT NULL;",
+        )
+        .unwrap();
+
+        // Two rows whose topics differ only by the accented-letter casing
+        // SQLite's ASCII-only LOWER() doesn't fold (LOWER("Décisions") =
+        // "décisions" but LOWER("DÉCISIONS") = "dÉcisions" — the 'É' stays
+        // uppercase) — so the old composite index treats them as distinct,
+        // even though they share the SAME summary_hash (Rust's
+        // Unicode-correct to_lowercase() folds both to "décisions").
+        conn.execute(
+            "INSERT INTO memories \
+             (id, created_at, last_accessed, topic, summary, importance, source_type, summary_hash) \
+             VALUES ('older-row', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', \
+                     'Décisions', 'we picked postgres', 'medium', 'manual', 'dup-hash-1')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO memories \
+             (id, created_at, last_accessed, topic, summary, importance, source_type, summary_hash) \
+             VALUES ('newer-row', '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z', \
+                     'DÉCISIONS', 'we picked postgres', 'medium', 'manual', 'dup-hash-1')",
+            [],
+        )
+        .unwrap();
+
+        // Re-running init_db must NOT error out — it must dedupe first.
+        init_db(&conn).expect("migration must survive pre-existing duplicate summary_hash rows");
+
+        let remaining: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM memories WHERE summary_hash = 'dup-hash-1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(remaining, 1, "exactly one duplicate row must survive");
+
+        let surviving_id: String = conn
+            .query_row(
+                "SELECT id FROM memories WHERE summary_hash = 'dup-hash-1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            surviving_id, "older-row",
+            "the earliest-inserted duplicate should survive, not be arbitrarily chosen"
+        );
+
+        // The new unique index must be in place and enforced going forward.
+        let sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_memories_topic_hash'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            !sql.contains("LOWER(topic)"),
+            "must be on the new definition: {sql}"
         );
     }
 


### PR DESCRIPTION
## Summary

- The accented-topic dedup fix (an earlier round) replaced the old composite `(LOWER(topic), summary_hash)` unique index with a `UNIQUE INDEX ON memories(summary_hash)`, since SQLite's ASCII-only `LOWER()` treated e.g. "Décisions"/"DÉCISIONS" as different topics while Rust's Unicode-correct `to_lowercase()` (which is what `summary_hash` is derived from) treats them as the same.
- Any DB that had already accumulated duplicate `summary_hash` rows under the old, buggy composite index now fails the new `CREATE UNIQUE INDEX` outright with a constraint violation. `init_db_with_dims` returns `Err`, and the application can't open the store at all — the fix for the accented-dedup bug bricks exactly the databases it was meant to repair.
- Added a dedup step (keep the earliest-inserted row per `summary_hash` group, delete the rest) before creating the unique index. A no-op empty scan on any DB that never hit the original bug.

## Test plan

- [x] New regression test: seeds a DB with the OLD composite index and two rows whose topics differ only by accented-letter casing (`"Décisions"` vs `"DÉCISIONS"`) but share one `summary_hash` — confirms `init_db` now succeeds (previously errored with `UNIQUE constraint failed`) and that exactly the earliest-inserted row survives.
- [x] Verified fail-before/pass-after: reverted the dedup step and confirmed the new test fails with the exact constraint-violation error described above; restored the fix and confirmed it passes.
- [x] All existing schema.rs migration tests still pass (11/11), including the pre-0.10.43 legacy-schema migration and the old-composite-index-replacement test.
- [x] `cargo test --workspace --all-features` (737 passed), `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all` (clean).
