### PR TITLE
fix(core): raise the dedup similarity threshold to stop false-positive merges

### DIFF
--- a/crates/icm-core/src/store.rs
+++ b/crates/icm-core/src/store.rs
@@ -2,7 +2,24 @@ use crate::error::IcmResult;
 use crate::memory::{Memory, StoreStats, TopicHealth};
 
 /// Similarity score above which a new memory is considered a duplicate of an existing one.
-pub const DEDUP_SIMILARITY_THRESHOLD: f32 = 0.85;
+///
+/// Calibrated empirically against the real multilingual-e5-base embedder
+/// (manual testing finding, 2026-07-27): short, topic-scoped sentences
+/// that share a syntactic template ("we picked X over Y" / "on a choisi X
+/// plutôt que Y") but describe genuinely DIFFERENT facts scored
+/// 0.90-0.93 cosine similarity — e.g. "We picked PostgreSQL over MySQL
+/// for the primary database" vs "We picked Kubernetes over Docker Swarm
+/// for the orchestration layer" scored 0.9093. At the old 0.85 threshold
+/// this silently overwrote the earlier, unrelated memory's content (the
+/// merge path replaces `summary` wholesale — see the `cmd_store`/
+/// `icm_memory_store` callers). Genuine near-duplicate restatements
+/// ("PostgreSQL was selected over MySQL for the main datastore") scored
+/// 0.9156-0.9635 — overlapping enough with the false-positive band that
+/// no threshold cleanly separates every case. 0.95 was chosen to
+/// eliminate the measured false positives (0.90-0.93) even at the cost
+/// of missing some looser true near-duplicates (an extra, redundant
+/// memory entry is far cheaper than silently destroying one).
+pub const DEDUP_SIMILARITY_THRESHOLD: f32 = 0.95;
 
 /// Find an existing memory that is similar enough to be considered a duplicate.
 ///
@@ -68,4 +85,150 @@ pub trait MemoryStore {
     fn count_by_topic(&self, topic: &str) -> IcmResult<usize>;
     fn stats(&self) -> IcmResult<StoreStats>;
     fn topic_health(&self, topic: &str) -> IcmResult<TopicHealth>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::Importance;
+
+    /// Minimal `MemoryStore` double: `search_by_embedding` returns a fixed
+    /// (Memory, score) pair regardless of the query embedding, everything
+    /// else is unused by `find_similar_memory` and panics if called.
+    struct FixedMatchStore {
+        candidate: Memory,
+        score: f32,
+    }
+
+    impl MemoryStore for FixedMatchStore {
+        fn store(&self, _memory: Memory) -> IcmResult<String> {
+            unimplemented!()
+        }
+        fn get(&self, _id: &str) -> IcmResult<Option<Memory>> {
+            unimplemented!()
+        }
+        fn update(&self, _memory: &Memory) -> IcmResult<()> {
+            unimplemented!()
+        }
+        fn delete(&self, _id: &str) -> IcmResult<()> {
+            unimplemented!()
+        }
+        fn search_by_keywords(&self, _keywords: &[&str], _limit: usize) -> IcmResult<Vec<Memory>> {
+            unimplemented!()
+        }
+        fn search_fts(&self, _query: &str, _limit: usize) -> IcmResult<Vec<Memory>> {
+            unimplemented!()
+        }
+        fn search_by_embedding(
+            &self,
+            _embedding: &[f32],
+            _limit: usize,
+        ) -> IcmResult<Vec<(Memory, f32)>> {
+            Ok(vec![(self.candidate.clone(), self.score)])
+        }
+        fn search_hybrid(
+            &self,
+            _query: &str,
+            _embedding: &[f32],
+            _limit: usize,
+        ) -> IcmResult<Vec<(Memory, f32)>> {
+            unimplemented!()
+        }
+        fn update_access(&self, _id: &str) -> IcmResult<()> {
+            unimplemented!()
+        }
+        fn batch_update_access(&self, _ids: &[&str]) -> IcmResult<usize> {
+            unimplemented!()
+        }
+        fn apply_decay(&self, _decay_factor: f32) -> IcmResult<usize> {
+            unimplemented!()
+        }
+        fn prune(&self, _weight_threshold: f32) -> IcmResult<usize> {
+            unimplemented!()
+        }
+        fn list_all(&self) -> IcmResult<Vec<Memory>> {
+            unimplemented!()
+        }
+        fn get_by_topic(&self, _topic: &str) -> IcmResult<Vec<Memory>> {
+            unimplemented!()
+        }
+        fn list_topics(&self) -> IcmResult<Vec<(String, usize)>> {
+            unimplemented!()
+        }
+        fn consolidate_topic(&self, _topic: &str, _consolidated: Memory) -> IcmResult<()> {
+            unimplemented!()
+        }
+        fn count(&self) -> IcmResult<usize> {
+            unimplemented!()
+        }
+        fn count_by_topic(&self, _topic: &str) -> IcmResult<usize> {
+            unimplemented!()
+        }
+        fn stats(&self) -> IcmResult<StoreStats> {
+            unimplemented!()
+        }
+        fn topic_health(&self, _topic: &str) -> IcmResult<TopicHealth> {
+            unimplemented!()
+        }
+    }
+
+    /// Manual-testing finding (2026-07-27): short, topic-scoped sentences
+    /// sharing a syntactic template but describing genuinely different
+    /// facts measured 0.90-0.93 cosine similarity against the real
+    /// multilingual-e5-base embedder — e.g. "We picked PostgreSQL over
+    /// MySQL for the primary database" vs "We picked Kubernetes over
+    /// Docker Swarm for the orchestration layer" scored 0.9093. At the old
+    /// 0.85 threshold this silently overwrote the earlier memory's
+    /// content. The new threshold (0.95) must reject a 0.90-similarity
+    /// match; a near-exact 0.99 match must still be treated as a
+    /// duplicate.
+    #[test]
+    fn dedup_threshold_rejects_the_measured_false_positive_similarity() {
+        let candidate = Memory::new(
+            "decisions".to_string(),
+            "We picked PostgreSQL over MySQL for the primary database".to_string(),
+            Importance::High,
+        );
+        let store = FixedMatchStore {
+            candidate,
+            score: 0.90,
+        };
+        let result = find_similar_memory(
+            &store,
+            "query",
+            &[1.0, 0.0],
+            "decisions",
+            DEDUP_SIMILARITY_THRESHOLD,
+        )
+        .unwrap();
+        assert!(
+            result.is_none(),
+            "a 0.90-similarity match (the measured false-positive band) must not be treated as a duplicate"
+        );
+    }
+
+    #[test]
+    fn dedup_threshold_still_accepts_a_near_exact_match() {
+        let candidate = Memory::new(
+            "decisions".to_string(),
+            "We picked PostgreSQL over MySQL for the primary database".to_string(),
+            Importance::High,
+        );
+        let store = FixedMatchStore {
+            candidate,
+            score: 0.99,
+        };
+        let result = find_similar_memory(
+            &store,
+            "query",
+            &[1.0, 0.0],
+            "decisions",
+            DEDUP_SIMILARITY_THRESHOLD,
+        )
+        .unwrap();
+        assert!(
+            result.is_some(),
+            "a near-exact 0.99-similarity match must still be treated as a duplicate"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Found via manual functional testing of the compiled binary (not the automated audit rounds): storing two genuinely different decisions under the same topic silently merged them, destroying the first one's content.

```
icm store -t decisions-icm -c "On a choisi SQLite plutot que Postgres pour la simplicite de deploiement" -i high
icm store -t decisions-icm -c "On a decide d'utiliser fastembed pour les embeddings locaux au lieu d'OpenAI" -i high
# -> "Updated existing memory (similarity 0.93)" - the SQLite decision's content is gone.
```

**Root cause**: `DEDUP_SIMILARITY_THRESHOLD = 0.85` was calibrated for the hybrid FTS+cosine score this code used before #363 replaced it with pure cosine similarity (a deliberate, correct fix at the time — the hybrid score capped a pure semantic match at 0.70, making the threshold unreachable). Pure cosine alone is far more permissive: two sentences sharing a syntactic template ("we picked X over Y" / "on a choisi X plutôt que Y") but describing unrelated facts can score very high similarity purely from the shared sentence structure.

**Calibration** (measured against the real multilingual-e5-base embedder, see the doc comment on the constant for the full data): same-template/different-content pairs scored 0.90–0.93; genuine near-duplicate restatements scored 0.9156–0.9635. The two bands overlap enough that no threshold perfectly separates every case. Raised to **0.95**, which eliminates every false positive I measured while still catching confident near-duplicates — the tradeoff (occasionally missing a looser true near-duplicate, leaving a redundant entry) is far preferable to silently destroying real content.

## Test plan

- [x] New regression tests using a deterministic stub `MemoryStore`: a 0.90-similarity match (the measured false-positive band) is correctly rejected; a 0.99-similarity match (near-exact) is still correctly treated as a duplicate.
- [x] Verified fail-before/pass-after: reverted to the old 0.85 threshold and confirmed the false-positive test fails; restored and confirmed it passes.
- [x] Real end-to-end verification on the compiled binary: replayed the exact original bug scenario — both decisions now correctly coexist. Confirmed exact duplicates (similarity 1.00) still merge, and a genuine near-duplicate paraphrase (similarity 0.98) still merges too.
- [x] `cargo test --workspace --all-features` (739 passed), `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean), `cargo fmt --all` (clean).
