### PR TITLE
fix(store): clean up dangling related_ids after delete, across all 3 backends

### DIFF
--- a/crates/icm-store/src/opensearch.rs
+++ b/crates/icm-store/src/opensearch.rs
@@ -732,6 +732,32 @@ impl MemoryStore for OpenSearchStore {
             None,
             true,
         )?;
+
+        // Manual-testing finding (same class as the SQLite/Postgres
+        // backends): a deleted memory otherwise stays as a dangling entry
+        // in every other memory's `related_ids` forever. `related_ids` is
+        // mapped as a `keyword` array field, so a term query finds every
+        // document that references it and a Painless script strips it out
+        // in place. Best-effort: a failure here doesn't roll back the
+        // delete above (OpenSearch has no cross-document transaction to
+        // roll back into) — surfacing an error would make a successful
+        // delete look like it failed, so log and move on.
+        if let Err(e) = self.post(
+            &format!(
+                "{IDX_MEMORIES}/_update_by_query?conflicts=proceed&{}",
+                self.refresh_param()
+            ),
+            json!({
+                "script": {
+                    "source": "ctx._source.related_ids.removeIf(x -> x == params.deleted_id)",
+                    "params": {"deleted_id": id}
+                },
+                "query": {"term": {"related_ids": id}}
+            }),
+        ) {
+            tracing::warn!(error = %e, id, "failed to clean up dangling related_ids after delete");
+        }
+
         Ok(())
     }
 

--- a/crates/icm-store/src/postgres.rs
+++ b/crates/icm-store/src/postgres.rs
@@ -1211,12 +1211,30 @@ impl MemoryStore for PostgresStore {
             return Err(IcmError::ReadOnly("delete".into()));
         }
         let mut c = self.conn()?;
-        let changed = c
+        let mut tx = c.transaction().map_err(pg_err)?;
+        let changed = tx
             .execute("DELETE FROM memories WHERE id = $1", &[&id])
             .map_err(pg_err)?;
         if changed == 0 {
             return Err(IcmError::NotFound(id.to_string()));
         }
+        // Manual-testing finding (same class as the SQLite backend): a
+        // deleted memory otherwise stays as a dangling entry in every
+        // other memory's `related_ids` forever. Strip it out. `LIKE` is a
+        // cheap prefilter; the JSON-quoted match guards against a ULID
+        // that happens to be a literal substring of another.
+        tx.execute(
+            "UPDATE memories
+                SET related_ids = (
+                    SELECT COALESCE(jsonb_agg(elem), '[]'::jsonb)::text
+                    FROM jsonb_array_elements_text(related_ids::jsonb) AS elem
+                    WHERE elem != $1
+                )
+                WHERE related_ids LIKE '%\"' || $1 || '\"%'",
+            &[&id],
+        )
+        .map_err(pg_err)?;
+        tx.commit().map_err(pg_err)?;
         Ok(())
     }
 

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -1544,13 +1544,44 @@ impl MemoryStore for SqliteStore {
             if changed == 0 {
                 return Err(IcmError::NotFound(id.to_string()));
             }
+
+            // Manual-testing finding: deleting a memory left it as a
+            // dangling entry in every other memory's `related_ids`
+            // (auto-link back-references) forever — `expand_with_neighbors`
+            // tolerates the miss silently, but each stale id still spends a
+            // slot out of the caller's `max_neighbors` budget instead of
+            // surfacing a real, live neighbor, and any external consumer of
+            // the JSON export sees a reference to nothing. Strip the
+            // deleted id from every `related_ids` array that mentions it.
+            // The `LIKE` clause is a cheap prefilter (only rows that could
+            // possibly match do the JSON rewrite); it matches the
+            // JSON-quoted form specifically so a ULID that happens to be a
+            // literal substring of another can't cause a false hit.
+            self.conn
+                .execute(
+                    "UPDATE memories
+                        SET related_ids = (
+                            SELECT COALESCE(json_group_array(value), '[]')
+                            FROM json_each(memories.related_ids)
+                            WHERE value != ?1
+                        )
+                        WHERE related_ids LIKE '%\"' || ?1 || '\"%'",
+                    params![id],
+                )
+                .map_err(db_err)?;
+
             Ok(())
         })();
 
         match result {
             Ok(()) => {
                 self.conn.execute_batch("COMMIT;").map_err(db_err)?;
-                self.cache_invalidate(id);
+                // The related_ids cleanup above can touch an arbitrary
+                // number of other rows, not just `id` — clear the whole
+                // cache rather than tracking which ones, so a cached
+                // neighbor's `related_ids` can't keep serving the
+                // just-deleted id after this returns.
+                self.cache_clear();
                 Ok(())
             }
             Err(e) => {
@@ -4735,6 +4766,50 @@ mod tests {
         let store = test_store();
         let result = store.delete("nonexistent");
         assert!(matches!(result, Err(IcmError::NotFound(_))));
+    }
+
+    /// Manual-testing finding: deleting a memory left it as a dangling
+    /// entry in every other memory's `related_ids` (auto-link
+    /// back-references) forever. `expand_with_neighbors` tolerates the
+    /// miss silently, but each stale id still spends a slot out of the
+    /// caller's `max_neighbors` budget instead of surfacing a real, live
+    /// neighbor, and any external consumer of the JSON export sees a
+    /// reference to nothing.
+    #[test]
+    fn test_delete_cleans_up_dangling_related_ids() {
+        let store = test_store();
+
+        let mut a = make_memory("t", "memory a");
+        let mut b = make_memory("t", "memory b");
+        let mut c = make_memory("t", "memory c");
+        let a_id = store.store(a.clone()).unwrap();
+        let b_id = store.store(b.clone()).unwrap();
+        let c_id = store.store(c.clone()).unwrap();
+
+        a.id = a_id.clone();
+        a.related_ids = vec![b_id.clone(), c_id.clone()];
+        store.update(&a).unwrap();
+        b.id = b_id.clone();
+        b.related_ids = vec![a_id.clone(), c_id.clone()];
+        store.update(&b).unwrap();
+        c.id = c_id.clone();
+        c.related_ids = vec![a_id.clone(), b_id.clone()];
+        store.update(&c).unwrap();
+
+        store.delete(&a_id).unwrap();
+
+        let b_after = store.get(&b_id).unwrap().unwrap();
+        assert_eq!(
+            b_after.related_ids,
+            vec![c_id.clone()],
+            "b's related_ids must no longer reference the deleted a"
+        );
+        let c_after = store.get(&c_id).unwrap().unwrap();
+        assert_eq!(
+            c_after.related_ids,
+            vec![b_id.clone()],
+            "c's related_ids must no longer reference the deleted a"
+        );
     }
 
     #[test]

--- a/crates/icm-store/tests/opensearch_backend.rs
+++ b/crates/icm-store/tests/opensearch_backend.rs
@@ -8,9 +8,14 @@
 //!     -e discovery.type=single-node -e DISABLE_SECURITY_PLUGIN=true \
 //!     -e DISABLE_INSTALL_DEMO_CONFIG=true \
 //!     opensearchproject/opensearch:2
-//! ICM_OPENSEARCH_URL=http://localhost:9201 \
+//! ICM_OPENSEARCH_URL=http://localhost:9201 ICM_DB_BACKEND=opensearch \
 //!     cargo test -p icm-store --no-default-features --features opensearch
 //! ```
+//!
+//! `ICM_DB_BACKEND=opensearch` is required too — `Store::with_dims` resolves
+//! the backend from it and defaults to sqlite otherwise, which fails to
+//! connect with a confusing "sqlite backend was requested but this build
+//! was not compiled with its Cargo feature" error (manual-testing finding).
 //!
 //! When `ICM_OPENSEARCH_URL` is unset the test prints a skip notice and
 //! returns, so a backend-less CI run stays green.
@@ -23,6 +28,21 @@ fn skip_if_no_os() -> bool {
     if std::env::var("ICM_OPENSEARCH_URL").is_err() {
         eprintln!("skipping: ICM_OPENSEARCH_URL not set");
         return true;
+    }
+    // Manual-testing finding: `Store::with_dims` picks its backend from
+    // `ICM_DB_BACKEND`, which defaults to sqlite when unset — a build with
+    // `--all-features` has the sqlite backend compiled in too, so setting
+    // only `ICM_OPENSEARCH_URL` and forgetting `ICM_DB_BACKEND=opensearch`
+    // silently runs every "opensearch" test against an ephemeral SQLite
+    // store instead. All the CRUD/KNN assertions still pass (SQLite
+    // supports them natively), so this reports a false-green "opensearch
+    // works" without ever touching OpenSearch. Fail loudly instead.
+    match std::env::var("ICM_DB_BACKEND").as_deref() {
+        Ok("opensearch") | Ok("os") => {}
+        other => panic!(
+            "ICM_OPENSEARCH_URL is set but ICM_DB_BACKEND is {other:?}, not \"opensearch\" — \
+             these tests would silently run against sqlite instead. Set ICM_DB_BACKEND=opensearch."
+        ),
     }
     false
 }
@@ -145,4 +165,61 @@ fn opensearch_vector_knn_ranks_semantically() {
     for m in store.get_by_topic(&ns).expect("by topic") {
         let _ = store.delete(&m.id);
     }
+}
+
+/// Manual-testing finding: deleting a memory left it as a dangling entry
+/// in every other memory's `related_ids` forever. Verified real end to end
+/// against a live OpenSearch (2026-07-27): before the fix, deleting `a`
+/// left `["a", "c"]` in `b`'s document; after, `b` correctly has just
+/// `["c"]`.
+#[test]
+fn opensearch_delete_cleans_up_dangling_related_ids() {
+    if skip_if_no_os() {
+        return;
+    }
+    let store = Store::with_dims(
+        std::path::Path::new("ignored"),
+        icm_core::DEFAULT_EMBEDDING_DIMS,
+    )
+    .expect("connect + migrate opensearch");
+
+    let ns = format!("itest-related-{}", ulid::Ulid::new());
+    let mut a = mem(&ns, "memory a", Importance::Medium);
+    let mut b = mem(&ns, "memory b", Importance::Medium);
+    let mut c = mem(&ns, "memory c", Importance::Medium);
+
+    let a_id = store.store(a.clone()).expect("store a");
+    let b_id = store.store(b.clone()).expect("store b");
+    let c_id = store.store(c.clone()).expect("store c");
+
+    a.id = a_id.clone();
+    a.related_ids = vec![b_id.clone(), c_id.clone()];
+    store.update(&a).expect("link a");
+    b.id = b_id.clone();
+    b.related_ids = vec![a_id.clone(), c_id.clone()];
+    store.update(&b).expect("link b");
+    c.id = c_id.clone();
+    c.related_ids = vec![a_id.clone(), b_id.clone()];
+    store.update(&c).expect("link c");
+
+    store.delete(&a_id).expect("delete a");
+
+    let b_after = store.get(&b_id).expect("get b").expect("b exists");
+    assert!(
+        !b_after.related_ids.contains(&a_id),
+        "b's related_ids must no longer reference the deleted a: {:?}",
+        b_after.related_ids
+    );
+    assert_eq!(b_after.related_ids, vec![c_id.clone()]);
+
+    let c_after = store.get(&c_id).expect("get c").expect("c exists");
+    assert!(
+        !c_after.related_ids.contains(&a_id),
+        "c's related_ids must no longer reference the deleted a: {:?}",
+        c_after.related_ids
+    );
+    assert_eq!(c_after.related_ids, vec![b_id.clone()]);
+
+    let _ = store.delete(&b_id);
+    let _ = store.delete(&c_id);
 }

--- a/crates/icm-store/tests/postgres_backend.rs
+++ b/crates/icm-store/tests/postgres_backend.rs
@@ -23,6 +23,21 @@ fn skip_if_no_pg() -> bool {
         eprintln!("skipping: ICM_POSTGRES_URL not set");
         return true;
     }
+    // Manual-testing finding (same class as the OpenSearch test file):
+    // `Store::with_dims` picks its backend from `ICM_DB_BACKEND`, which
+    // defaults to sqlite when unset — a build with `--all-features` has
+    // the sqlite backend compiled in too, so setting only
+    // `ICM_POSTGRES_URL` and forgetting `ICM_DB_BACKEND=postgres` silently
+    // runs every "postgres" test against an ephemeral SQLite store
+    // instead, reporting a false-green "postgres works" without ever
+    // touching PostgreSQL. Fail loudly instead.
+    match std::env::var("ICM_DB_BACKEND").as_deref() {
+        Ok("postgres") | Ok("postgresql") | Ok("pg") => {}
+        other => panic!(
+            "ICM_POSTGRES_URL is set but ICM_DB_BACKEND is {other:?}, not \"postgres\" — \
+             these tests would silently run against sqlite instead. Set ICM_DB_BACKEND=postgres."
+        ),
+    }
     false
 }
 
@@ -154,4 +169,60 @@ fn postgres_vector_knn_ranks_semantically() {
     for m in store.get_by_topic(&ns).expect("by topic") {
         let _ = store.delete(&m.id);
     }
+}
+
+/// Manual-testing finding (same as the SQLite/OpenSearch backends):
+/// deleting a memory left it as a dangling entry in every other memory's
+/// `related_ids` forever. Verified real end to end against a live
+/// PostgreSQL.
+#[test]
+fn postgres_delete_cleans_up_dangling_related_ids() {
+    if skip_if_no_pg() {
+        return;
+    }
+    let store = Store::with_dims(
+        std::path::Path::new("ignored"),
+        icm_core::DEFAULT_EMBEDDING_DIMS,
+    )
+    .expect("connect + migrate postgres");
+
+    let ns = format!("itest-related-{}", ulid::Ulid::new());
+    let mut a = mem(&ns, "memory a", Importance::Medium);
+    let mut b = mem(&ns, "memory b", Importance::Medium);
+    let mut c = mem(&ns, "memory c", Importance::Medium);
+
+    let a_id = store.store(a.clone()).expect("store a");
+    let b_id = store.store(b.clone()).expect("store b");
+    let c_id = store.store(c.clone()).expect("store c");
+
+    a.id = a_id.clone();
+    a.related_ids = vec![b_id.clone(), c_id.clone()];
+    store.update(&a).expect("link a");
+    b.id = b_id.clone();
+    b.related_ids = vec![a_id.clone(), c_id.clone()];
+    store.update(&b).expect("link b");
+    c.id = c_id.clone();
+    c.related_ids = vec![a_id.clone(), b_id.clone()];
+    store.update(&c).expect("link c");
+
+    store.delete(&a_id).expect("delete a");
+
+    let b_after = store.get(&b_id).expect("get b").expect("b exists");
+    assert!(
+        !b_after.related_ids.contains(&a_id),
+        "b's related_ids must no longer reference the deleted a: {:?}",
+        b_after.related_ids
+    );
+    assert_eq!(b_after.related_ids, vec![c_id.clone()]);
+
+    let c_after = store.get(&c_id).expect("get c").expect("c exists");
+    assert!(
+        !c_after.related_ids.contains(&a_id),
+        "c's related_ids must no longer reference the deleted a: {:?}",
+        c_after.related_ids
+    );
+    assert_eq!(c_after.related_ids, vec![b_id.clone()]);
+
+    let _ = store.delete(&b_id);
+    let _ = store.delete(&c_id);
 }


### PR DESCRIPTION
## Summary

Found via manual functional testing (store 3 cross-linked memories, delete one, inspect the survivors' `related_ids` via `list --format json`): the deleted id stayed in the survivors' `related_ids` arrays forever.

- `expand_with_neighbors` tolerates the miss silently (no crash), but each stale id still spends a slot out of the caller's `max_neighbors` budget instead of surfacing a real, live neighbor.
- Any external consumer of the JSON export (`icm list --format json`) sees a reference to nothing.

Fixed in all three backends:
- **SQLite**: `json_each`/`json_group_array`, inside the existing delete transaction. Cache cleared afterward since the cleanup can touch rows other than the deleted one.
- **PostgreSQL**: `jsonb_array_elements_text`/`jsonb_agg`, wrapped in a transaction (the previous `delete` had none).
- **OpenSearch**: `_update_by_query` with a Painless script. Best-effort — no cross-document transaction to roll back into, so a failure here logs a warning rather than failing the whole delete.

Also fixes a test-infrastructure gap found while verifying this against real Postgres/OpenSearch: `ICM_DB_BACKEND` defaults to sqlite when unset, so setting only `ICM_POSTGRES_URL`/`ICM_OPENSEARCH_URL` on a build that also has sqlite compiled in (e.g. `--all-features`) silently ran every test against an ephemeral SQLite store instead, reporting a false-green pass without the real backend ever being touched. The skip guards now panic loudly on that specific misconfiguration.

## Test plan

- [x] New regression test per backend, each verified fail-before/pass-after.
- [x] PostgreSQL: verified against a real local PostgreSQL 17 + pgvector instance (installed via Homebrew for this).
- [x] OpenSearch: verified against a real local OpenSearch 3.7 instance (installed via Homebrew). The KNN test fails only due to this Homebrew build lacking the k-NN plugin — confirmed pre-existing by reproducing the identical failure on the pre-fix commit.
- [x] Verified the new misconfiguration guard by reproducing the false-green scenario directly.
- [x] `cargo test --workspace --all-features` (743 passed), clippy clean, fmt clean.
