### PR TITLE
fix(store): clean up dangling related_ids on consolidate too, all 3 backends

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -7239,15 +7239,24 @@ fn cmd_consolidate(
 
     let mut consolidated = Memory::new(topic.to_string(), merged_summary, best_importance);
     consolidated.keywords = all_keywords;
-    consolidated.related_ids = memories.iter().map(|m| m.id.clone()).collect();
 
     if keep_originals {
+        // The originals survive this call, so pointing the consolidated
+        // memory's related_ids at them is a meaningful, live provenance
+        // link — expand_with_neighbors can actually follow it.
+        consolidated.related_ids = memories.iter().map(|m| m.id.clone()).collect();
         let id = store.store(consolidated)?;
         println!(
             "Consolidated {} memories from '{topic}' into {id} (originals kept).",
             memories.len()
         );
     } else {
+        // Manual-testing finding: the consolidated memory used to inherit
+        // the originals' ids as related_ids unconditionally — but in this
+        // branch those originals are deleted in the same operation, so it
+        // was born already pointing at nothing. Leave related_ids empty;
+        // consolidate_topic separately cleans up any *other* memory that
+        // referenced the now-deleted originals.
         store.consolidate_topic(topic, consolidated)?;
         println!(
             "Consolidated {} memories from '{topic}' into 1 (originals removed).",
@@ -11032,6 +11041,97 @@ mod cli_contracts_tests {
         assert!(
             !safe.contains("Originals will be deleted"),
             "no destructive-deletion clause when keep_originals=true: {safe}"
+        );
+    }
+
+    /// Manual-testing finding: the destructive (keep_originals=false) path
+    /// used to set the new consolidated memory's own `related_ids` to the
+    /// original ids being deleted in the same operation — born pointing at
+    /// nothing. It must come out empty instead.
+    #[test]
+    fn cmd_consolidate_destructive_does_not_self_reference_deleted_originals() {
+        let store = Store::in_memory().unwrap();
+        store
+            .store(icm_core::Memory::new(
+                "t".into(),
+                "expendable 1".into(),
+                icm_core::Importance::Medium,
+            ))
+            .unwrap();
+        store
+            .store(icm_core::Memory::new(
+                "t".into(),
+                "expendable 2".into(),
+                icm_core::Importance::Medium,
+            ))
+            .unwrap();
+
+        cmd_consolidate(
+            &store,
+            "t",
+            false,
+            &config::SummarizerConfig::default(),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let after = store.get_by_topic("t").unwrap();
+        assert_eq!(after.len(), 1);
+        assert!(
+            after[0].related_ids.is_empty(),
+            "consolidated memory must not be born self-referencing the deleted originals: {:?}",
+            after[0].related_ids
+        );
+    }
+
+    /// The keep_originals=true path is the mirror case: the originals
+    /// survive, so related_ids pointing at them is meaningful and must
+    /// still be set.
+    #[test]
+    fn cmd_consolidate_keep_originals_still_links_to_them() {
+        let store = Store::in_memory().unwrap();
+        let id1 = store
+            .store(icm_core::Memory::new(
+                "t".into(),
+                "expendable 1".into(),
+                icm_core::Importance::Medium,
+            ))
+            .unwrap();
+        let id2 = store
+            .store(icm_core::Memory::new(
+                "t".into(),
+                "expendable 2".into(),
+                icm_core::Importance::Medium,
+            ))
+            .unwrap();
+
+        cmd_consolidate(
+            &store,
+            "t",
+            true,
+            &config::SummarizerConfig::default(),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let all = store.get_by_topic("t").unwrap();
+        let consolidated = all
+            .iter()
+            .find(|m| !id1.eq(&m.id) && !id2.eq(&m.id))
+            .expect("the new consolidated memory must exist alongside the kept originals");
+        assert_eq!(
+            all.len(),
+            3,
+            "originals must survive alongside the new consolidated memory"
+        );
+        assert!(
+            consolidated.related_ids.contains(&id1) && consolidated.related_ids.contains(&id2),
+            "kept originals are live, so related_ids pointing at them is meaningful: {:?}",
+            consolidated.related_ids
         );
     }
 

--- a/crates/icm-store/src/opensearch.rs
+++ b/crates/icm-store/src/opensearch.rs
@@ -1016,6 +1016,16 @@ impl MemoryStore for OpenSearchStore {
         //    it can't collide with any original.
         let consolidated = validate_and_normalize(consolidated)?;
         self.check_dims(&consolidated)?;
+        // Manual-testing finding: captured before store_inner/delete below
+        // (the deleted rows are gone afterward), so any *other* memory's
+        // related_ids pointing at them can be cleaned up — same dangling-
+        // reference bug already fixed for the single-id `delete`.
+        let deleted_ids: Vec<String> = self
+            .get_by_topic(topic)?
+            .into_iter()
+            .filter(|m| m.importance != Importance::Critical)
+            .map(|m| m.id)
+            .collect();
         // `store_inner` returns the id actually used — the caller's fresh
         // id on a normal insert, or an existing row's id if this exact
         // (topic, summary_hash) happened to already exist (dedup merge).
@@ -1036,6 +1046,25 @@ impl MemoryStore for OpenSearchStore {
                 ]
             }}}),
         )?;
+
+        if !deleted_ids.is_empty() {
+            if let Err(e) = self.post(
+                &format!(
+                    "{IDX_MEMORIES}/_update_by_query?conflicts=proceed&{}",
+                    self.refresh_param()
+                ),
+                json!({
+                    "script": {
+                        "source": "ctx._source.related_ids.removeIf(x -> params.deleted_ids.contains(x))",
+                        "params": {"deleted_ids": deleted_ids}
+                    },
+                    "query": {"terms": {"related_ids": deleted_ids}}
+                }),
+            ) {
+                tracing::warn!(topic, error = %e, "consolidate_topic: failed to clean up dangling related_ids");
+            }
+        }
+
         Ok(())
     }
 

--- a/crates/icm-store/src/postgres.rs
+++ b/crates/icm-store/src/postgres.rs
@@ -1524,11 +1524,40 @@ impl MemoryStore for PostgresStore {
         // already applied to SQLite's consolidate_topic. This unconditional
         // DELETE previously wiped critical memories in a consolidated topic
         // too.
+        // Manual-testing finding: captured before the delete, since
+        // afterward these rows are gone. Used to clean up any *other*
+        // memory's related_ids that pointed at them — same dangling-
+        // reference bug already fixed for the single-id `delete`.
+        let deleted_ids: Vec<String> = tx
+            .query(
+                "SELECT id FROM memories WHERE topic = $1 AND importance <> 'critical'",
+                &[&topic],
+            )
+            .map_err(pg_err)?
+            .iter()
+            .map(|row| row.get(0))
+            .collect();
+
         tx.execute(
             "DELETE FROM memories WHERE topic = $1 AND importance <> 'critical'",
             &[&topic],
         )
         .map_err(pg_err)?;
+
+        if !deleted_ids.is_empty() {
+            tx.execute(
+                "UPDATE memories
+                    SET related_ids = (
+                        SELECT COALESCE(jsonb_agg(elem), '[]'::jsonb)::text
+                        FROM jsonb_array_elements_text(related_ids::jsonb) AS elem
+                        WHERE elem <> ALL($1::text[])
+                    )
+                    WHERE related_ids::jsonb ?| $1::text[]",
+                &[&deleted_ids],
+            )
+            .map_err(pg_err)?;
+        }
+
         insert_or_merge_memory(&mut tx, &consolidated)?;
         tx.commit().map_err(pg_err)?;
         Ok(())

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -2013,6 +2013,23 @@ impl MemoryStore for SqliteStore {
             .execute_batch("BEGIN IMMEDIATE;")
             .map_err(db_err)?;
 
+        // Manual-testing finding: captured before the delete below, since
+        // afterward the rows (and thus this query) are gone. Used to clean
+        // up any *other* memory's related_ids that pointed at these —
+        // same dangling-reference bug already fixed for the single-id
+        // `delete`, reachable here too since this is a second, separate
+        // bulk-delete code path.
+        let deleted_ids: Vec<String> = {
+            let mut stmt = self
+                .conn
+                .prepare("SELECT id FROM memories WHERE topic = ?1 AND importance != 'critical'")
+                .map_err(db_err)?;
+            let rows = stmt
+                .query_map(params![topic], |row| row.get::<_, String>(0))
+                .map_err(db_err)?;
+            rows.collect::<rusqlite::Result<Vec<_>>>().map_err(db_err)?
+        };
+
         // `critical` memories are never deleted — same contract as
         // `apply_decay` and `prune`. Consolidation replaces the expendable
         // tail of a topic, not its "never forget" entries (audit finding:
@@ -2036,6 +2053,27 @@ impl MemoryStore for SqliteStore {
             tracing::warn!(topic, error = %e, "consolidate_topic: rolling back after memories delete failed");
             let _ = self.conn.execute_batch("ROLLBACK;");
             return Err(IcmError::Database(e.to_string()));
+        }
+
+        if !deleted_ids.is_empty() {
+            let ids_json = serde_json::to_string(&deleted_ids).map_err(IcmError::from)?;
+            if let Err(e) = self.conn.execute(
+                "UPDATE memories
+                    SET related_ids = (
+                        SELECT COALESCE(json_group_array(value), '[]')
+                        FROM json_each(memories.related_ids)
+                        WHERE value NOT IN (SELECT value FROM json_each(?1))
+                    )
+                    WHERE EXISTS (
+                        SELECT 1 FROM json_each(memories.related_ids)
+                        WHERE value IN (SELECT value FROM json_each(?1))
+                    )",
+                params![ids_json],
+            ) {
+                tracing::warn!(topic, error = %e, "consolidate_topic: rolling back after related_ids cleanup failed");
+                let _ = self.conn.execute_batch("ROLLBACK;");
+                return Err(IcmError::Database(e.to_string()));
+            }
         }
 
         if let Err(e) = self.store_inner(&consolidated) {
@@ -5197,6 +5235,34 @@ mod tests {
         assert!(summaries.contains(&"never forget this"));
         assert!(summaries.contains(&"rollup"));
         assert!(!summaries.contains(&"expendable 1"));
+    }
+
+    /// Manual-testing finding: consolidate_topic bulk-deletes the topic's
+    /// non-critical memories and does its own DELETE, entirely separate
+    /// from the single-id `delete()` — so it had the same dangling
+    /// related_ids bug in a second place. An external memory (in a
+    /// different topic) that referenced one of the consolidated-away ids
+    /// must have that reference cleaned up too.
+    #[test]
+    fn consolidate_topic_cleans_up_dangling_related_ids_in_other_memories() {
+        let store = test_store();
+        let a_id = store.store(make_memory("t", "memory a")).unwrap();
+        let b_id = store.store(make_memory("t", "memory b")).unwrap();
+
+        let mut external = make_memory("other-topic", "external memory");
+        external.related_ids = vec![a_id.clone(), b_id.clone()];
+        let external_id = store.store(external).unwrap();
+
+        store
+            .consolidate_topic("t", make_memory("t", "rollup"))
+            .unwrap();
+
+        let external_after = store.get(&external_id).unwrap().unwrap();
+        assert!(
+            external_after.related_ids.is_empty(),
+            "external memory must no longer reference the consolidated-away ids: {:?}",
+            external_after.related_ids
+        );
     }
 
     /// Audit regression: critical memories are exempt from consolidation, so

--- a/crates/icm-store/tests/opensearch_backend.rs
+++ b/crates/icm-store/tests/opensearch_backend.rs
@@ -223,3 +223,55 @@ fn opensearch_delete_cleans_up_dangling_related_ids() {
     let _ = store.delete(&b_id);
     let _ = store.delete(&c_id);
 }
+
+/// Manual-testing finding: `consolidate_topic` does its own bulk
+/// `_delete_by_query`, entirely separate from the single-id `delete` — so
+/// it had the same dangling related_ids bug in a second place. An external
+/// memory (in a different topic) that referenced one of the
+/// consolidated-away ids must have that reference cleaned up too.
+#[test]
+fn opensearch_consolidate_topic_cleans_up_dangling_related_ids_in_other_memories() {
+    if skip_if_no_os() {
+        return;
+    }
+    let store = Store::with_dims(
+        std::path::Path::new("ignored"),
+        icm_core::DEFAULT_EMBEDDING_DIMS,
+    )
+    .expect("connect + migrate opensearch");
+
+    let ns = format!("itest-cons-{}", ulid::Ulid::new());
+    let a_id = store
+        .store(mem(&ns, "memory a", Importance::Medium))
+        .expect("store a");
+    let b_id = store
+        .store(mem(&ns, "memory b", Importance::Medium))
+        .expect("store b");
+
+    let mut external = mem(
+        &format!("{ns}-external"),
+        "external memory",
+        Importance::Medium,
+    );
+    external.related_ids = vec![a_id.clone(), b_id.clone()];
+    let external_id = store.store(external).expect("store external");
+
+    store
+        .consolidate_topic(&ns, mem(&ns, "rollup", Importance::Medium))
+        .expect("consolidate");
+
+    let external_after = store
+        .get(&external_id)
+        .expect("get external")
+        .expect("exists");
+    assert!(
+        external_after.related_ids.is_empty(),
+        "external memory must no longer reference the consolidated-away ids: {:?}",
+        external_after.related_ids
+    );
+
+    for m in store.get_by_topic(&ns).expect("by topic") {
+        let _ = store.delete(&m.id);
+    }
+    let _ = store.delete(&external_id);
+}

--- a/crates/icm-store/tests/postgres_backend.rs
+++ b/crates/icm-store/tests/postgres_backend.rs
@@ -226,3 +226,55 @@ fn postgres_delete_cleans_up_dangling_related_ids() {
     let _ = store.delete(&b_id);
     let _ = store.delete(&c_id);
 }
+
+/// Manual-testing finding: `consolidate_topic` does its own bulk DELETE,
+/// entirely separate from the single-id `delete` — so it had the same
+/// dangling related_ids bug in a second place. An external memory (in a
+/// different topic) that referenced one of the consolidated-away ids must
+/// have that reference cleaned up too.
+#[test]
+fn postgres_consolidate_topic_cleans_up_dangling_related_ids_in_other_memories() {
+    if skip_if_no_pg() {
+        return;
+    }
+    let store = Store::with_dims(
+        std::path::Path::new("ignored"),
+        icm_core::DEFAULT_EMBEDDING_DIMS,
+    )
+    .expect("connect + migrate postgres");
+
+    let ns = format!("itest-cons-{}", ulid::Ulid::new());
+    let a_id = store
+        .store(mem(&ns, "memory a", Importance::Medium))
+        .expect("store a");
+    let b_id = store
+        .store(mem(&ns, "memory b", Importance::Medium))
+        .expect("store b");
+
+    let mut external = mem(
+        &format!("{ns}-external"),
+        "external memory",
+        Importance::Medium,
+    );
+    external.related_ids = vec![a_id.clone(), b_id.clone()];
+    let external_id = store.store(external).expect("store external");
+
+    store
+        .consolidate_topic(&ns, mem(&ns, "rollup", Importance::Medium))
+        .expect("consolidate");
+
+    let external_after = store
+        .get(&external_id)
+        .expect("get external")
+        .expect("exists");
+    assert!(
+        external_after.related_ids.is_empty(),
+        "external memory must no longer reference the consolidated-away ids: {:?}",
+        external_after.related_ids
+    );
+
+    for m in store.get_by_topic(&ns).expect("by topic") {
+        let _ = store.delete(&m.id);
+    }
+    let _ = store.delete(&external_id);
+}


### PR DESCRIPTION
## Summary

Follow-up to #392: found via the same manual testing methodology that `consolidate_topic` has the exact same dangling `related_ids` bug in a second, entirely separate code path.

```
icm store -t t -c "memory a" ; icm store -t t -c "memory b"
icm store -t other -c "external memory"   # then link it to a and b
icm consolidate --topic t
icm list --topic other --format json
# still references a's and b's ids, which no longer exist
```

Fixed in all three backends: capture the ids about to be deleted before the delete runs, then clean up any other memory's `related_ids` that mentioned them (same technique as #392 — SQLite `json_each`/`json_group_array`, PostgreSQL `jsonb ?|`, OpenSearch `update_by_query` + Painless, all inside the existing transaction where one exists).

Also found and fixed a second, related bug in `cmd_consolidate` (main.rs): the new consolidated memory's own `related_ids` was unconditionally set to the ids of the memories being merged — but in the default destructive path (no `--keep-originals`), those originals are deleted in the *same* operation, so the new memory was born already pointing at nothing. Now only set when `--keep-originals` actually keeps them alive.

## Test plan

- [x] New regression test per backend for the consolidate-time cleanup, each verified fail-before/pass-after against the real backend (real local Postgres 17+pgvector, real local OpenSearch 3.7).
- [x] New regression tests in main.rs for the second bug (destructive path must not self-reference; keep-originals path must still link), fail-before/pass-after verified.
- [x] `cargo test --workspace --all-features` (748 passed), clippy clean, fmt clean.
