### PR TITLE
fix(mcp): stop doubling the "invalid relation" error in icm_memoir_link

### DIFF
--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -2083,7 +2083,10 @@ fn tool_memoir_link(store: &Store, args: &Value) -> ToolResult {
 
     let relation: Relation = match relation_str.parse() {
         Ok(r) => r,
-        Err(e) => return ToolResult::error(format!("invalid relation: {e}")),
+        // `Relation::from_str`'s error already reads "invalid relation:
+        // <value>" — re-prefixing here doubled it to "invalid relation:
+        // invalid relation: <value>".
+        Err(e) => return ToolResult::error(e),
     };
 
     let memoir = match resolve_memoir(store, memoir_name) {
@@ -2541,6 +2544,49 @@ mod tests {
         assert!(
             !compact_out.contains('\n') || compact_out.matches('\n').count() == 1,
             "compact: embedded newline forged an extra line: {compact_out}"
+        );
+    }
+
+    /// Manual-testing finding: `tool_memoir_link` re-wrapped
+    /// `Relation::from_str`'s error (already "invalid relation: <value>")
+    /// in another "invalid relation: {e}", doubling the prefix.
+    #[test]
+    fn memoir_link_invalid_relation_error_is_not_doubled() {
+        let store = test_store();
+        call_tool(
+            &store,
+            None,
+            "icm_memoir_create",
+            &json!({"name": "m"}),
+            false,
+        );
+        call_tool(
+            &store,
+            None,
+            "icm_memoir_add_concept",
+            &json!({"memoir": "m", "name": "a", "definition": "a"}),
+            false,
+        );
+        call_tool(
+            &store,
+            None,
+            "icm_memoir_add_concept",
+            &json!({"memoir": "m", "name": "b", "definition": "b"}),
+            false,
+        );
+        let result = call_tool(
+            &store,
+            None,
+            "icm_memoir_link",
+            &json!({"memoir": "m", "from": "a", "to": "b", "relation": "relates_to"}),
+            false,
+        );
+        assert!(result.is_error);
+        let text = &result.content[0].text;
+        assert_eq!(
+            text.matches("invalid relation:").count(),
+            1,
+            "error prefix must not be doubled: {text}"
         );
     }
 


### PR DESCRIPTION
## Summary

Found while doing the first-ever real MCP JSON-RPC session test of this codebase (31 tools tested end to end via stdio against the compiled binary — the MCP server had never been exercised for real this whole session; almost everything else checked out correctly).

`Relation::from_str` (icm-core/src/memoir.rs) already returns `"invalid relation: <value>"` on a bad input. `tool_memoir_link` (icm-mcp/src/tools.rs) wrapped that error in another `format!("invalid relation: {e}")`, producing `"invalid relation: invalid relation: relates_to"` for an agent that passes an unsupported relation string.

## Fix

Return the underlying error as-is instead of re-prefixing it.

## Test plan

- [x] New regression test `memoir_link_invalid_relation_error_is_not_doubled`, verified fail-before/pass-after.
- [x] Real e2e verification via an actual MCP JSON-RPC session against the compiled binary.
- [x] `cargo test --workspace` (all crates green), clippy clean, fmt clean.