### PR TITLE
fix(consolidate): attach embeddings to the merged memory, CLI + MCP

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1925,30 +1925,38 @@ fn main() -> Result<()> {
             summarizer_provider,
             summarizer_model,
             summarizer_max_tokens,
-        } => cmd_consolidate(
-            &store,
-            &topic,
-            keep_originals,
-            &cfg.consolidate.summarizer,
-            summarizer_provider.as_deref(),
-            summarizer_model.as_deref(),
-            summarizer_max_tokens,
-        ),
+        } => {
+            let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
+            cmd_consolidate(
+                &store,
+                &topic,
+                keep_originals,
+                &cfg.consolidate.summarizer,
+                summarizer_provider.as_deref(),
+                summarizer_model.as_deref(),
+                summarizer_max_tokens,
+                emb_ref,
+            )
+        }
         Commands::ConsolidateAll {
             threshold,
             summarizer_provider,
             summarizer_model,
             summarizer_max_tokens,
             dry_run,
-        } => cmd_consolidate_all(
-            &store,
-            threshold,
-            &cfg.consolidate.summarizer,
-            summarizer_provider.as_deref(),
-            summarizer_model.as_deref(),
-            summarizer_max_tokens,
-            dry_run,
-        ),
+        } => {
+            let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
+            cmd_consolidate_all(
+                &store,
+                threshold,
+                &cfg.consolidate.summarizer,
+                summarizer_provider.as_deref(),
+                summarizer_model.as_deref(),
+                summarizer_max_tokens,
+                dry_run,
+                emb_ref,
+            )
+        }
         Commands::Embed {
             topic,
             force,
@@ -7196,6 +7204,7 @@ fn cmd_consolidate(
     cli_provider: Option<&str>,
     cli_model: Option<&str>,
     cli_max_tokens: Option<usize>,
+    embedder: Option<&dyn icm_core::Embedder>,
 ) -> Result<()> {
     let memories = store.get_by_topic(topic)?;
     if memories.is_empty() {
@@ -7273,6 +7282,14 @@ fn cmd_consolidate(
 
     let mut consolidated = Memory::new(topic.to_string(), merged_summary, best_importance);
     consolidated.keywords = all_keywords;
+    // Same bug class as #394/#395: cmd_consolidate had no embedder param at
+    // all, so the merged memory was always born with embedding: None — a
+    // real gap found via manual testing against a real Postgres backend.
+    if let Some(emb) = embedder {
+        if let Ok(vec) = emb.embed(&consolidated.embed_text()) {
+            consolidated.embedding = Some(vec);
+        }
+    }
 
     if keep_originals {
         // The originals survive this call, so pointing the consolidated
@@ -7305,6 +7322,7 @@ fn cmd_consolidate(
 /// because a consolidated topic collapses to one memory (below the threshold)
 /// and is skipped next time. Never keeps originals — that would defeat the
 /// idempotency the cron use case relies on.
+#[allow(clippy::too_many_arguments)]
 fn cmd_consolidate_all(
     store: &Store,
     threshold: usize,
@@ -7313,6 +7331,7 @@ fn cmd_consolidate_all(
     cli_model: Option<&str>,
     cli_max_tokens: Option<usize>,
     dry_run: bool,
+    embedder: Option<&dyn icm_core::Embedder>,
 ) -> Result<()> {
     // `threshold = 0` would leave a just-consolidated single-memory topic still
     // "over" the threshold (1 > 0), so every run re-consolidates everything —
@@ -7375,6 +7394,7 @@ fn cmd_consolidate_all(
             cli_provider,
             cli_model,
             cli_max_tokens,
+            embedder,
         ) {
             Ok(()) => done += 1,
             Err(e) => {
@@ -9892,7 +9912,7 @@ mod hook_start_tests {
 
         let cfg = config::SummarizerConfig::default();
         // provider "none" → deterministic lexical consolidation, no LLM spawn.
-        cmd_consolidate_all(&store, 3, &cfg, Some("none"), None, None, false).unwrap();
+        cmd_consolidate_all(&store, 3, &cfg, Some("none"), None, None, false, None).unwrap();
 
         assert_eq!(store.count_by_topic("alpha").unwrap(), 1);
         assert_eq!(store.count_by_topic("gamma").unwrap(), 1);
@@ -9903,7 +9923,7 @@ mod hook_start_tests {
         );
 
         // Idempotent: nothing left over the threshold.
-        cmd_consolidate_all(&store, 3, &cfg, Some("none"), None, None, false).unwrap();
+        cmd_consolidate_all(&store, 3, &cfg, Some("none"), None, None, false, None).unwrap();
         assert_eq!(store.count_by_topic("alpha").unwrap(), 1);
         assert_eq!(store.count_by_topic("beta").unwrap(), 2);
     }
@@ -9918,7 +9938,7 @@ mod hook_start_tests {
                 .unwrap();
         }
         let cfg = config::SummarizerConfig::default();
-        cmd_consolidate_all(&store, 3, &cfg, Some("none"), None, None, true).unwrap();
+        cmd_consolidate_all(&store, 3, &cfg, Some("none"), None, None, true, None).unwrap();
         assert_eq!(
             store.count_by_topic("t").unwrap(),
             5,
@@ -9938,13 +9958,17 @@ mod hook_start_tests {
         let cfg = config::SummarizerConfig::default(); // provider defaults to "none"
                                                        // Bare run (no explicit provider) resolves to none → refuse (a batch
                                                        // lexical join + delete of originals across the whole store).
-        assert!(cmd_consolidate_all(&store, 3, &cfg, None, None, None, false).is_err());
+        assert!(cmd_consolidate_all(&store, 3, &cfg, None, None, None, false, None).is_err());
         // threshold 0 → refuse.
-        assert!(cmd_consolidate_all(&store, 0, &cfg, Some("none"), None, None, false).is_err());
+        assert!(
+            cmd_consolidate_all(&store, 0, &cfg, Some("none"), None, None, false, None).is_err()
+        );
         // Neither refused call touched the data.
         assert_eq!(store.count_by_topic("t").unwrap(), 5);
         // Explicit `none` is an accepted opt-in and does consolidate.
-        assert!(cmd_consolidate_all(&store, 3, &cfg, Some("none"), None, None, false).is_ok());
+        assert!(
+            cmd_consolidate_all(&store, 3, &cfg, Some("none"), None, None, false, None).is_ok()
+        );
         assert_eq!(store.count_by_topic("t").unwrap(), 1);
     }
 
@@ -11108,6 +11132,7 @@ mod cli_contracts_tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -11149,6 +11174,7 @@ mod cli_contracts_tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -11166,6 +11192,64 @@ mod cli_contracts_tests {
             consolidated.related_ids.contains(&id1) && consolidated.related_ids.contains(&id2),
             "kept originals are live, so related_ids pointing at them is meaningful: {:?}",
             consolidated.related_ids
+        );
+    }
+
+    /// Manual-testing finding (against a real local Postgres backend):
+    /// `cmd_consolidate` had no `embedder` parameter at all, so the merged
+    /// memory it creates was always born with `embedding: None` — same bug
+    /// class as #394/#395, in a third sibling code path.
+    #[test]
+    fn cmd_consolidate_attaches_an_embedding_to_the_merged_memory() {
+        use icm_core::{Embedder, IcmResult};
+
+        struct StubEmbedder;
+        impl Embedder for StubEmbedder {
+            fn embed(&self, _text: &str) -> IcmResult<Vec<f32>> {
+                Ok(vec![0.3_f32; 64])
+            }
+            fn embed_batch(&self, texts: &[&str]) -> IcmResult<Vec<Vec<f32>>> {
+                texts.iter().map(|t| self.embed(t)).collect()
+            }
+            fn dimensions(&self) -> usize {
+                64
+            }
+        }
+
+        let store = Store::in_memory_with_dims(64).unwrap();
+        store
+            .store(icm_core::Memory::new(
+                "t".into(),
+                "expendable 1".into(),
+                icm_core::Importance::Medium,
+            ))
+            .unwrap();
+        store
+            .store(icm_core::Memory::new(
+                "t".into(),
+                "expendable 2".into(),
+                icm_core::Importance::Medium,
+            ))
+            .unwrap();
+
+        let embedder = StubEmbedder;
+        cmd_consolidate(
+            &store,
+            "t",
+            false,
+            &config::SummarizerConfig::default(),
+            None,
+            None,
+            None,
+            Some(&embedder),
+        )
+        .unwrap();
+
+        let all = store.get_by_topic("t").unwrap();
+        assert_eq!(all.len(), 1);
+        assert!(
+            all[0].embedding.is_some(),
+            "consolidated memory must have an embedding attached"
         );
     }
 

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -788,7 +788,7 @@ pub fn call_tool_with_config(
         "icm_memory_forget" => tool_forget(store, args),
         "icm_memory_forget_topic" => tool_forget_topic(store, args),
         "icm_memory_update" => tool_update(store, embedder, args),
-        "icm_memory_consolidate" => tool_consolidate(store, args),
+        "icm_memory_consolidate" => tool_consolidate(store, embedder, args),
         "icm_memory_list_topics" => tool_list_topics(store),
         "icm_memory_stats" => tool_stats(store),
         "icm_memory_health" => tool_health(store, args),
@@ -1454,7 +1454,7 @@ fn tool_learn(store: &Store, args: &Value) -> ToolResult {
     }
 }
 
-fn tool_consolidate(store: &Store, args: &Value) -> ToolResult {
+fn tool_consolidate(store: &Store, embedder: Option<&dyn Embedder>, args: &Value) -> ToolResult {
     let topic = match get_str(args, "topic") {
         Some(t) => t,
         None => return ToolResult::error("missing required field: topic".into()),
@@ -1464,7 +1464,14 @@ fn tool_consolidate(store: &Store, args: &Value) -> ToolResult {
         None => return ToolResult::error("missing required field: summary".into()),
     };
 
-    let consolidated = Memory::new(topic.into(), summary.into(), icm_core::Importance::High);
+    let mut consolidated = Memory::new(topic.into(), summary.into(), icm_core::Importance::High);
+    // Same bug class as #394/#395/cmd_consolidate: this tool never attached
+    // an embedding to the merged memory it creates.
+    if let Some(emb) = embedder {
+        if let Ok(vec) = emb.embed(&consolidated.embed_text()) {
+            consolidated.embedding = Some(vec);
+        }
+    }
 
     match store.consolidate_topic(topic, consolidated) {
         Ok(()) => ToolResult::text(format!("Consolidated topic: {topic}")),
@@ -2587,6 +2594,47 @@ mod tests {
             text.matches("invalid relation:").count(),
             1,
             "error prefix must not be doubled: {text}"
+        );
+    }
+
+    /// Manual-testing finding (against a real local Postgres backend):
+    /// `tool_consolidate` (icm_memory_consolidate) never received the
+    /// `embedder` that `call_tool_with_config` already threads through to
+    /// its sibling tools, so the merged memory it creates was always born
+    /// with `embedding: None` — same bug class as #394/#395/cmd_consolidate.
+    #[test]
+    fn tool_consolidate_attaches_an_embedding_to_the_merged_memory() {
+        use icm_core::{Embedder, IcmResult};
+
+        struct StubEmbedder;
+        impl Embedder for StubEmbedder {
+            fn embed(&self, _text: &str) -> IcmResult<Vec<f32>> {
+                Ok(vec![0.3_f32; 64])
+            }
+            fn embed_batch(&self, texts: &[&str]) -> IcmResult<Vec<Vec<f32>>> {
+                texts.iter().map(|t| self.embed(t)).collect()
+            }
+            fn dimensions(&self) -> usize {
+                64
+            }
+        }
+
+        let store = Store::in_memory_with_dims(64).unwrap();
+        let embedder = StubEmbedder;
+        let result = call_tool(
+            &store,
+            Some(&embedder),
+            "icm_memory_consolidate",
+            &json!({"topic": "t", "summary": "merged summary"}),
+            false,
+        );
+        assert!(!result.is_error, "{:?}", result.content);
+
+        let memories = store.get_by_topic("t").unwrap();
+        assert_eq!(memories.len(), 1);
+        assert!(
+            memories[0].embedding.is_some(),
+            "consolidated memory must have an embedding attached"
         );
     }
 


### PR DESCRIPTION
## Summary

Found via real functional testing against a local Postgres backend (part of the standing overnight bug-hunt loop): consolidating a topic — `icm consolidate` (CLI) or the MCP `icm_memory_consolidate` tool — always produced a merged memory with `embedding: NULL`, regardless of backend. Same bug class as #394/#395, in two more sibling code paths those fixes didn't cover.

- `cmd_consolidate` (CLI) had no `embedder` parameter at all — threaded it through from `main.rs` (both `icm consolidate` and `icm consolidate-all`, which calls `cmd_consolidate` internally) and attach the embedding right after building the consolidated `Memory`.
- `tool_consolidate` (MCP `icm_memory_consolidate`) never received the `embedder` that `call_tool_with_config` already threads through to every sibling tool (store/recall/update/embed_all) — same fix.

Verified live against a real local Postgres instance: consolidating a real topic produced `embedding: NULL` before the fix (confirmed via **direct SQL**, not the CLI's own `list --format json` — which doesn't expose the embedding field at all, the exact same trap that masked #394 earlier this session), and a real embedding after.

## Test plan

- [x] New regression tests (`cmd_consolidate_attaches_an_embedding_to_the_merged_memory`, `tool_consolidate_attaches_an_embedding_to_the_merged_memory`), each verified fail-before/pass-after.
- [x] Real e2e verification against a local Postgres instance with direct SQL confirmation.
- [x] `cargo test --workspace` (all crates green), clippy clean, fmt clean.