### PR TITLE
fix(store): eliminate the concurrent first-open schema-creation race

### DIFF
--- a/crates/icm-store/src/schema.rs
+++ b/crates/icm-store/src/schema.rs
@@ -183,10 +183,19 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
     )
     .map_err(db_err)?;
 
-    // Check if FTS table already exists (memories)
-    if !fts_table_exists(conn, "memories_fts")? {
-        conn.execute_batch(
-            "
+    // Check if FTS table already exists (memories). Atomic via BEGIN
+    // IMMEDIATE: a plain check-then-create from Rust is a TOCTOU race —
+    // two processes opening the same brand-new DB concurrently can both
+    // see "missing" and both try to create it; the loser gets a hard
+    // "table already exists" error or a broken FTS5 vtable ("vtable
+    // constructor failed"), found via real concurrent testing. Acquiring
+    // the write lock before re-checking makes the loser's re-check
+    // correctly see the winner's already-committed table and no-op.
+    conn.execute_batch("BEGIN IMMEDIATE;").map_err(db_err)?;
+    let memories_fts_init: Result<(), IcmError> = (|| {
+        if !fts_table_exists(conn, "memories_fts")? {
+            conn.execute_batch(
+                "
             CREATE VIRTUAL TABLE memories_fts USING fts5(
                 id,
                 topic,
@@ -213,14 +222,26 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
                 VALUES (new.rowid, new.id, new.topic, new.summary, new.keywords);
             END;
             ",
-        )
-        .map_err(db_err)?;
+            )
+            .map_err(db_err)?;
+        }
+        Ok(())
+    })();
+    match memories_fts_init {
+        Ok(()) => conn.execute_batch("COMMIT;").map_err(db_err)?,
+        Err(e) => {
+            let _ = conn.execute_batch("ROLLBACK;");
+            return Err(e);
+        }
     }
 
-    // Check if concepts FTS table already exists
-    if !fts_table_exists(conn, "concepts_fts")? {
-        conn.execute_batch(
-            "
+    // Check if concepts FTS table already exists. Same TOCTOU race as
+    // memories_fts above (BEGIN IMMEDIATE fix) — see its comment.
+    conn.execute_batch("BEGIN IMMEDIATE;").map_err(db_err)?;
+    let concepts_fts_init: Result<(), IcmError> = (|| {
+        if !fts_table_exists(conn, "concepts_fts")? {
+            conn.execute_batch(
+                "
             CREATE VIRTUAL TABLE concepts_fts USING fts5(
                 id,
                 name,
@@ -247,8 +268,17 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
                 VALUES (new.rowid, new.id, new.name, new.definition, new.labels);
             END;
             ",
-        )
-        .map_err(db_err)?;
+            )
+            .map_err(db_err)?;
+        }
+        Ok(())
+    })();
+    match concepts_fts_init {
+        Ok(()) => conn.execute_batch("COMMIT;").map_err(db_err)?,
+        Err(e) => {
+            let _ = conn.execute_batch("ROLLBACK;");
+            return Err(e);
+        }
     }
 
     // Metadata key-value table for internal state (e.g. last_decay_at)
@@ -279,10 +309,13 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
     )
     .map_err(db_err)?;
 
-    // Feedback FTS table
-    if !fts_table_exists(conn, "feedback_fts")? {
-        conn.execute_batch(
-            "
+    // Feedback FTS table. Same TOCTOU race as memories_fts above (BEGIN
+    // IMMEDIATE fix) — see its comment.
+    conn.execute_batch("BEGIN IMMEDIATE;").map_err(db_err)?;
+    let feedback_fts_init: Result<(), IcmError> = (|| {
+        if !fts_table_exists(conn, "feedback_fts")? {
+            conn.execute_batch(
+                "
             CREATE VIRTUAL TABLE feedback_fts USING fts5(
                 id, topic, context, predicted, corrected, reason,
                 content='feedback', content_rowid='rowid'
@@ -305,8 +338,17 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
                 VALUES (new.rowid, new.id, new.topic, new.context, new.predicted, new.corrected, new.reason);
             END;
             ",
-        )
-        .map_err(db_err)?;
+            )
+            .map_err(db_err)?;
+        }
+        Ok(())
+    })();
+    match feedback_fts_init {
+        Ok(()) => conn.execute_batch("COMMIT;").map_err(db_err)?,
+        Err(e) => {
+            let _ = conn.execute_batch("ROLLBACK;");
+            return Err(e);
+        }
     }
 
     // Structured facts (issue #273): one row per `(entity, key,
@@ -427,10 +469,14 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
     )
     .map_err(db_err)?;
 
-    // FTS5 over messages.content (+ role/tool_name so 'role:tool' style filters work)
-    if !fts_table_exists(conn, "messages_fts")? {
-        conn.execute_batch(
-            "
+    // FTS5 over messages.content (+ role/tool_name so 'role:tool' style
+    // filters work). Same TOCTOU race as memories_fts above (BEGIN
+    // IMMEDIATE fix) — see its comment.
+    conn.execute_batch("BEGIN IMMEDIATE;").map_err(db_err)?;
+    let messages_fts_init: Result<(), IcmError> = (|| {
+        if !fts_table_exists(conn, "messages_fts")? {
+            conn.execute_batch(
+                "
             CREATE VIRTUAL TABLE messages_fts USING fts5(
                 id UNINDEXED,
                 session_id UNINDEXED,
@@ -458,8 +504,17 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
                 VALUES (new.rowid, new.id, new.session_id, new.role, new.content, COALESCE(new.tool_name, ''));
             END;
             ",
-        )
-        .map_err(db_err)?;
+            )
+            .map_err(db_err)?;
+        }
+        Ok(())
+    })();
+    match messages_fts_init {
+        Ok(()) => conn.execute_batch("COMMIT;").map_err(db_err)?,
+        Err(e) => {
+            let _ = conn.execute_batch("ROLLBACK;");
+            return Err(e);
+        }
     }
 
     // Migration: add updated_at column if missing (existing DBs pre-0.3.1)
@@ -492,14 +547,36 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
     // which churned the FTS index and could create ghost entries.
     migrate_fts_update_trigger(conn)?;
 
-    // sqlite-vec virtual table for vector search (dimension-aware)
-    let vec_exists: bool = conn
-        .query_row(
-            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='vec_memories'",
-            [],
-            |row| row.get(0),
-        )
-        .map_err(db_err)?;
+    // sqlite-vec virtual table for vector search (dimension-aware). The
+    // existence check + first-time create is the same TOCTOU race as the
+    // FTS5 tables above (BEGIN IMMEDIATE fix) — see memories_fts's
+    // comment. The already-exists + dims-mismatch-recreate branch below
+    // is unaffected: it has its own transaction and only runs when the
+    // table demonstrably existed before this connection opened it.
+    conn.execute_batch("BEGIN IMMEDIATE;").map_err(db_err)?;
+    let vec_create_result: Result<bool, IcmError> = (|| {
+        let exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='vec_memories'",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(db_err)?;
+        if !exists {
+            create_vec_table(conn, embedding_dims)?;
+        }
+        Ok(exists)
+    })();
+    let vec_exists = match vec_create_result {
+        Ok(existed_before) => {
+            conn.execute_batch("COMMIT;").map_err(db_err)?;
+            existed_before
+        }
+        Err(e) => {
+            let _ = conn.execute_batch("ROLLBACK;");
+            return Err(e);
+        }
+    };
 
     if vec_exists {
         // Check if stored dims differ from requested dims — if so, recreate
@@ -528,8 +605,6 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
             create_vec_table(&tx, embedding_dims)?;
             tx.commit().map_err(db_err)?;
         }
-    } else {
-        create_vec_table(conn, embedding_dims)?;
     }
 
     // Defensive dim-drift sweep (issue #200).
@@ -606,6 +681,63 @@ mod tests {
         init_db(&conn).unwrap();
         // Second call should be idempotent
         init_db(&conn).unwrap();
+    }
+
+    /// Manual-testing finding: 10 real `icm` processes opening the same
+    /// brand-new (not-yet-created) DB file concurrently reproducibly hung
+    /// (several past 60s) or errored ("table memories_fts already exists",
+    /// "vtable constructor failed: memories_fts", "database is locked") —
+    /// and **zero** of the 10 stores actually succeeded. Root cause: each
+    /// FTS5/vec0 virtual table used a plain "check sqlite_master, then
+    /// CREATE" from Rust — a TOCTOU race, since `CREATE VIRTUAL TABLE` has
+    /// no `IF NOT EXISTS` guard here. Reproduced at the unit level with
+    /// real OS threads, each opening its own `Connection` (in-memory DBs
+    /// don't share state across connections, so this needs a real file) to
+    /// the same fresh path and racing `init_db`.
+    #[test]
+    fn concurrent_first_open_of_a_fresh_db_never_races_schema_creation() {
+        ensure_vec_init();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("concurrent.db");
+
+        // Exercise the real production entry point end to end (PRAGMA
+        // ordering + BEGIN IMMEDIATE schema wrapping + the retry-on-
+        // transient-error safety net), not a hand-rolled approximation.
+        let handles: Vec<_> = (0..10)
+            .map(|_| {
+                let path = path.clone();
+                std::thread::spawn(move || -> Result<(), IcmError> {
+                    crate::store::SqliteStore::with_dims(&path, icm_core::DEFAULT_EMBEDDING_DIMS)
+                        .map(|_| ())
+                })
+            })
+            .collect();
+
+        let mut failures = Vec::new();
+        for h in handles {
+            if let Err(e) = h.join().unwrap() {
+                failures.push(e.to_string());
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "concurrent first-open must never fail: {failures:?}"
+        );
+
+        // The schema must be fully, correctly formed afterward.
+        let conn = Connection::open(&path).unwrap();
+        for table in [
+            "memories_fts",
+            "concepts_fts",
+            "feedback_fts",
+            "messages_fts",
+            "vec_memories",
+        ] {
+            assert!(
+                fts_table_exists(&conn, table).unwrap(),
+                "{table} must exist after concurrent init"
+            );
+        }
     }
 
     /// Simulates upgrading a pre-0.10.43 database (no `summary_hash`

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -393,11 +393,72 @@ impl SqliteStore {
         }
         let conn = Connection::open(path)
             .map_err(|e| IcmError::Database(format!("cannot open database: {e}")))?;
-        conn.execute_batch(
-            "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=30000;",
-        )
-        .map_err(db_err)?;
-        init_db_with_dims(&conn, embedding_dims)?;
+        // Schema/PRAGMA setup races with other processes opening the same
+        // brand-new DB simultaneously (found via real concurrent testing:
+        // 10 processes opening one fresh DB, several hung, others errored,
+        // zero succeeded). Both the WAL-mode switch (needs a brief
+        // exclusive lock to convert a fresh file — busy_timeout must be
+        // set first in the same batch, or this statement itself has no
+        // timeout active yet) and init_db_with_dims's schema creation
+        // (BEGIN IMMEDIATE-wrapped in schema.rs, but SQLite's FTS5
+        // virtual-table module can still surface a transient error on the
+        // loser even so) are retried together here: whatever the winner
+        // already committed, a fresh attempt's PRAGMA + existence checks
+        // correctly see and no-op past it. Jittered, not just linear,
+        // backoff: a fixed schedule lets many racing processes retry in
+        // near-lockstep and collide again and again.
+        let mut last_err = None;
+        for attempt in 0..40u32 {
+            if attempt > 0 {
+                let base_ms = (attempt as u64).min(20) * 15;
+                let jitter_ms = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| u64::from(d.subsec_nanos()) % 40)
+                    .unwrap_or(0);
+                std::thread::sleep(std::time::Duration::from_millis(base_ms + jitter_ms));
+            }
+            // A short busy_timeout during this retry loop, not the normal
+            // 30s: 30s is meant to tolerate *ordinary* write contention
+            // during real use (e.g. a hook write racing a consolidate),
+            // but stacked with up to 40 outer attempts here it turns into
+            // a potentially multi-minute worst case under real multi-
+            // process contention (measured: several real `icm` processes
+            // hung well past 60s with the 30s inner timeout) — the outer
+            // jittered loop is what actually provides the robustness here,
+            // so the inner SQLite-level wait only needs to be long enough
+            // to smooth over a single competing transaction, not to be a
+            // retry mechanism in its own right. Restored to 30s below once
+            // the schema is confirmed present.
+            let attempt_result = conn
+                .execute_batch(
+                    "PRAGMA busy_timeout=1000; PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;",
+                )
+                .map_err(db_err)
+                .and_then(|()| init_db_with_dims(&conn, embedding_dims));
+            match attempt_result {
+                Ok(()) => {
+                    last_err = None;
+                    break;
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    let transient = msg.contains("vtable constructor failed")
+                        || msg.contains("already exists")
+                        || msg.contains("database is locked")
+                        || msg.contains("database is busy");
+                    last_err = Some(e);
+                    if !transient {
+                        break;
+                    }
+                }
+            }
+        }
+        if let Some(e) = last_err {
+            return Err(e);
+        }
+        conn.execute_batch("PRAGMA busy_timeout=30000;")
+            .map_err(db_err)?;
+
         Ok(Self {
             conn,
             cache: Mutex::new(new_cache()),


### PR DESCRIPTION
## Summary

Found via real multi-process testing during the overnight bug-hunt loop: **10 `icm store` processes opening the same brand-new (not-yet-created) SQLite DB simultaneously** — a real scenario (several terminal tabs / editor sessions on a fresh project, or a burst of hook events before the DB exists) — reproducibly caused several processes to hang past 60s and the rest to error out with:
- `table memories_fts already exists`
- `vtable constructor failed: memories_fts`
- `database is locked`

**Zero of the 10 stores succeeded.**

## Root causes (all in the first-open path)

1. **`init_db_with_dims` (schema.rs)** used a plain "check `sqlite_master`, then `CREATE VIRTUAL TABLE`" from Rust for each FTS5 table (`memories_fts`/`concepts_fts`/`feedback_fts`/`messages_fts`) and the `vec0` table — a TOCTOU race, since `CREATE VIRTUAL TABLE` has no `IF NOT EXISTS` guard usable here (paired triggers need to go with it). Two processes can both see "missing" and both try to create it.
2. **`with_dims` (store.rs)** set `PRAGMA journal_mode=WAL` *before* `PRAGMA busy_timeout` — so the WAL-mode switch itself (which needs a brief exclusive lock on a fresh file) had no busy-retry active yet.
3. Even after fixing both of the above, a residual race remained under real multi-process contention (SQLite's FTS5 virtual-table module can still surface a transient error on the loser, below the application-transaction level) — closed with a jittered retry loop around the whole PRAGMA+schema-init sequence. A **fixed** backoff schedule made this *worse* (processes retry in near-lockstep and collide again), jitter fixed it. The original 30s `busy_timeout`, stacked with the outer retry loop, itself produced multi-minute worst-case hangs under real process contention — reduced to a short 1s timeout during this retry phase (the outer jittered loop is what actually provides the robustness) and restored to 30s once the schema is confirmed present, for normal-operation contention tolerance.

## Fix

- `schema.rs`: wrap each FTS5/vec0 table's existence-check + create in `BEGIN IMMEDIATE`/`COMMIT` (rollback on error) so a second process's re-check, after acquiring the write lock, correctly sees the first process's already-committed table and no-ops.
- `store.rs`: reorder PRAGMAs (`busy_timeout` first), and retry the whole PRAGMA+`init_db_with_dims` sequence with jittered backoff on the specific transient errors above (up to 40 attempts, short inner `busy_timeout`, full 30s timeout restored after success).

## Test plan

- [x] New regression test `concurrent_first_open_of_a_fresh_db_never_races_schema_creation` — 10 real threads, each with its own `Connection`, racing `SqliteStore::with_dims` on the same fresh file path (in-memory DBs don't share state across connections, so this needs a real file). Verified fail-before (flaky-failed ~60-80% of runs against the original code) / pass-after (140+ consecutive passes at the unit level).
- [x] Real e2e re-verification with the compiled binary, the *exact* original 10-process repro: with `--no-embeddings` (isolates the pure SQLite behavior from unrelated CPU contention) — all 10 succeed in 0.16s (was: hangs/errors, zero successes). With embeddings enabled, 10-way concurrency now completes (just slower, ~2.5 min, dominated by 10 concurrent ONNX model loads — a separate, pre-existing, unrelated performance characteristic, not a correctness bug).
- [x] `cargo test --workspace` (all crates green), clippy clean, fmt clean.