### PR TITLE
feat(feedback): add semantic search fallback (icm_feedback_search)

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1811,12 +1811,20 @@ fn main() -> Result<()> {
                 corrected,
                 reason,
                 source,
-            } => cmd_feedback_record(&store, topic, context, predicted, corrected, reason, source),
+            } => {
+                let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
+                cmd_feedback_record(
+                    &store, emb_ref, topic, context, predicted, corrected, reason, source,
+                )
+            }
             FeedbackCommands::Search {
                 query,
                 topic,
                 limit,
-            } => cmd_feedback_search(&store, &query, topic.as_deref(), limit),
+            } => {
+                let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
+                cmd_feedback_search(&store, emb_ref, &query, topic.as_deref(), limit)
+            }
             FeedbackCommands::List { topic, limit } => {
                 cmd_feedback_list(&store, topic.as_deref(), limit)
             }
@@ -2781,8 +2789,10 @@ fn cmd_health(store: &Store, topic_filter: Option<&str>) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_feedback_record(
     store: &Store,
+    embedder: Option<&dyn icm_core::Embedder>,
     topic: String,
     context: String,
     predicted: String,
@@ -2790,7 +2800,7 @@ fn cmd_feedback_record(
     reason: Option<String>,
     source: String,
 ) -> Result<()> {
-    let feedback = Feedback::new(
+    let mut feedback = Feedback::new(
         topic.clone(),
         context,
         predicted.clone(),
@@ -2798,6 +2808,14 @@ fn cmd_feedback_record(
         reason,
         source,
     );
+    // Manual-testing finding: feedback search had no semantic fallback at
+    // all — attach an embedding here so search_feedback can blend
+    // semantic similarity in, mirroring cmd_store.
+    if let Some(emb) = embedder {
+        if let Ok(v) = emb.embed(&feedback.embed_text()) {
+            feedback.embedding = Some(v);
+        }
+    }
     let id = store.store_feedback(feedback)?;
     println!("Feedback recorded: {id}");
     println!("  topic: {topic}");
@@ -2808,11 +2826,13 @@ fn cmd_feedback_record(
 
 fn cmd_feedback_search(
     store: &Store,
+    embedder: Option<&dyn icm_core::Embedder>,
     query: &str,
     topic: Option<&str>,
     limit: usize,
 ) -> Result<()> {
-    let results = store.search_feedback(query, topic, limit)?;
+    let query_embedding = embedder.and_then(|emb| emb.embed_query(query).ok());
+    let results = store.search_feedback(query, query_embedding.as_deref(), topic, limit)?;
     if results.is_empty() {
         println!("No feedback found.");
         return Ok(());

--- a/crates/icm-core/src/feedback.rs
+++ b/crates/icm-core/src/feedback.rs
@@ -12,6 +12,13 @@ pub struct Feedback {
     pub source: String,
     pub created_at: DateTime<Utc>,
     pub applied_count: u32,
+    /// Manual-testing finding: `feedback search` had no semantic fallback
+    /// at all — pure FTS5 with implicit AND, so a query missing even one
+    /// exact token (no stemming) returned nothing, even with an obviously
+    /// relevant entry present. Mirrors `Memory::embedding`: attached by
+    /// the caller (CLI/MCP) via an `Embedder` before `store_feedback`.
+    #[serde(default)]
+    pub embedding: Option<Vec<f32>>,
 }
 
 impl Feedback {
@@ -33,7 +40,16 @@ impl Feedback {
             source,
             created_at: Utc::now(),
             applied_count: 0,
+            embedding: None,
         }
+    }
+
+    /// Text used to compute this feedback's embedding — mirrors
+    /// `Memory::embed_text`. `context` carries the situation, `predicted`/
+    /// `corrected` carry the actual correction content a future query is
+    /// most likely to be phrased against.
+    pub fn embed_text(&self) -> String {
+        format!("{} {} {}", self.context, self.predicted, self.corrected)
     }
 }
 

--- a/crates/icm-core/src/feedback_store.rs
+++ b/crates/icm-core/src/feedback_store.rs
@@ -3,9 +3,14 @@ use crate::feedback::{Feedback, FeedbackStats};
 
 pub trait FeedbackStore {
     fn store_feedback(&self, feedback: Feedback) -> IcmResult<String>;
+    /// `query_embedding`: when the caller has an embedder available, pass
+    /// the query's embedding to blend semantic similarity (70%) with FTS
+    /// (30%) — same weights as `MemoryStore::search_hybrid`. `None` falls
+    /// back to FTS-only, still ordered by relevance (not just recency).
     fn search_feedback(
         &self,
         query: &str,
+        query_embedding: Option<&[f32]>,
         topic: Option<&str>,
         limit: usize,
     ) -> IcmResult<Vec<Feedback>>;

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -808,8 +808,8 @@ pub fn call_tool_with_config(
         // Learn tool
         "icm_learn" => tool_learn(store, args),
         // Feedback tools
-        "icm_feedback_record" => tool_feedback_record(store, args, compact),
-        "icm_feedback_search" => tool_feedback_search(store, args),
+        "icm_feedback_record" => tool_feedback_record(store, embedder, args, compact),
+        "icm_feedback_search" => tool_feedback_search(store, embedder, args),
         "icm_feedback_stats" => tool_feedback_stats(store),
         // Transcript tools
         "icm_transcript_start_session" => tool_transcript_start_session(store, args),
@@ -2391,7 +2391,12 @@ fn tool_memoir_export(store: &Store, args: &Value) -> ToolResult {
     }
 }
 
-fn tool_feedback_record(store: &Store, args: &Value, compact: bool) -> ToolResult {
+fn tool_feedback_record(
+    store: &Store,
+    embedder: Option<&dyn Embedder>,
+    args: &Value,
+    compact: bool,
+) -> ToolResult {
     let topic = match get_str(args, "topic") {
         Some(t) => t,
         None => return ToolResult::error("missing required field: topic".into()),
@@ -2425,7 +2430,7 @@ fn tool_feedback_record(store: &Store, args: &Value, compact: bool) -> ToolResul
         }
     }
 
-    let feedback = Feedback::new(
+    let mut feedback = Feedback::new(
         topic.into(),
         context.into(),
         predicted.into(),
@@ -2433,6 +2438,15 @@ fn tool_feedback_record(store: &Store, args: &Value, compact: bool) -> ToolResul
         reason,
         source,
     );
+    // Manual-testing finding: feedback search had no semantic fallback at
+    // all — pure FTS5 with implicit AND, so a query missing even one exact
+    // token returned nothing. Attach an embedding here so search_feedback
+    // can blend semantic similarity in, mirroring icm_memory_store.
+    if let Some(emb) = embedder {
+        if let Ok(v) = emb.embed(&feedback.embed_text()) {
+            feedback.embedding = Some(v);
+        }
+    }
 
     let id = feedback.id.clone();
     match store.store_feedback(feedback) {
@@ -2447,15 +2461,20 @@ fn tool_feedback_record(store: &Store, args: &Value, compact: bool) -> ToolResul
     }
 }
 
-fn tool_feedback_search(store: &Store, args: &Value) -> ToolResult {
+fn tool_feedback_search(
+    store: &Store,
+    embedder: Option<&dyn Embedder>,
+    args: &Value,
+) -> ToolResult {
     let query = match get_str(args, "query") {
         Some(q) => q,
         None => return ToolResult::error("missing required field: query".into()),
     };
     let topic = get_str(args, "topic");
     let limit = get_i64(args, "limit", 5).clamp(1, 100) as usize;
+    let query_embedding = embedder.and_then(|emb| emb.embed_query(query).ok());
 
-    match store.search_feedback(query, topic, limit) {
+    match store.search_feedback(query, query_embedding.as_deref(), topic, limit) {
         Ok(results) => {
             if results.is_empty() {
                 return ToolResult::text("No feedback found.".into());

--- a/crates/icm-store/src/backend.rs
+++ b/crates/icm-store/src/backend.rs
@@ -652,10 +652,11 @@ impl FeedbackStore for Store {
     fn search_feedback(
         &self,
         query: &str,
+        query_embedding: Option<&[f32]>,
         topic: Option<&str>,
         limit: usize,
     ) -> IcmResult<Vec<Feedback>> {
-        dispatch!(self, search_feedback(query, topic, limit))
+        dispatch!(self, search_feedback(query, query_embedding, topic, limit))
     }
     fn list_feedback(&self, topic: Option<&str>, limit: usize) -> IcmResult<Vec<Feedback>> {
         dispatch!(self, list_feedback(topic, limit))

--- a/crates/icm-store/src/opensearch.rs
+++ b/crates/icm-store/src/opensearch.rs
@@ -1860,6 +1860,7 @@ impl FeedbackStore for OpenSearchStore {
     fn search_feedback(
         &self,
         _query: &str,
+        _query_embedding: Option<&[f32]>,
         _topic: Option<&str>,
         _limit: usize,
     ) -> IcmResult<Vec<Feedback>> {

--- a/crates/icm-store/src/postgres.rs
+++ b/crates/icm-store/src/postgres.rs
@@ -1763,6 +1763,7 @@ impl FeedbackStore for PostgresStore {
     fn search_feedback(
         &self,
         _query: &str,
+        _query_embedding: Option<&[f32]>,
         _topic: Option<&str>,
         _limit: usize,
     ) -> IcmResult<Vec<Feedback>> {

--- a/crates/icm-store/src/schema.rs
+++ b/crates/icm-store/src/schema.rs
@@ -302,12 +302,24 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
             reason TEXT,
             source TEXT NOT NULL DEFAULT '',
             created_at TEXT NOT NULL,
-            applied_count INTEGER DEFAULT 0
+            applied_count INTEGER DEFAULT 0,
+            embedding BLOB
         );
         CREATE INDEX IF NOT EXISTS idx_feedback_topic ON feedback(topic);
         ",
     )
     .map_err(db_err)?;
+
+    // Migration: add `embedding` to `feedback` for existing DBs that
+    // predate feedback search's semantic fallback (manual-testing finding
+    // — see Feedback::embedding's doc comment). Must run after the table
+    // above exists, unlike the memories/summary_hash migration higher up.
+    if let Err(e) = conn.execute("ALTER TABLE feedback ADD COLUMN embedding BLOB", []) {
+        let msg = e.to_string();
+        if !msg.contains("duplicate column name") {
+            return Err(db_err(e));
+        }
+    }
 
     // Feedback FTS table. Same TOCTOU race as memories_fts above (BEGIN
     // IMMEDIATE fix) — see its comment.

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -2951,6 +2951,9 @@ impl MemoirStore for SqliteStore {
 // ---------------------------------------------------------------------------
 
 fn row_to_feedback(row: &rusqlite::Row) -> rusqlite::Result<Feedback> {
+    let embedding: Option<Vec<f32>> = row
+        .get::<_, Option<Vec<u8>>>(9)?
+        .map(|b| blob_to_embedding(&b));
     Ok(Feedback {
         id: row.get(0)?,
         topic: row.get(1)?,
@@ -2961,22 +2964,53 @@ fn row_to_feedback(row: &rusqlite::Row) -> rusqlite::Result<Feedback> {
         source: row.get(6)?,
         created_at: parse_dt(&row.get::<_, String>(7)?),
         applied_count: row.get(8)?,
+        embedding,
     })
 }
 
 const FEEDBACK_COLS: &str =
-    "id, topic, context, predicted, corrected, reason, source, created_at, applied_count";
+    "id, topic, context, predicted, corrected, reason, source, created_at, applied_count, embedding";
+/// Same columns, qualified for the `feedback f JOIN feedback_fts fts` query
+/// in `search_feedback` — both tables have an `id` column post-join, so the
+/// unqualified `FEEDBACK_COLS` is ambiguous there (found via real testing:
+/// `search_feedback` errored on every call once the join was introduced).
+const FEEDBACK_COLS_F: &str = "f.id, f.topic, f.context, f.predicted, f.corrected, f.reason, \
+     f.source, f.created_at, f.applied_count, f.embedding";
 
 // ---------------------------------------------------------------------------
 // FeedbackStore impl
 // ---------------------------------------------------------------------------
 
+/// Pure Rust cosine similarity for the feedback semantic fallback (no
+/// vec0 virtual table — feedback volume is expected far lower than
+/// memories, so a brute-force scan over rows with an embedding is simpler
+/// and avoids replicating the vec0/dimension-migration machinery for a
+/// low-cardinality table). A dimension mismatch returns -1.0 (below any
+/// real cosine similarity) rather than silently comparing a truncated
+/// prefix — same reasoning as `extract_semantic.rs`'s `cosine`.
+fn feedback_cosine(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return -1.0;
+    }
+    let (mut dot, mut na, mut nb) = (0.0f32, 0.0f32, 0.0f32);
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        na += a[i] * a[i];
+        nb += b[i] * b[i];
+    }
+    if na == 0.0 || nb == 0.0 {
+        return -1.0;
+    }
+    dot / (na.sqrt() * nb.sqrt())
+}
+
 impl FeedbackStore for SqliteStore {
     fn store_feedback(&self, feedback: Feedback) -> IcmResult<String> {
+        let embedding_blob = feedback.embedding.as_deref().map(embedding_to_blob);
         self.conn
             .execute(
-                "INSERT INTO feedback (id, topic, context, predicted, corrected, reason, source, created_at, applied_count)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                "INSERT INTO feedback (id, topic, context, predicted, corrected, reason, source, created_at, applied_count, embedding)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
                 params![
                     feedback.id,
                     feedback.topic,
@@ -2987,6 +3021,7 @@ impl FeedbackStore for SqliteStore {
                     feedback.source,
                     feedback.created_at.to_rfc3339(),
                     feedback.applied_count,
+                    embedding_blob,
                 ],
             )
             .map_err(db_err)?;
@@ -2996,6 +3031,7 @@ impl FeedbackStore for SqliteStore {
     fn search_feedback(
         &self,
         query: &str,
+        query_embedding: Option<&[f32]>,
         topic: Option<&str>,
         limit: usize,
     ) -> IcmResult<Vec<Feedback>> {
@@ -3005,42 +3041,114 @@ impl FeedbackStore for SqliteStore {
             return self.list_feedback(topic, limit);
         }
 
-        let (sql, params_vec): (String, Vec<Box<dyn rusqlite::types::ToSql>>) =
+        let pool = limit.saturating_mul(4).max(limit);
+
+        // FTS candidates, ranked (FTS5 bm25: more negative = more relevant).
+        let (fts_sql, fts_params): (String, Vec<Box<dyn rusqlite::types::ToSql>>) =
             if let Some(t) = topic {
                 (
                     format!(
-                        "SELECT {FEEDBACK_COLS} FROM feedback
-                     WHERE id IN (SELECT id FROM feedback_fts WHERE feedback_fts MATCH ?1)
-                     AND topic = ?2
-                     ORDER BY created_at DESC LIMIT ?3"
+                        "SELECT {FEEDBACK_COLS_F}, fts.rank as rnk FROM feedback f
+                         JOIN feedback_fts fts ON fts.id = f.id
+                         WHERE feedback_fts MATCH ?1 AND f.topic = ?2
+                         ORDER BY fts.rank LIMIT ?3"
                     ),
                     vec![
-                        Box::new(sanitized) as Box<dyn rusqlite::types::ToSql>,
+                        Box::new(sanitized.clone()) as Box<dyn rusqlite::types::ToSql>,
                         Box::new(t.to_string()),
-                        Box::new(limit as i64),
+                        Box::new(pool as i64),
                     ],
                 )
             } else {
                 (
                     format!(
-                        "SELECT {FEEDBACK_COLS} FROM feedback
-                     WHERE id IN (SELECT id FROM feedback_fts WHERE feedback_fts MATCH ?1)
-                     ORDER BY created_at DESC LIMIT ?2"
+                        "SELECT {FEEDBACK_COLS_F}, fts.rank as rnk FROM feedback f
+                         JOIN feedback_fts fts ON fts.id = f.id
+                         WHERE feedback_fts MATCH ?1
+                         ORDER BY fts.rank LIMIT ?2"
                     ),
                     vec![
-                        Box::new(sanitized) as Box<dyn rusqlite::types::ToSql>,
-                        Box::new(limit as i64),
+                        Box::new(sanitized.clone()) as Box<dyn rusqlite::types::ToSql>,
+                        Box::new(pool as i64),
                     ],
                 )
             };
 
-        let mut stmt = self.conn.prepare(&sql).map_err(db_err)?;
-        let refs: Vec<&dyn rusqlite::types::ToSql> =
-            params_vec.iter().map(|p| p.as_ref()).collect();
-        let rows = stmt
-            .query_map(refs.as_slice(), row_to_feedback)
-            .map_err(db_err)?;
-        collect_rows(rows)
+        let mut all: HashMap<String, Feedback> = HashMap::new();
+        let mut fts_scores: HashMap<String, f32> = HashMap::new();
+        {
+            let mut stmt = self.conn.prepare(&fts_sql).map_err(db_err)?;
+            let refs: Vec<&dyn rusqlite::types::ToSql> =
+                fts_params.iter().map(|p| p.as_ref()).collect();
+            let col_count = 10; // FEEDBACK_COLS (10) + rnk
+            let rows = stmt
+                .query_map(refs.as_slice(), |row| {
+                    let fb = row_to_feedback(row)?;
+                    let rank: f32 = row.get(col_count)?;
+                    Ok((fb, rank))
+                })
+                .map_err(db_err)?;
+            for row in rows.flatten() {
+                let (fb, rank) = row;
+                // Same monotonic-increasing-in-relevance transform as
+                // memories' search_hybrid (audit finding there: the naive
+                // `1.0 / (1.0 + |rank|)` inverts the relationship).
+                let score = rank.abs() / (1.0 + rank.abs());
+                fts_scores.insert(fb.id.clone(), score);
+                all.insert(fb.id.clone(), fb);
+            }
+        }
+
+        // Semantic candidates: brute-force cosine over rows with an
+        // embedding (see feedback_cosine's doc comment for why no vec0).
+        let mut vec_scores: HashMap<String, f32> = HashMap::new();
+        if let Some(qemb) = query_embedding {
+            let topic_sql = if topic.is_some() {
+                " WHERE topic = ?1"
+            } else {
+                ""
+            };
+            let sql = format!("SELECT {FEEDBACK_COLS} FROM feedback{topic_sql}");
+            let mut stmt = self.conn.prepare(&sql).map_err(db_err)?;
+            let candidates: Vec<Feedback> = if let Some(t) = topic {
+                collect_rows(
+                    stmt.query_map(params![t], row_to_feedback)
+                        .map_err(db_err)?,
+                )?
+            } else {
+                collect_rows(stmt.query_map([], row_to_feedback).map_err(db_err)?)?
+            };
+            for fb in candidates {
+                if let Some(emb) = &fb.embedding {
+                    let sim = feedback_cosine(qemb, emb);
+                    if sim > 0.0 {
+                        vec_scores.insert(fb.id.clone(), sim);
+                        all.entry(fb.id.clone()).or_insert(fb);
+                    }
+                }
+            }
+        }
+
+        let mut scored: Vec<(String, f32)> = all
+            .keys()
+            .map(|id| {
+                let fts = fts_scores.get(id).copied().unwrap_or(0.0);
+                let vec = vec_scores.get(id).copied().unwrap_or(0.0);
+                (id.clone(), 0.3 * fts + 0.7 * vec)
+            })
+            .collect();
+        // Pure-FTS fallback (no query embedding available) must still rank
+        // by relevance, not just whatever HashMap order `all` iterates in.
+        if query_embedding.is_none() {
+            scored = fts_scores.iter().map(|(id, s)| (id.clone(), *s)).collect();
+        }
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(limit);
+
+        Ok(scored
+            .into_iter()
+            .filter_map(|(id, _)| all.remove(&id))
+            .collect())
     }
 
     fn list_feedback(&self, topic: Option<&str>, limit: usize) -> IcmResult<Vec<Feedback>> {
@@ -7064,7 +7172,9 @@ mod tests {
             ))
             .unwrap();
 
-        let results = store.search_feedback("memory leak", None, 10).unwrap();
+        let results = store
+            .search_feedback("memory leak", None, None, 10)
+            .unwrap();
         assert_eq!(results.len(), 1);
         assert!(results[0].context.contains("memory leak"));
     }
@@ -7079,9 +7189,53 @@ mod tests {
             .store_feedback(make_feedback("pr-review", "memory usage", "ok", "bad"))
             .unwrap();
 
-        let results = store.search_feedback("memory", Some("triage"), 10).unwrap();
+        let results = store
+            .search_feedback("memory", None, Some("triage"), 10)
+            .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].topic, "triage");
+    }
+
+    /// Manual-testing finding: `feedback search` had no semantic fallback
+    /// at all — pure FTS5 with implicit AND, so a query missing even one
+    /// exact token (no stemming: "formatting" != "format") returned
+    /// nothing, even with an obviously relevant entry stored. Proves the
+    /// fix: the exact real-world query that failed now succeeds once an
+    /// embedding is attached and a query embedding is supplied.
+    #[test]
+    fn feedback_search_falls_back_to_semantic_similarity_on_partial_fts_miss() {
+        let store = SqliteStore::in_memory_with_dims(64).unwrap();
+
+        let mut fb = make_feedback(
+            "code-style",
+            "user asked to format a date",
+            "used strftime with %Y-%m-%d",
+            "should use format_local helper for timezone consistency",
+        );
+        fb.embedding = Some(vec![0.5_f32; 64]);
+        store.store_feedback(fb).unwrap();
+
+        // FTS-only (no query embedding) must reproduce the original bug:
+        // "formatting" has no exact-token match anywhere in the entry.
+        let fts_only = store
+            .search_feedback("date formatting", None, None, 10)
+            .unwrap();
+        assert!(
+            fts_only.is_empty(),
+            "sanity check: FTS-only must still miss this partial-token query"
+        );
+
+        // With a query embedding, semantic similarity must find it even
+        // though the FTS side still misses.
+        let query_embedding = vec![0.5_f32; 64];
+        let hybrid = store
+            .search_feedback("date formatting", Some(&query_embedding), None, 10)
+            .unwrap();
+        assert_eq!(
+            hybrid.len(),
+            1,
+            "semantic fallback must surface the entry FTS alone misses"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Found via manual testing during the daytime bug-hunt loop: `feedback search` had no semantic/vector fallback at all, unlike `icm recall` — pure FTS5 with implicit AND, so a query missing even one exact token (no stemming: "formatting" != "format") returned nothing, even with an obviously relevant entry stored.

Real repro: recorded a correction about date formatting, searched `"date formatting"`, got `"No feedback found."` despite the entry literally being about formatting a date.

## Fix

- `Feedback` gains an `embedding: Option<Vec<f32>>` field (mirrors `Memory`) and an `embed_text()` helper (context + predicted + corrected).
- **SQLite**: `feedback` table gains an `embedding` BLOB column (fresh schema + idempotent `ALTER TABLE` migration for existing DBs — placed *after* the table now exists, unlike the `memories`/`summary_hash` migration this was modeled on, which runs before its table exists in that flow). `search_feedback` now blends FTS (30%) with cosine similarity (70%) — same weights as `MemoryStore::search_hybrid`. No `vec0` virtual table — feedback volume is expected far lower than memories, so a brute-force cosine scan over rows with an embedding is simpler and lower-risk than replicating the vec0/dimension-migration machinery for a low-cardinality table.
- **Postgres/OpenSearch**: `search_feedback` was already fully unimplemented (`unsupported(...)` stubs) — just updated the trait signature, no behavior change.
- **CLI**/**MCP**: `cmd_feedback_record`/`cmd_feedback_search` and `tool_feedback_record`/`tool_feedback_search` now attach/query embeddings, mirroring `cmd_store`/`icm_memory_store`.

## Test plan

- [x] New regression test `feedback_search_falls_back_to_semantic_similarity_on_partial_fts_miss` — the sanity-check half reproduces the original bug (FTS-only misses the partial-token query), the second half proves the fix (semantic fallback finds it).
- [x] Existing feedback test suite (9 tests) still green — including a real bug caught while writing this: the FTS join query (`feedback f JOIN feedback_fts fts`) needed qualified column names, since both tables have an `id` column post-join ("ambiguous column name" error on every call, caught immediately by the existing tests).
- [x] Real e2e verification against the compiled binary (CLI and MCP): the exact originally-failing query now finds the entry, embedding confirmed attached via direct SQL, `--no-embeddings` still degrades gracefully to FTS-only for exact-token queries.
- [x] `cargo test --workspace --all-features` and default-features (all crates green), clippy clean, fmt clean.