### PR TITLE
Add opt-in trust for local ICM MCP tools

### DIFF
--- a/crates/icm-cli/src/install_manifest.rs
+++ b/crates/icm-cli/src/install_manifest.rs
@@ -2,9 +2,8 @@
 //!
 //! Every time `icm init` configures an AI tool, it records the touched
 //! path here. The manifest persists across invocations: subsequent
-//! `icm init` runs update entries in place, and `icm uninstall` (a
-//! future PR) consumes it to know exactly what to clean up — without
-//! having to derive the surface from a hard-coded list.
+//! `icm init` runs update entries in place, and `icm uninstall` consumes
+//! its ownership metadata to avoid removing matching user configuration.
 //!
 //! Path: `<icm-data-dir>/install-manifest.json`
 //! - Linux/WSL: `~/.local/share/icm/install-manifest.json`
@@ -14,14 +13,14 @@
 //! Schema is versioned (`schema_version` field) so future migrations
 //! stay backwards-compatible.
 
-#![allow(dead_code)] // consumed by cmd_init in the next commit
-
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-const CURRENT_SCHEMA: u32 = 1;
+use crate::trusted_mcp::TrustChange;
+
+const CURRENT_SCHEMA: u32 = 2;
 
 /// Top-level install manifest persisted at `<data_dir>/install-manifest.json`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -53,6 +52,11 @@ pub(crate) struct ManifestEntry {
     pub sha256_before: Option<String>,
     /// File size in bytes before init touched it. 0 for pure creates.
     pub bytes_before: u64,
+    /// Exact trust values inserted by ICM. Missing on legacy manifests,
+    /// where uninstall retains its historical exact-match fallback. An
+    /// explicit empty list means init saw matching user values and owns none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trust_changes: Option<Vec<TrustChange>>,
 }
 
 /// What `cmd_init` did at this path.
@@ -94,7 +98,7 @@ impl InstallManifest {
         }
         let raw = std::fs::read_to_string(path)
             .with_context(|| format!("cannot read manifest at {}", path.display()))?;
-        let m: InstallManifest = serde_json::from_str(&raw)
+        let mut m: InstallManifest = serde_json::from_str(&raw)
             .with_context(|| format!("invalid JSON in manifest {}", path.display()))?;
         if m.schema_version > CURRENT_SCHEMA {
             anyhow::bail!(
@@ -106,12 +110,16 @@ impl InstallManifest {
                 CURRENT_SCHEMA,
             );
         }
+        if m.schema_version == 1 {
+            m.schema_version = CURRENT_SCHEMA;
+        }
         Ok(m)
     }
 
     /// Write the manifest, creating the parent directory if needed.
     /// Bumps `updated_at` and `icm_version` on every save.
     pub fn save(&mut self, path: &Path) -> Result<()> {
+        self.schema_version = CURRENT_SCHEMA;
         self.updated_at = iso_timestamp();
         self.icm_version = env!("CARGO_PKG_VERSION").to_string();
         if let Some(parent) = path.parent() {
@@ -146,6 +154,7 @@ impl InstallManifest {
                 kind,
                 sha256_before: None,
                 bytes_before: 0,
+                trust_changes: Some(Vec::new()),
             });
         }
         let meta =
@@ -158,7 +167,90 @@ impl InstallManifest {
             kind,
             sha256_before,
             bytes_before,
+            trust_changes: Some(Vec::new()),
         })
+    }
+
+    /// Add newly inserted trust values without discarding ownership from a
+    /// previous idempotent init run. A legacy entry stays legacy when this
+    /// invocation added nothing, preserving its documented fallback.
+    pub fn record_trust_changes(&mut self, path: &Path, changes: Vec<TrustChange>) {
+        let Some(entry) = self.entries.iter_mut().find(|entry| entry.path == path) else {
+            return;
+        };
+        if changes.is_empty() {
+            return;
+        }
+        let owned = entry.trust_changes.get_or_insert_with(Vec::new);
+        for change in changes {
+            if !owned.contains(&change) {
+                owned.push(change);
+            }
+        }
+    }
+
+    /// Establish an authoritative ownership record before a trust config is
+    /// mutated. Persisting this empty marker first makes an interrupted init
+    /// conservative: uninstall preserves values whose ownership was never
+    /// durably recorded instead of applying the legacy exact-match fallback.
+    pub fn ensure_trust_tracking(&mut self, path: &Path) -> Result<()> {
+        let entry = self
+            .entries
+            .iter_mut()
+            .find(|entry| entry.path == path)
+            .with_context(|| format!("no install manifest entry for {}", path.display()))?;
+        entry.trust_changes.get_or_insert_with(Vec::new);
+        Ok(())
+    }
+
+    /// `None` distinguishes a manifest written before trust provenance was
+    /// available from an explicit record that owns zero values.
+    pub fn trust_changes_for(&self, path: &Path) -> Option<&[TrustChange]> {
+        self.entries
+            .iter()
+            .find(|entry| entry.path == path)
+            .and_then(|entry| entry.trust_changes.as_deref())
+    }
+
+    /// Consume trust ownership after a successful uninstall mutation. Keeping
+    /// an explicit empty list prevents a later identical user value from being
+    /// mistaken for residue by a stale manifest entry.
+    pub fn clear_trust_changes(&mut self, path: &Path) -> bool {
+        let Some(entry) = self.entries.iter_mut().find(|entry| entry.path == path) else {
+            return false;
+        };
+        if entry
+            .trust_changes
+            .as_ref()
+            .is_some_and(|changes| changes.is_empty())
+        {
+            return false;
+        }
+        entry.trust_changes = Some(Vec::new());
+        true
+    }
+
+    /// Reconcile a provenance-aware entry with values still present on disk.
+    /// Legacy entries remain untouched because they intentionally use fallback
+    /// discovery rather than an authoritative ownership list.
+    pub fn replace_recorded_trust_changes(
+        &mut self,
+        path: &Path,
+        present: Vec<TrustChange>,
+    ) -> bool {
+        let Some(changes) = self
+            .entries
+            .iter_mut()
+            .find(|entry| entry.path == path)
+            .and_then(|entry| entry.trust_changes.as_mut())
+        else {
+            return false;
+        };
+        if *changes == present {
+            return false;
+        }
+        *changes = present;
+        true
     }
 
     /// Number of recorded entries.
@@ -251,6 +343,7 @@ mod tests {
             kind: EntryKind::JsonMcpServer,
             sha256_before: Some("abc".into()),
             bytes_before: 42,
+            trust_changes: Some(Vec::new()),
         });
         m.save(&path).unwrap();
 
@@ -258,6 +351,103 @@ mod tests {
         assert_eq!(m2.entries.len(), 1);
         assert_eq!(m2.entries[0].tool, "Claude Code");
         assert_eq!(m2.entries[0].kind, EntryKind::JsonMcpServer);
+        assert_eq!(m2.entries[0].trust_changes, Some(Vec::new()));
+    }
+
+    #[test]
+    fn trust_provenance_uses_a_schema_old_writers_must_reject() {
+        assert_eq!(CURRENT_SCHEMA, 2);
+
+        let mut manifest = InstallManifest::empty();
+        manifest.record(ManifestEntry {
+            path: PathBuf::from("/x/settings.json"),
+            tool: "Claude Code".into(),
+            kind: EntryKind::JsonHooks,
+            sha256_before: None,
+            bytes_before: 0,
+            trust_changes: Some(vec![TrustChange::JsonArrayMember {
+                path: vec!["permissions".into(), "allow".into()],
+                value: "mcp__icm__icm_memory_recall".into(),
+            }]),
+        });
+
+        let serialized = serde_json::to_value(&manifest).unwrap();
+        assert_eq!(serialized["schema_version"], 2);
+        assert!(serialized["entries"][0].get("trust_changes").is_some());
+        assert!(serialized["schema_version"].as_u64().unwrap() > 1);
+    }
+
+    #[test]
+    fn load_migrates_schema_one_and_save_forces_current_schema() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("install-manifest.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "schema_version": 1,
+                "icm_version": "0.10.61",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "entries": []
+            }"#,
+        )
+        .unwrap();
+
+        let mut manifest = InstallManifest::load(&path).unwrap();
+        assert_eq!(manifest.schema_version, 2);
+
+        manifest.schema_version = 1;
+        manifest.save(&path).unwrap();
+        let saved: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(saved["schema_version"], 2);
+    }
+
+    #[test]
+    fn legacy_entry_without_trust_changes_keeps_fallback_marker() {
+        let raw = r#"{
+            "schema_version": 1,
+            "icm_version": "0.10.61",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "entries": [{
+                "path": "/x/settings.json",
+                "tool": "Claude Code",
+                "kind": "JsonHooks",
+                "sha256_before": null,
+                "bytes_before": 0
+            }]
+        }"#;
+        let mut manifest: InstallManifest = serde_json::from_str(raw).unwrap();
+        assert!(manifest.entries[0].trust_changes.is_none());
+        assert!(manifest.clear_trust_changes(Path::new("/x/settings.json")));
+        assert_eq!(manifest.entries[0].trust_changes, Some(Vec::new()));
+    }
+
+    #[test]
+    fn trust_ownership_accumulates_without_claiming_idempotent_values() {
+        let path = PathBuf::from("/x/settings.json");
+        let mut manifest = InstallManifest::empty();
+        manifest.record(ManifestEntry {
+            path: path.clone(),
+            tool: "Claude Code".into(),
+            kind: EntryKind::JsonHooks,
+            sha256_before: None,
+            bytes_before: 0,
+            trust_changes: Some(Vec::new()),
+        });
+        let change = TrustChange::JsonArrayMember {
+            path: vec!["permissions".into(), "allow".into()],
+            value: "mcp__icm__icm_memory_recall".into(),
+        };
+        manifest.record_trust_changes(&path, vec![change.clone(), change.clone()]);
+        manifest.record_trust_changes(&path, Vec::new());
+        assert_eq!(manifest.trust_changes_for(&path), Some([change].as_slice()));
+        assert!(manifest.clear_trust_changes(&path));
+        assert_eq!(
+            manifest.trust_changes_for(&path),
+            Some(&[] as &[TrustChange])
+        );
+        assert!(!manifest.clear_trust_changes(&path));
+        assert!(!manifest.replace_recorded_trust_changes(&path, Vec::new()));
     }
 
     #[test]
@@ -269,6 +459,7 @@ mod tests {
             kind: EntryKind::JsonMcpServer,
             sha256_before: Some("aa".into()),
             bytes_before: 1,
+            trust_changes: Some(Vec::new()),
         };
         let entry2 = ManifestEntry {
             path: PathBuf::from("/x"),
@@ -276,6 +467,7 @@ mod tests {
             kind: EntryKind::TomlMcpServer,
             sha256_before: Some("bb".into()),
             bytes_before: 2,
+            trust_changes: Some(Vec::new()),
         };
         m.record(entry1);
         m.record(entry2);

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -26,6 +26,7 @@ mod learn_tests;
 mod ort_runtime;
 mod recall_format;
 mod summarizer;
+mod trusted_mcp;
 #[cfg(feature = "tui")]
 mod tui;
 mod uninstall;
@@ -428,6 +429,13 @@ enum Commands {
         /// (`extract_every`, `min_score`, `store_raw=false`).
         #[arg(long)]
         with_codex_post_hook: bool,
+
+        /// Explicitly allow the local ICM recall and store MCP tools in
+        /// Codex CLI and Claude Code without per-call approval prompts.
+        /// Other ICM tools remain subject to each client's normal policy.
+        /// Requires `--mode mcp` or `--mode all`.
+        #[arg(long)]
+        trust_local_mcp: bool,
     },
 
     /// Diagnose ICM integration: hook binary paths + SQLite database integrity
@@ -2034,7 +2042,14 @@ fn main() -> Result<()> {
             force,
             per_project,
             with_codex_post_hook,
-        } => cmd_init(mode, force, per_project, with_codex_post_hook),
+            trust_local_mcp,
+        } => cmd_init(
+            mode,
+            force,
+            per_project,
+            with_codex_post_hook,
+            trust_local_mcp,
+        ),
         // Doctor and Repair are dispatched before `open_store` above; these
         // arms exist only for match exhaustiveness and are unreachable.
         Commands::Doctor => cmd_doctor(&db_path),
@@ -4511,11 +4526,86 @@ pub(crate) fn cmd_matches_icm_pattern(cmd: &str, pattern: &str) -> bool {
     cmd.contains(&format!("{pattern}.exe"))
 }
 
+fn run_tracked_trust_write<F>(
+    manifest: &mut install_manifest::InstallManifest,
+    manifest_path: &Path,
+    config_path: &Path,
+    tool: &str,
+    kind: install_manifest::EntryKind,
+    write: F,
+) -> Result<String>
+where
+    F: FnOnce() -> Result<(String, Vec<trusted_mcp::TrustChange>)>,
+{
+    let entry = install_manifest::InstallManifest::entry_from_disk(config_path, tool, kind)?;
+    manifest.record(entry);
+    manifest.ensure_trust_tracking(config_path)?;
+    manifest.save(manifest_path)?;
+
+    let (status, trust_changes) = write()?;
+    manifest.record_trust_changes(config_path, trust_changes);
+    manifest.save(manifest_path)?;
+    Ok(status)
+}
+
+fn trusted_provider_manifest_kind(
+    config: trusted_mcp::ProviderConfig,
+) -> install_manifest::EntryKind {
+    match config {
+        trusted_mcp::ProviderConfig::JsonTrust { .. } => install_manifest::EntryKind::JsonHooks,
+        trusted_mcp::ProviderConfig::JsonMcp { .. } => install_manifest::EntryKind::JsonMcpServer,
+        trusted_mcp::ProviderConfig::TomlMcp { .. } => install_manifest::EntryKind::TomlMcpServer,
+    }
+}
+
+fn write_trusted_provider_config(
+    provider: trusted_mcp::TrustedProvider,
+    config_path: &Path,
+    icm_bin: &str,
+    trust_local_mcp: bool,
+) -> Result<(String, Vec<trusted_mcp::TrustChange>)> {
+    use trusted_mcp::{ProviderConfig, ProviderId};
+
+    match provider.id() {
+        ProviderId::Claude => {
+            let ProviderConfig::JsonTrust { spec, .. } = provider.config else {
+                anyhow::bail!("Claude trust provider must use a JSON trust config");
+            };
+            inject_claude_mcp_permissions(config_path, spec)
+        }
+        ProviderId::Cursor => {
+            let ProviderConfig::JsonTrust { spec, .. } = provider.config else {
+                anyhow::bail!("Cursor trust provider must use a JSON trust config");
+            };
+            inject_cursor_mcp_permissions(config_path, spec)
+        }
+        ProviderId::Zed => {
+            let ProviderConfig::JsonMcp { spec, .. } = provider.config else {
+                anyhow::bail!("Zed trust provider must use a JSON MCP config");
+            };
+            inject_zed_mcp_server(config_path, "icm", icm_bin, trust_local_mcp, spec)
+        }
+        ProviderId::Codex => {
+            let ProviderConfig::TomlMcp { spec, .. } = provider.config else {
+                anyhow::bail!("Codex trust provider must use a TOML MCP config");
+            };
+            inject_codex_mcp_server(config_path, "icm", icm_bin, trust_local_mcp, spec)
+        }
+        ProviderId::OpenCode => {
+            let ProviderConfig::JsonMcp { spec, .. } = provider.config else {
+                anyhow::bail!("OpenCode trust provider must use a JSON MCP config");
+            };
+            inject_opencode_mcp_server(config_path, "icm", icm_bin, trust_local_mcp, spec)
+        }
+    }
+}
+
 fn cmd_init(
     mode: InitMode,
     force: bool,
     per_project: bool,
     with_codex_post_hook: bool,
+    trust_local_mcp: bool,
 ) -> Result<()> {
     let icm_bin = std::env::current_exe().context("cannot determine icm binary path")?;
     let icm_bin_str = portable_command_path(&icm_bin);
@@ -4534,6 +4624,9 @@ fn cmd_init(
     let do_cli = matches!(mode, InitMode::Cli | InitMode::All | InitMode::Standard);
     let do_skill = matches!(mode, InitMode::Skill | InitMode::All | InitMode::Standard);
     let do_hook = matches!(mode, InitMode::Hook | InitMode::All | InitMode::Standard);
+    if trust_local_mcp && !do_mcp {
+        anyhow::bail!("--trust-local-mcp requires --mode mcp or --mode all");
+    }
 
     // Shared across every mode for tool detection.
     let vscode_data = if cfg!(target_os = "macos") {
@@ -4642,56 +4735,58 @@ fn cmd_init(
             println!("[mcp] {name:<16} {status}");
         }
 
-        // Zed uses nested command.path format
-        let zed_path = if cfg!(target_os = "macos") {
+        let home_path = PathBuf::from(&home);
+        let zed_settings = if cfg!(target_os = "macos") {
             PathBuf::from(&home).join(".zed/settings.json")
         } else {
             PathBuf::from(&home).join(".config/zed/settings.json")
         };
-        if !force && !detect_tool("Zed", &home, &vscode_data) {
-            println!("[mcp] {:<16} skipped (not detected)", "Zed");
-        } else {
-            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
-                &zed_path,
-                "Zed",
-                install_manifest::EntryKind::JsonMcpServer,
-            ) {
-                manifest.record(e);
-            }
-            let zed_status = inject_zed_mcp_server(&zed_path, "icm", &icm_bin_str)?;
-            println!("[mcp] {:<16} {zed_status}", "Zed");
-        }
+        let provider_paths = trusted_mcp::ProviderPathContext {
+            home: &home_path,
+            claude_dir: &claude_dir,
+            codex_dir: &codex_dir,
+            zed_settings: &zed_settings,
+        };
 
-        // Codex CLI uses TOML format
-        let codex_path = codex_dir.join("config.toml");
-        if !force && !detect_tool("Codex CLI", &home, &vscode_data) {
-            println!("[mcp] {:<16} skipped (not detected)", "Codex CLI");
-        } else {
-            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
-                &codex_path,
-                "Codex CLI",
-                install_manifest::EntryKind::TomlMcpServer,
-            ) {
-                manifest.record(e);
+        for provider in trusted_mcp::TRUSTED_PROVIDERS {
+            let includes_mcp_server = provider.config.includes_mcp_server();
+            if !trust_local_mcp && !includes_mcp_server {
+                continue;
             }
-            let codex_status = inject_codex_mcp_server(&codex_path, "icm", &icm_bin_str)?;
-            println!("[mcp] {:<16} {codex_status}", "Codex CLI");
-        }
+            if !force && !detect_tool(provider.client, &home, &vscode_data) {
+                if includes_mcp_server {
+                    println!("[mcp] {:<16} skipped (not detected)", provider.client);
+                }
+                continue;
+            }
 
-        // OpenCode uses different JSON structure (command is array, key is "mcp")
-        let opencode_path = PathBuf::from(&home).join(".config/opencode/opencode.json");
-        if !force && !detect_tool("OpenCode", &home, &vscode_data) {
-            println!("[mcp] {:<16} skipped (not detected)", "OpenCode");
-        } else {
-            if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
-                &opencode_path,
-                "OpenCode",
-                install_manifest::EntryKind::JsonMcpServer,
-            ) {
-                manifest.record(e);
+            let config_path = provider.config_path(&provider_paths);
+            let manifest_kind = trusted_provider_manifest_kind(provider.config);
+            let status = if trust_local_mcp {
+                run_tracked_trust_write(
+                    &mut manifest,
+                    &manifest_path,
+                    &config_path,
+                    provider.client,
+                    manifest_kind,
+                    || write_trusted_provider_config(provider, &config_path, &icm_bin_str, true),
+                )?
+            } else {
+                if let Ok(entry) = install_manifest::InstallManifest::entry_from_disk(
+                    &config_path,
+                    provider.client,
+                    manifest_kind,
+                ) {
+                    manifest.record(entry);
+                }
+                write_trusted_provider_config(provider, &config_path, &icm_bin_str, false)?.0
+            };
+
+            if includes_mcp_server {
+                println!("[mcp] {:<16} {status}", provider.client);
+            } else {
+                println!("[trust] {:<14} {status}", provider.client);
             }
-            let opencode_status = inject_opencode_mcp_server(&opencode_path, "icm", &icm_bin_str)?;
-            println!("[mcp] {:<16} {opencode_status}", "OpenCode");
         }
 
         // Copilot CLI uses mcpServers key with explicit "type": "local"
@@ -4724,6 +4819,11 @@ fn cmd_init(
             }
             let continue_status = inject_continue_mcp_server(&continue_path, "icm", &icm_bin_str)?;
             println!("[mcp] {:<16} {continue_status}", "Continue.dev");
+        }
+        if trust_local_mcp {
+            println!(
+                "[trust] Client safety checks and higher-priority deny rules can still reject calls."
+            );
         }
     }
 
@@ -6469,8 +6569,14 @@ fn inject_mcp_server(
     Ok("configured".into())
 }
 
-/// Inject ICM MCP server into Zed settings.json (uses `context_servers` with nested `command` object).
-fn inject_zed_mcp_server(config_path: &Path, name: &str, bin_path: &str) -> Result<String> {
+/// Inject ICM MCP server into Zed settings.json (uses `context_servers`).
+fn inject_zed_mcp_server(
+    config_path: &Path,
+    name: &str,
+    bin_path: &str,
+    trust_local_mcp: bool,
+    trust_spec: trusted_mcp::JsonTrustSpec,
+) -> Result<(String, Vec<trusted_mcp::TrustChange>)> {
     let mut config: Value = if config_path.exists() {
         parse_json_config(config_path)?
     } else {
@@ -6480,37 +6586,48 @@ fn inject_zed_mcp_server(config_path: &Path, name: &str, bin_path: &str) -> Resu
         serde_json::json!({})
     };
 
-    let servers = config
+    let root = config
         .as_object_mut()
-        .context("config is not a JSON object")?
+        .context("config is not a JSON object")?;
+    let servers = root
         .entry("context_servers")
-        .or_insert_with(|| serde_json::json!({}));
-
-    if servers.get(name).is_some() {
-        return Ok("already configured".into());
-    }
-
-    let zed_entry = serde_json::json!({
-        "command": bin_path,
-        "args": ["serve"],
-        "env": {},
-    });
-
-    servers
+        .or_insert_with(|| serde_json::json!({}))
         .as_object_mut()
         .with_context(|| {
             format!(
                 "`context_servers` in {} is not a JSON object",
                 config_path.display()
             )
-        })?
-        .insert(name.to_string(), zed_entry);
+        })?;
+    let already_configured = servers.get(name).is_some();
+    if !already_configured {
+        servers.insert(
+            name.to_string(),
+            serde_json::json!({
+                "command": bin_path,
+                "args": ["serve"],
+                "env": {},
+            }),
+        );
+    }
+
+    let trust_changes = if trust_local_mcp {
+        trusted_mcp::apply_json_trust(&mut config, trust_spec)?
+    } else {
+        Vec::new()
+    };
 
     let output = serde_json::to_string_pretty(&config)?;
     std::fs::write(config_path, output)
         .with_context(|| format!("cannot write {}", config_path.display()))?;
 
-    Ok("configured".into())
+    let status = match (already_configured, trust_local_mcp) {
+        (true, true) => "already configured; approved recall + store",
+        (false, true) => "configured; approved recall + store",
+        (true, false) => "already configured",
+        (false, false) => "configured",
+    };
+    Ok((status.into(), trust_changes))
 }
 
 /// Inject ICM MCP server into Copilot CLI config (~/.copilot/mcp-config.json).
@@ -6685,8 +6802,60 @@ fn inject_copilot_hooks(copilot_dir: &std::path::Path, icm_bin: &str) -> Result<
     Ok("configured".into())
 }
 
-/// Inject ICM MCP server into Codex CLI TOML config. Returns a status string.
-fn inject_codex_mcp_server(config_path: &Path, name: &str, icm_bin: &str) -> Result<String> {
+/// Add narrowly scoped Claude Code permission rules for ICM's two core tools.
+fn inject_claude_mcp_permissions(
+    settings_path: &Path,
+    trust_spec: trusted_mcp::JsonTrustSpec,
+) -> Result<(String, Vec<trusted_mcp::TrustChange>)> {
+    let mut config = if settings_path.exists() {
+        parse_json_config(settings_path)?
+    } else {
+        serde_json::json!({})
+    };
+    let trust_changes = trusted_mcp::apply_json_trust(&mut config, trust_spec)?;
+    if trust_changes.is_empty() {
+        return Ok(("already trusted".into(), trust_changes));
+    }
+    if let Some(parent) = settings_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let output = serde_json::to_string_pretty(&config)?;
+    std::fs::write(settings_path, output)
+        .with_context(|| format!("cannot write {}", settings_path.display()))?;
+    Ok(("allowed recall + store".into(), trust_changes))
+}
+
+/// Add Cursor IDE allowlist entries for ICM's two core tools.
+fn inject_cursor_mcp_permissions(
+    config_path: &Path,
+    trust_spec: trusted_mcp::JsonTrustSpec,
+) -> Result<(String, Vec<trusted_mcp::TrustChange>)> {
+    let mut config = if config_path.exists() {
+        parse_json_config(config_path)?
+    } else {
+        serde_json::json!({})
+    };
+    let trust_changes = trusted_mcp::apply_json_trust(&mut config, trust_spec)?;
+    if trust_changes.is_empty() {
+        return Ok(("already trusted".into(), trust_changes));
+    }
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let output = serde_json::to_string_pretty(&config)?;
+    std::fs::write(config_path, output)
+        .with_context(|| format!("cannot write {}", config_path.display()))?;
+    Ok(("allowed recall + store".into(), trust_changes))
+}
+
+/// Inject ICM MCP server into Codex CLI TOML config.
+fn inject_codex_mcp_server(
+    config_path: &Path,
+    name: &str,
+    icm_bin: &str,
+    trust_local_mcp: bool,
+    trust_spec: trusted_mcp::TomlTrustSpec,
+) -> Result<(String, Vec<trusted_mcp::TrustChange>)> {
     let mut config: toml::Value = if config_path.exists() {
         let content = std::fs::read_to_string(config_path)
             .with_context(|| format!("cannot read {}", config_path.display()))?;
@@ -6708,39 +6877,58 @@ fn inject_codex_mcp_server(config_path: &Path, name: &str, icm_bin: &str) -> Res
         .entry("mcp_servers")
         .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
 
-    // Check if already configured with same binary
-    if let Some(existing) = mcp_servers.get(name) {
-        if existing.get("command").and_then(|v| v.as_str()) == Some(icm_bin) {
-            return Ok("already configured".into());
-        }
+    let mcp_servers = mcp_servers.as_table_mut().with_context(|| {
+        format!(
+            "`mcp_servers` in {} is not a TOML table",
+            config_path.display()
+        )
+    })?;
+    let already_configured = mcp_servers
+        .get(name)
+        .and_then(toml::Value::as_table)
+        .and_then(|server| server.get("command"))
+        .and_then(toml::Value::as_str)
+        == Some(icm_bin);
+    if already_configured && !trust_local_mcp {
+        return Ok(("already configured".into(), Vec::new()));
     }
 
-    let mut server = toml::map::Map::new();
-    server.insert("command".into(), toml::Value::String(icm_bin.to_string()));
-    server.insert(
-        "args".into(),
-        toml::Value::Array(vec![toml::Value::String("serve".into())]),
-    );
+    if !already_configured {
+        let mut server = toml::map::Map::new();
+        server.insert("command".into(), toml::Value::String(icm_bin.to_string()));
+        server.insert(
+            "args".into(),
+            toml::Value::Array(vec![toml::Value::String("serve".into())]),
+        );
+        mcp_servers.insert(name.to_string(), toml::Value::Table(server));
+    }
 
-    mcp_servers
-        .as_table_mut()
-        .with_context(|| {
-            format!(
-                "`mcp_servers` in {} is not a TOML table",
-                config_path.display()
-            )
-        })?
-        .insert(name.to_string(), toml::Value::Table(server));
+    let trust_changes = if trust_local_mcp {
+        trusted_mcp::apply_toml_trust(&mut config, trust_spec)?
+    } else {
+        Vec::new()
+    };
 
     let output = toml::to_string_pretty(&config)?;
     std::fs::write(config_path, output)
         .with_context(|| format!("cannot write {}", config_path.display()))?;
 
-    Ok("configured".into())
+    let status = if trust_local_mcp {
+        "configured; approved recall + store"
+    } else {
+        "configured"
+    };
+    Ok((status.into(), trust_changes))
 }
 
 /// Inject ICM MCP server into OpenCode config (uses "mcp" key, command is array).
-fn inject_opencode_mcp_server(config_path: &Path, name: &str, icm_bin: &str) -> Result<String> {
+fn inject_opencode_mcp_server(
+    config_path: &Path,
+    name: &str,
+    icm_bin: &str,
+    trust_local_mcp: bool,
+    trust_spec: trusted_mcp::JsonTrustSpec,
+) -> Result<(String, Vec<trusted_mcp::TrustChange>)> {
     let mut config: Value = if config_path.exists() {
         parse_json_config(config_path)?
     } else {
@@ -6750,23 +6938,23 @@ fn inject_opencode_mcp_server(config_path: &Path, name: &str, icm_bin: &str) -> 
         serde_json::json!({})
     };
 
-    let mcp = config
+    let root = config
         .as_object_mut()
-        .context("config is not a JSON object")?
+        .context("config is not a JSON object")?;
+    let mcp = root
         .entry("mcp")
-        .or_insert_with(|| serde_json::json!({}));
-
-    if let Some(existing) = mcp.get(name) {
-        if let Some(cmd) = existing.get("command").and_then(|v| v.as_array()) {
-            if cmd.first().and_then(|v| v.as_str()) == Some(icm_bin) {
-                return Ok("already configured".into());
-            }
-        }
-    }
-
-    mcp.as_object_mut()
-        .with_context(|| format!("`mcp` in {} is not a JSON object", config_path.display()))?
-        .insert(
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .with_context(|| format!("`mcp` in {} is not a JSON object", config_path.display()))?;
+    let already_configured = mcp
+        .get(name)
+        .and_then(|existing| existing.get("command"))
+        .and_then(Value::as_array)
+        .and_then(|command| command.first())
+        .and_then(Value::as_str)
+        == Some(icm_bin);
+    if !already_configured {
+        mcp.insert(
             name.to_string(),
             serde_json::json!({
                 "type": "local",
@@ -6774,12 +6962,25 @@ fn inject_opencode_mcp_server(config_path: &Path, name: &str, icm_bin: &str) -> 
                 "enabled": true
             }),
         );
+    }
+
+    let trust_changes = if trust_local_mcp {
+        trusted_mcp::apply_json_trust(&mut config, trust_spec)?
+    } else {
+        Vec::new()
+    };
 
     let output = serde_json::to_string_pretty(&config)?;
     std::fs::write(config_path, output)
         .with_context(|| format!("cannot write {}", config_path.display()))?;
 
-    Ok("configured".into())
+    let status = match (already_configured, trust_local_mcp) {
+        (true, true) => "already configured; approved recall + store",
+        (false, true) => "configured; approved recall + store",
+        (true, false) => "already configured",
+        (false, false) => "configured",
+    };
+    Ok((status.into(), trust_changes))
 }
 
 fn cmd_config() -> Result<()> {
@@ -12449,5 +12650,237 @@ mod cmd_memoir_tests {
             matches!(relation, CliRelation::DependsOn),
             "relation must map to depends-on"
         );
+    }
+
+    #[test]
+    fn parses_opt_in_local_mcp_trust() {
+        let cli =
+            Cli::try_parse_from(["icm", "init", "--mode", "mcp", "--trust-local-mcp"]).unwrap();
+        let Commands::Init {
+            trust_local_mcp, ..
+        } = cli.command
+        else {
+            panic!("expected init");
+        };
+        assert!(trust_local_mcp);
+    }
+
+    #[test]
+    fn trusted_provider_registry_wires_every_init_mutator() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let claude_dir = home.join(".claude");
+        let codex_dir = home.join(".codex");
+        let zed_settings = home.join(".config/zed/settings.json");
+        let paths = trusted_mcp::ProviderPathContext {
+            home,
+            claude_dir: &claude_dir,
+            codex_dir: &codex_dir,
+            zed_settings: &zed_settings,
+        };
+
+        for provider in trusted_mcp::TRUSTED_PROVIDERS {
+            let path = provider.config_path(&paths);
+            let (_, inserted) =
+                write_trusted_provider_config(provider, &path, "/usr/bin/icm", true).unwrap();
+            assert_eq!(
+                inserted.len(),
+                trusted_mcp::TRUSTED_LOCAL_TOOLS.len(),
+                "{} init mutator",
+                provider.client
+            );
+        }
+    }
+
+    #[test]
+    fn interrupted_multi_provider_init_preserves_unrecorded_trust_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest_path = tmp.path().join("install-manifest.json");
+        let claude_path = tmp.path().join("claude/settings.json");
+        let cursor_path = tmp.path().join("cursor/permissions.json");
+        let claude = *trusted_mcp::trusted_provider(trusted_mcp::ProviderId::Claude);
+        let cursor = *trusted_mcp::trusted_provider(trusted_mcp::ProviderId::Cursor);
+        let claude_spec = claude.json_spec().unwrap();
+        let cursor_spec = cursor.json_spec().unwrap();
+        let mut manifest = install_manifest::InstallManifest::empty();
+
+        run_tracked_trust_write(
+            &mut manifest,
+            &manifest_path,
+            &claude_path,
+            claude.client,
+            install_manifest::EntryKind::JsonHooks,
+            || inject_claude_mcp_permissions(&claude_path, claude_spec),
+        )
+        .unwrap();
+
+        let interrupted = run_tracked_trust_write(
+            &mut manifest,
+            &manifest_path,
+            &cursor_path,
+            cursor.client,
+            install_manifest::EntryKind::JsonHooks,
+            || {
+                let _ = inject_cursor_mcp_permissions(&cursor_path, cursor_spec)?;
+                anyhow::bail!("simulated interruption after config write");
+            },
+        );
+        assert!(interrupted.is_err());
+
+        let persisted = install_manifest::InstallManifest::load(&manifest_path).unwrap();
+        assert_eq!(persisted.schema_version, 2);
+        assert_eq!(
+            persisted.trust_changes_for(&claude_path).unwrap().len(),
+            trusted_mcp::TRUSTED_LOCAL_TOOLS.len()
+        );
+        assert_eq!(
+            persisted.trust_changes_for(&cursor_path),
+            Some(&[] as &[trusted_mcp::TrustChange])
+        );
+
+        let mut cursor_config: Value =
+            serde_json::from_str(&std::fs::read_to_string(&cursor_path).unwrap()).unwrap();
+        let before_uninstall = cursor_config.clone();
+        let removed = trusted_mcp::strip_json_trust(
+            &mut cursor_config,
+            cursor_spec,
+            persisted.trust_changes_for(&cursor_path),
+        );
+        assert_eq!(removed, 0);
+        assert_eq!(cursor_config, before_uninstall);
+    }
+
+    #[test]
+    fn claude_trust_is_narrow_preserving_and_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{"permissions":{"allow":["Read"],"deny":["Bash"]},"theme":"dark"}"#,
+        )
+        .unwrap();
+
+        let spec = trusted_mcp::trusted_provider(trusted_mcp::ProviderId::Claude)
+            .json_spec()
+            .unwrap();
+        let (status, inserted) = inject_claude_mcp_permissions(&path, spec).unwrap();
+        assert_eq!(status, "allowed recall + store");
+        assert_eq!(inserted.len(), 2);
+        let (status, inserted) = inject_claude_mcp_permissions(&path, spec).unwrap();
+        assert_eq!(status, "already trusted");
+        assert!(inserted.is_empty());
+        let value: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(value["theme"], "dark");
+        assert_eq!(value["permissions"]["deny"], serde_json::json!(["Bash"]));
+        assert_eq!(
+            value["permissions"]["allow"],
+            serde_json::json!([
+                "Read",
+                "mcp__icm__icm_memory_recall",
+                "mcp__icm__icm_memory_store"
+            ])
+        );
+    }
+
+    #[test]
+    fn codex_trust_approves_only_recall_and_store() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(&path, "model = \"gpt-test\"\n").unwrap();
+
+        let spec = trusted_mcp::trusted_provider(trusted_mcp::ProviderId::Codex)
+            .toml_spec()
+            .unwrap();
+        inject_codex_mcp_server(&path, "icm", "/usr/bin/icm", true, spec).unwrap();
+        inject_codex_mcp_server(&path, "icm", "/usr/bin/icm", true, spec).unwrap();
+        let value: toml::Value = std::fs::read_to_string(path).unwrap().parse().unwrap();
+        let server = &value["mcp_servers"]["icm"];
+        assert_eq!(value["model"].as_str(), Some("gpt-test"));
+        assert_eq!(server["command"].as_str(), Some("/usr/bin/icm"));
+        assert_eq!(
+            server["tools"]["icm_memory_recall"]["approval_mode"].as_str(),
+            Some("approve")
+        );
+        assert_eq!(
+            server["tools"]["icm_memory_store"]["approval_mode"].as_str(),
+            Some("approve")
+        );
+        assert!(server["tools"].get("icm_memory_forget").is_none());
+        assert!(server.get("default_tools_approval_mode").is_none());
+    }
+
+    #[test]
+    fn cursor_opencode_and_zed_trust_only_core_tools() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let cursor_spec = trusted_mcp::trusted_provider(trusted_mcp::ProviderId::Cursor)
+            .json_spec()
+            .unwrap();
+        let opencode_spec = trusted_mcp::trusted_provider(trusted_mcp::ProviderId::OpenCode)
+            .json_spec()
+            .unwrap();
+        let zed_spec = trusted_mcp::trusted_provider(trusted_mcp::ProviderId::Zed)
+            .json_spec()
+            .unwrap();
+
+        let cursor_path = tmp.path().join("cursor/permissions.json");
+        std::fs::create_dir_all(cursor_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &cursor_path,
+            r#"{"mcpAllowlist":["other:tool"],"mcpBlocklist":["icm:icm_memory_store"]}"#,
+        )
+        .unwrap();
+        let (_, inserted) = inject_cursor_mcp_permissions(&cursor_path, cursor_spec).unwrap();
+        assert_eq!(inserted.len(), 2);
+        let (status, inserted) = inject_cursor_mcp_permissions(&cursor_path, cursor_spec).unwrap();
+        assert_eq!(status, "already trusted");
+        assert!(inserted.is_empty());
+        let cursor: Value =
+            serde_json::from_str(&std::fs::read_to_string(cursor_path).unwrap()).unwrap();
+        assert_eq!(
+            cursor["mcpAllowlist"],
+            serde_json::json!([
+                "other:tool",
+                "icm:icm_memory_recall",
+                "icm:icm_memory_store"
+            ])
+        );
+        assert_eq!(
+            cursor["mcpBlocklist"],
+            serde_json::json!(["icm:icm_memory_store"])
+        );
+
+        let opencode_path = tmp.path().join("opencode.json");
+        std::fs::write(
+            &opencode_path,
+            r#"{"permission":{"bash":"ask","icm_icm_memory_store":"deny","icm_icm_memory_forget":"deny"}}"#,
+        )
+        .unwrap();
+        inject_opencode_mcp_server(&opencode_path, "icm", "/usr/bin/icm", true, opencode_spec)
+            .unwrap();
+        inject_opencode_mcp_server(&opencode_path, "icm", "/usr/bin/icm", true, opencode_spec)
+            .unwrap();
+        let opencode: Value =
+            serde_json::from_str(&std::fs::read_to_string(opencode_path).unwrap()).unwrap();
+        assert_eq!(opencode["permission"]["bash"], "ask");
+        assert_eq!(opencode["permission"]["icm_icm_memory_recall"], "allow");
+        assert_eq!(opencode["permission"]["icm_icm_memory_store"], "deny");
+        assert_eq!(opencode["permission"]["icm_icm_memory_forget"], "deny");
+
+        let zed_path = tmp.path().join("zed/settings.json");
+        std::fs::create_dir_all(zed_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &zed_path,
+            r#"{"agent":{"tool_permissions":{"default":"confirm","tools":{"mcp:icm:icm_memory_store":{"default":"confirm"},"mcp:icm:icm_memory_forget":{"default":"deny"}}}}}"#,
+        )
+        .unwrap();
+        inject_zed_mcp_server(&zed_path, "icm", "/usr/bin/icm", true, zed_spec).unwrap();
+        inject_zed_mcp_server(&zed_path, "icm", "/usr/bin/icm", true, zed_spec).unwrap();
+        let zed: Value = serde_json::from_str(&std::fs::read_to_string(zed_path).unwrap()).unwrap();
+        let tools = &zed["agent"]["tool_permissions"]["tools"];
+        assert_eq!(tools["mcp:icm:icm_memory_recall"]["default"], "allow");
+        assert_eq!(tools["mcp:icm:icm_memory_store"]["default"], "confirm");
+        assert_eq!(tools["mcp:icm:icm_memory_forget"]["default"], "deny");
+        assert_eq!(zed["agent"]["tool_permissions"]["default"], "confirm");
     }
 }

--- a/crates/icm-cli/src/trusted_mcp.rs
+++ b/crates/icm-cli/src/trusted_mcp.rs
@@ -1,0 +1,902 @@
+//! Declarative trust policy for local ICM MCP tools.
+//!
+//! Provider descriptors stay deliberately finite and source-controlled.
+//! They are interpreted by the same apply, discovery, and uninstall code,
+//! so adding a provider does not create another lifecycle implementation.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// Only the read and write primitives needed for persistent memory are
+/// approved automatically. Destructive and administrative tools continue
+/// to require the client's normal confirmation flow.
+pub(crate) const TRUSTED_LOCAL_TOOLS: [&str; 2] = ["icm_memory_recall", "icm_memory_store"];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProviderId {
+    Claude,
+    Cursor,
+    Zed,
+    Codex,
+    OpenCode,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProviderConfigPath {
+    ClaudeSettings,
+    CursorPermissions,
+    ZedSettings,
+    CodexConfig,
+    OpenCodeConfig,
+}
+
+pub(crate) struct ProviderPathContext<'a> {
+    pub home: &'a Path,
+    pub claude_dir: &'a Path,
+    pub codex_dir: &'a Path,
+    pub zed_settings: &'a Path,
+}
+
+impl ProviderConfigPath {
+    pub(crate) fn resolve(self, paths: &ProviderPathContext<'_>) -> PathBuf {
+        match self {
+            Self::ClaudeSettings => paths.claude_dir.join("settings.json"),
+            Self::CursorPermissions => paths.home.join(".cursor/permissions.json"),
+            Self::ZedSettings => paths.zed_settings.to_path_buf(),
+            Self::CodexConfig => paths.codex_dir.join("config.toml"),
+            Self::OpenCodeConfig => paths.home.join(".config/opencode/opencode.json"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum JsonTrustShape {
+    StringArray,
+    StringMap {
+        value: &'static str,
+    },
+    ObjectMapField {
+        field: &'static str,
+        value: &'static str,
+    },
+}
+
+/// A provider's JSON representation of one permission per trusted tool.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct JsonTrustSpec {
+    provider: ProviderId,
+    path: &'static [&'static str],
+    key_prefix: &'static str,
+    shape: JsonTrustShape,
+}
+
+/// Codex keeps tool approval inside the ICM server table rather than in a
+/// separate permission document.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TomlTrustSpec {
+    provider: ProviderId,
+    path: &'static [&'static str],
+    field: &'static str,
+    value: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProviderConfig {
+    JsonTrust {
+        spec: JsonTrustSpec,
+        has_hooks: bool,
+    },
+    JsonMcp {
+        spec: JsonTrustSpec,
+        servers_key: &'static str,
+    },
+    TomlMcp {
+        spec: TomlTrustSpec,
+        table: &'static str,
+        entry: &'static str,
+    },
+}
+
+impl ProviderConfig {
+    pub(crate) const fn provider_id(self) -> ProviderId {
+        match self {
+            Self::JsonTrust { spec, .. } | Self::JsonMcp { spec, .. } => spec.provider,
+            Self::TomlMcp { spec, .. } => spec.provider,
+        }
+    }
+
+    pub(crate) const fn includes_mcp_server(self) -> bool {
+        matches!(self, Self::JsonMcp { .. } | Self::TomlMcp { .. })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TrustedProvider {
+    pub client: &'static str,
+    pub uninstall_label: &'static str,
+    pub path: ProviderConfigPath,
+    pub config: ProviderConfig,
+}
+
+impl TrustedProvider {
+    pub(crate) const fn id(self) -> ProviderId {
+        self.config.provider_id()
+    }
+
+    pub(crate) fn config_path(self, paths: &ProviderPathContext<'_>) -> PathBuf {
+        self.path.resolve(paths)
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn json_spec(self) -> Option<JsonTrustSpec> {
+        match self.config {
+            ProviderConfig::JsonTrust { spec, .. } | ProviderConfig::JsonMcp { spec, .. } => {
+                Some(spec)
+            }
+            ProviderConfig::TomlMcp { .. } => None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn toml_spec(self) -> Option<TomlTrustSpec> {
+        match self.config {
+            ProviderConfig::TomlMcp { spec, .. } => Some(spec),
+            ProviderConfig::JsonTrust { .. } | ProviderConfig::JsonMcp { .. } => None,
+        }
+    }
+}
+
+pub(crate) const TRUSTED_PROVIDERS: [TrustedProvider; 5] = [
+    TrustedProvider {
+        client: "Claude Code",
+        uninstall_label: "Claude Code settings",
+        path: ProviderConfigPath::ClaudeSettings,
+        config: ProviderConfig::JsonTrust {
+            spec: JsonTrustSpec {
+                provider: ProviderId::Claude,
+                path: &["permissions", "allow"],
+                key_prefix: "mcp__icm__",
+                shape: JsonTrustShape::StringArray,
+            },
+            has_hooks: true,
+        },
+    },
+    TrustedProvider {
+        client: "Cursor",
+        uninstall_label: "Cursor permissions",
+        path: ProviderConfigPath::CursorPermissions,
+        config: ProviderConfig::JsonTrust {
+            spec: JsonTrustSpec {
+                provider: ProviderId::Cursor,
+                path: &["mcpAllowlist"],
+                key_prefix: "icm:",
+                shape: JsonTrustShape::StringArray,
+            },
+            has_hooks: false,
+        },
+    },
+    TrustedProvider {
+        client: "Zed",
+        uninstall_label: "Zed MCP",
+        path: ProviderConfigPath::ZedSettings,
+        config: ProviderConfig::JsonMcp {
+            spec: JsonTrustSpec {
+                provider: ProviderId::Zed,
+                path: &["agent", "tool_permissions", "tools"],
+                key_prefix: "mcp:icm:",
+                shape: JsonTrustShape::ObjectMapField {
+                    field: "default",
+                    value: "allow",
+                },
+            },
+            servers_key: "context_servers",
+        },
+    },
+    TrustedProvider {
+        client: "Codex CLI",
+        uninstall_label: "Codex CLI MCP",
+        path: ProviderConfigPath::CodexConfig,
+        config: ProviderConfig::TomlMcp {
+            spec: TomlTrustSpec {
+                provider: ProviderId::Codex,
+                path: &["mcp_servers", "icm", "tools"],
+                field: "approval_mode",
+                value: "approve",
+            },
+            table: "mcp_servers",
+            entry: "icm",
+        },
+    },
+    TrustedProvider {
+        client: "OpenCode",
+        uninstall_label: "OpenCode MCP",
+        path: ProviderConfigPath::OpenCodeConfig,
+        config: ProviderConfig::JsonMcp {
+            spec: JsonTrustSpec {
+                provider: ProviderId::OpenCode,
+                path: &["permission"],
+                key_prefix: "icm_",
+                shape: JsonTrustShape::StringMap { value: "allow" },
+            },
+            servers_key: "mcp",
+        },
+    },
+];
+
+pub(crate) fn trusted_provider(id: ProviderId) -> &'static TrustedProvider {
+    let index = match id {
+        ProviderId::Claude => 0,
+        ProviderId::Cursor => 1,
+        ProviderId::Zed => 2,
+        ProviderId::Codex => 3,
+        ProviderId::OpenCode => 4,
+    };
+    &TRUSTED_PROVIDERS[index]
+}
+
+impl JsonTrustSpec {
+    pub(crate) fn client(self) -> &'static str {
+        trusted_provider(self.provider).client
+    }
+}
+
+impl TomlTrustSpec {
+    pub(crate) fn client(self) -> &'static str {
+        trusted_provider(self.provider).client
+    }
+}
+
+/// One exact config value inserted by ICM. The install manifest persists
+/// these changes so uninstall does not claim identical user-authored values.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum TrustChange {
+    JsonArrayMember {
+        path: Vec<String>,
+        value: String,
+    },
+    JsonMapEntry {
+        path: Vec<String>,
+        key: String,
+        value: String,
+    },
+    JsonObjectField {
+        path: Vec<String>,
+        key: String,
+        field: String,
+        value: String,
+    },
+    TomlString {
+        path: Vec<String>,
+        value: String,
+    },
+}
+
+impl TrustChange {
+    pub(crate) fn permission_label(&self) -> Option<&str> {
+        match self {
+            Self::JsonArrayMember { value, .. } => Some(value),
+            Self::JsonMapEntry { key, .. } | Self::JsonObjectField { key, .. } => Some(key),
+            Self::TomlString { path, .. } => path.iter().rev().nth(1).map(String::as_str),
+        }
+    }
+}
+
+impl JsonTrustSpec {
+    fn desired_changes(self) -> Vec<TrustChange> {
+        let path: Vec<String> = self.path.iter().map(|part| (*part).to_string()).collect();
+        TRUSTED_LOCAL_TOOLS
+            .iter()
+            .map(|tool| {
+                let rule = format!("{}{}", self.key_prefix, tool);
+                match self.shape {
+                    JsonTrustShape::StringArray => TrustChange::JsonArrayMember {
+                        path: path.clone(),
+                        value: rule,
+                    },
+                    JsonTrustShape::StringMap { value } => TrustChange::JsonMapEntry {
+                        path: path.clone(),
+                        key: rule,
+                        value: value.to_string(),
+                    },
+                    JsonTrustShape::ObjectMapField { field, value } => {
+                        TrustChange::JsonObjectField {
+                            path: path.clone(),
+                            key: rule,
+                            field: field.to_string(),
+                            value: value.to_string(),
+                        }
+                    }
+                }
+            })
+            .collect()
+    }
+}
+
+impl TomlTrustSpec {
+    fn desired_changes(self) -> Vec<TrustChange> {
+        TRUSTED_LOCAL_TOOLS
+            .iter()
+            .map(|tool| {
+                let mut path: Vec<String> =
+                    self.path.iter().map(|part| (*part).to_string()).collect();
+                path.push((*tool).to_string());
+                path.push(self.field.to_string());
+                TrustChange::TomlString {
+                    path,
+                    value: self.value.to_string(),
+                }
+            })
+            .collect()
+    }
+}
+
+/// Apply all missing JSON permissions and return only the values inserted by
+/// this invocation. Existing values are left untouched and are not owned.
+pub(crate) fn apply_json_trust(root: &mut Value, spec: JsonTrustSpec) -> Result<Vec<TrustChange>> {
+    let mut inserted = Vec::new();
+    for change in spec.desired_changes() {
+        if apply_json_change(root, &change)? {
+            inserted.push(change);
+        }
+    }
+    Ok(inserted)
+}
+
+/// Find exact provider permissions. `None` enables the pre-provenance legacy
+/// policy; a recorded slice limits discovery to values ICM actually inserted.
+pub(crate) fn discover_json_trust(
+    root: &Value,
+    spec: JsonTrustSpec,
+    owned: Option<&[TrustChange]>,
+) -> Vec<TrustChange> {
+    candidate_json_changes(spec, owned)
+        .into_iter()
+        .filter(|change| json_change_is_present(root, change))
+        .collect()
+}
+
+/// Remove exact provider permissions and return the number of config values
+/// removed. Empty containers are collapsed only after an owned value changed.
+pub(crate) fn strip_json_trust(
+    root: &mut Value,
+    spec: JsonTrustSpec,
+    owned: Option<&[TrustChange]>,
+) -> usize {
+    let legacy = owned.is_none();
+    candidate_json_changes(spec, owned)
+        .iter()
+        .map(|change| remove_json_change(root, change, legacy))
+        .sum()
+}
+
+/// Apply Codex's missing tool approvals and return the exact fields inserted.
+pub(crate) fn apply_toml_trust(
+    root: &mut toml::Value,
+    spec: TomlTrustSpec,
+) -> Result<Vec<TrustChange>> {
+    let mut inserted = Vec::new();
+    for change in spec.desired_changes() {
+        if apply_toml_change(root, &change)? {
+            inserted.push(change);
+        }
+    }
+    Ok(inserted)
+}
+
+pub(crate) fn discover_toml_trust(
+    root: &toml::Value,
+    spec: TomlTrustSpec,
+    owned: Option<&[TrustChange]>,
+) -> Vec<TrustChange> {
+    candidate_toml_changes(spec, owned)
+        .into_iter()
+        .filter(|change| toml_change_is_present(root, change))
+        .collect()
+}
+
+pub(crate) fn strip_toml_trust(
+    root: &mut toml::Value,
+    spec: TomlTrustSpec,
+    owned: Option<&[TrustChange]>,
+) -> usize {
+    candidate_toml_changes(spec, owned)
+        .iter()
+        .map(|change| remove_toml_change(root, change))
+        .sum()
+}
+
+fn candidate_json_changes(spec: JsonTrustSpec, owned: Option<&[TrustChange]>) -> Vec<TrustChange> {
+    let desired = spec.desired_changes();
+    match owned {
+        None => desired,
+        Some(changes) => changes
+            .iter()
+            .filter(|change| desired.contains(change))
+            .cloned()
+            .collect(),
+    }
+}
+
+fn candidate_toml_changes(spec: TomlTrustSpec, owned: Option<&[TrustChange]>) -> Vec<TrustChange> {
+    let desired = spec.desired_changes();
+    match owned {
+        None => desired,
+        Some(changes) => changes
+            .iter()
+            .filter(|change| desired.contains(change))
+            .cloned()
+            .collect(),
+    }
+}
+
+fn apply_json_change(root: &mut Value, change: &TrustChange) -> Result<bool> {
+    match change {
+        TrustChange::JsonArrayMember { path, value } => {
+            let slot = json_path_mut(root, path, JsonContainer::Array)?;
+            let values = slot
+                .as_array_mut()
+                .with_context(|| format!("JSON trust path {} is not an array", path_label(path)))?;
+            if values.iter().any(|item| item.as_str() == Some(value)) {
+                Ok(false)
+            } else {
+                values.push(Value::String(value.clone()));
+                Ok(true)
+            }
+        }
+        TrustChange::JsonMapEntry { path, key, value } => {
+            let slot = json_path_mut(root, path, JsonContainer::Object)?;
+            let values = slot.as_object_mut().with_context(|| {
+                format!("JSON trust path {} is not an object", path_label(path))
+            })?;
+            if values.contains_key(key) {
+                Ok(false)
+            } else {
+                values.insert(key.clone(), Value::String(value.clone()));
+                Ok(true)
+            }
+        }
+        TrustChange::JsonObjectField {
+            path,
+            key,
+            field,
+            value,
+        } => {
+            let slot = json_path_mut(root, path, JsonContainer::Object)?;
+            let values = slot.as_object_mut().with_context(|| {
+                format!("JSON trust path {} is not an object", path_label(path))
+            })?;
+            if let Some(existing) = values.get_mut(key) {
+                let Some(entry) = existing.as_object_mut() else {
+                    return Ok(false);
+                };
+                if entry.contains_key(field) {
+                    Ok(false)
+                } else {
+                    entry.insert(field.clone(), Value::String(value.clone()));
+                    Ok(true)
+                }
+            } else {
+                let mut entry = Map::new();
+                entry.insert(field.clone(), Value::String(value.clone()));
+                values.insert(key.clone(), Value::Object(entry));
+                Ok(true)
+            }
+        }
+        TrustChange::TomlString { .. } => Ok(false),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum JsonContainer {
+    Array,
+    Object,
+}
+
+impl JsonContainer {
+    fn empty(self) -> Value {
+        match self {
+            Self::Array => Value::Array(Vec::new()),
+            Self::Object => Value::Object(Map::new()),
+        }
+    }
+}
+
+fn json_path_mut<'a>(
+    value: &'a mut Value,
+    path: &[String],
+    leaf: JsonContainer,
+) -> Result<&'a mut Value> {
+    let Some((head, tail)) = path.split_first() else {
+        return Ok(value);
+    };
+    let object = value.as_object_mut().with_context(|| {
+        format!(
+            "JSON trust parent for {} is not an object",
+            path_label(path)
+        )
+    })?;
+    let child = object.entry(head.clone()).or_insert_with(|| {
+        if tail.is_empty() {
+            leaf.empty()
+        } else {
+            Value::Object(Map::new())
+        }
+    });
+    json_path_mut(child, tail, leaf)
+}
+
+fn json_path<'a>(value: &'a Value, path: &[String]) -> Option<&'a Value> {
+    let mut current = value;
+    for part in path {
+        current = current.as_object()?.get(part)?;
+    }
+    Some(current)
+}
+
+fn json_change_is_present(root: &Value, change: &TrustChange) -> bool {
+    match change {
+        TrustChange::JsonArrayMember { path, value } => json_path(root, path)
+            .and_then(Value::as_array)
+            .is_some_and(|items| items.iter().any(|item| item.as_str() == Some(value))),
+        TrustChange::JsonMapEntry { path, key, value } => {
+            json_path(root, path)
+                .and_then(Value::as_object)
+                .and_then(|entries| entries.get(key))
+                .and_then(Value::as_str)
+                == Some(value)
+        }
+        TrustChange::JsonObjectField {
+            path,
+            key,
+            field,
+            value,
+        } => {
+            json_path(root, path)
+                .and_then(Value::as_object)
+                .and_then(|entries| entries.get(key))
+                .and_then(Value::as_object)
+                .and_then(|entry| entry.get(field))
+                .and_then(Value::as_str)
+                == Some(value)
+        }
+        TrustChange::TomlString { .. } => false,
+    }
+}
+
+fn remove_json_change(root: &mut Value, change: &TrustChange, legacy: bool) -> usize {
+    let (removed, cleanup_path) = match change {
+        TrustChange::JsonArrayMember { path, value } => {
+            let Some(items) = json_path_mut_existing(root, path).and_then(Value::as_array_mut)
+            else {
+                return 0;
+            };
+            let removed = if legacy {
+                let before = items.len();
+                items.retain(|item| item.as_str() != Some(value));
+                before - items.len()
+            } else if let Some(index) = items.iter().position(|item| item.as_str() == Some(value)) {
+                items.remove(index);
+                1
+            } else {
+                0
+            };
+            (removed, path.as_slice())
+        }
+        TrustChange::JsonMapEntry { path, key, value } => {
+            let Some(entries) = json_path_mut_existing(root, path).and_then(Value::as_object_mut)
+            else {
+                return 0;
+            };
+            let removed = if entries.get(key).and_then(Value::as_str) == Some(value) {
+                entries.remove(key);
+                1
+            } else {
+                0
+            };
+            (removed, path.as_slice())
+        }
+        TrustChange::JsonObjectField {
+            path,
+            key,
+            field,
+            value,
+        } => {
+            let Some(entries) = json_path_mut_existing(root, path).and_then(Value::as_object_mut)
+            else {
+                return 0;
+            };
+            let Some(entry) = entries.get_mut(key).and_then(Value::as_object_mut) else {
+                return 0;
+            };
+            let removed = if entry.get(field).and_then(Value::as_str) == Some(value) {
+                entry.remove(field);
+                1
+            } else {
+                0
+            };
+            if removed > 0 && entry.is_empty() {
+                entries.remove(key);
+            }
+            (removed, path.as_slice())
+        }
+        TrustChange::TomlString { .. } => return 0,
+    };
+
+    if removed > 0 {
+        cleanup_json_path(root, cleanup_path);
+    }
+    removed
+}
+
+fn json_path_mut_existing<'a>(value: &'a mut Value, path: &[String]) -> Option<&'a mut Value> {
+    let Some((head, tail)) = path.split_first() else {
+        return Some(value);
+    };
+    let child = value.as_object_mut()?.get_mut(head)?;
+    json_path_mut_existing(child, tail)
+}
+
+fn cleanup_json_path(value: &mut Value, path: &[String]) -> bool {
+    let Some((head, tail)) = path.split_first() else {
+        return json_container_is_empty(value);
+    };
+    let Some(object) = value.as_object_mut() else {
+        return false;
+    };
+    let remove_child = if let Some(child) = object.get_mut(head) {
+        if tail.is_empty() {
+            json_container_is_empty(child)
+        } else {
+            cleanup_json_path(child, tail)
+        }
+    } else {
+        false
+    };
+    if remove_child {
+        object.remove(head);
+    }
+    object.is_empty()
+}
+
+fn json_container_is_empty(value: &Value) -> bool {
+    value.as_object().is_some_and(|object| object.is_empty())
+        || value.as_array().is_some_and(|array| array.is_empty())
+}
+
+fn apply_toml_change(root: &mut toml::Value, change: &TrustChange) -> Result<bool> {
+    let TrustChange::TomlString { path, value } = change else {
+        return Ok(false);
+    };
+    let Some((field, parents)) = path.split_last() else {
+        return Ok(false);
+    };
+    let table = toml_table_mut(root, parents)?;
+    if table.contains_key(field) {
+        Ok(false)
+    } else {
+        table.insert(field.clone(), toml::Value::String(value.clone()));
+        Ok(true)
+    }
+}
+
+fn toml_table_mut<'a>(
+    value: &'a mut toml::Value,
+    path: &[String],
+) -> Result<&'a mut toml::map::Map<String, toml::Value>> {
+    let table = value
+        .as_table_mut()
+        .with_context(|| format!("TOML trust parent for {} is not a table", path_label(path)))?;
+    let Some((head, tail)) = path.split_first() else {
+        return Ok(table);
+    };
+    let child = table
+        .entry(head.clone())
+        .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+    toml_table_mut(child, tail)
+}
+
+fn toml_path<'a>(value: &'a toml::Value, path: &[String]) -> Option<&'a toml::Value> {
+    let mut current = value;
+    for part in path {
+        current = current.as_table()?.get(part)?;
+    }
+    Some(current)
+}
+
+fn toml_change_is_present(root: &toml::Value, change: &TrustChange) -> bool {
+    match change {
+        TrustChange::TomlString { path, value } => {
+            toml_path(root, path).and_then(toml::Value::as_str) == Some(value)
+        }
+        _ => false,
+    }
+}
+
+fn remove_toml_change(root: &mut toml::Value, change: &TrustChange) -> usize {
+    let TrustChange::TomlString { path, value } = change else {
+        return 0;
+    };
+    let Some((field, parents)) = path.split_last() else {
+        return 0;
+    };
+    let Some(parent) = toml_table_mut_existing(root, parents) else {
+        return 0;
+    };
+    if parent.get(field).and_then(toml::Value::as_str) != Some(value) {
+        return 0;
+    }
+    parent.remove(field);
+    cleanup_toml_path(root, parents);
+    1
+}
+
+fn toml_table_mut_existing<'a>(
+    value: &'a mut toml::Value,
+    path: &[String],
+) -> Option<&'a mut toml::map::Map<String, toml::Value>> {
+    let table = value.as_table_mut()?;
+    let Some((head, tail)) = path.split_first() else {
+        return Some(table);
+    };
+    let child = table.get_mut(head)?;
+    toml_table_mut_existing(child, tail)
+}
+
+fn cleanup_toml_path(value: &mut toml::Value, path: &[String]) -> bool {
+    let Some((head, tail)) = path.split_first() else {
+        return value.as_table().is_some_and(|table| table.is_empty());
+    };
+    let Some(table) = value.as_table_mut() else {
+        return false;
+    };
+    let remove_child = table
+        .get_mut(head)
+        .is_some_and(|child| cleanup_toml_path(child, tail));
+    if remove_child {
+        table.remove(head);
+    }
+    table.is_empty()
+}
+
+fn path_label(path: &[String]) -> String {
+    path.join(".")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn json_spec(id: ProviderId) -> JsonTrustSpec {
+        trusted_provider(id)
+            .json_spec()
+            .expect("provider must use JSON trust")
+    }
+
+    fn toml_spec(id: ProviderId) -> TomlTrustSpec {
+        trusted_provider(id)
+            .toml_spec()
+            .expect("provider must use TOML trust")
+    }
+
+    #[test]
+    fn provider_registry_shares_apply_discover_and_strip_lifecycle() {
+        for provider in TRUSTED_PROVIDERS {
+            assert_eq!(*trusted_provider(provider.id()), provider);
+            match provider.config {
+                ProviderConfig::JsonTrust { spec, .. } | ProviderConfig::JsonMcp { spec, .. } => {
+                    let mut value = json!({});
+                    let inserted =
+                        apply_json_trust(&mut value, spec).expect("provider spec applies");
+                    assert_eq!(
+                        inserted.len(),
+                        TRUSTED_LOCAL_TOOLS.len(),
+                        "{}",
+                        provider.client
+                    );
+                    assert_eq!(spec.client(), provider.client);
+                    assert_eq!(
+                        discover_json_trust(&value, spec, Some(&inserted)),
+                        inserted,
+                        "{}",
+                        provider.client
+                    );
+                    assert_eq!(strip_json_trust(&mut value, spec, Some(&inserted)), 2);
+                    assert_eq!(value, json!({}), "{}", provider.client);
+                }
+                ProviderConfig::TomlMcp { spec, .. } => {
+                    let mut value = toml::Value::Table(toml::map::Map::new());
+                    let inserted =
+                        apply_toml_trust(&mut value, spec).expect("provider spec applies");
+                    assert_eq!(inserted.len(), TRUSTED_LOCAL_TOOLS.len());
+                    assert_eq!(spec.client(), provider.client);
+                    assert_eq!(discover_toml_trust(&value, spec, Some(&inserted)), inserted);
+                    assert_eq!(strip_toml_trust(&mut value, spec, Some(&inserted)), 2);
+                    assert_eq!(value, toml::Value::Table(toml::map::Map::new()));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn json_apply_is_idempotent_and_does_not_claim_existing_values() {
+        let mut value = json!({});
+        let spec = json_spec(ProviderId::Claude);
+        let first = apply_json_trust(&mut value, spec).unwrap();
+        let after_first = value.clone();
+        let second = apply_json_trust(&mut value, spec).unwrap();
+        assert_eq!(first.len(), 2);
+        assert!(second.is_empty());
+        assert_eq!(value, after_first);
+    }
+
+    #[test]
+    fn recorded_empty_ownership_preserves_matching_user_values() {
+        let mut value = json!({
+            "permission": {
+                "icm_icm_memory_recall": "allow",
+                "icm_icm_memory_store": "allow"
+            }
+        });
+        let before = value.clone();
+        let spec = json_spec(ProviderId::OpenCode);
+        assert!(discover_json_trust(&value, spec, Some(&[])).is_empty());
+        assert_eq!(strip_json_trust(&mut value, spec, Some(&[])), 0);
+        assert_eq!(value, before);
+    }
+
+    #[test]
+    fn recorded_subset_removes_only_owned_value() {
+        let mut value = json!({});
+        let spec = json_spec(ProviderId::Cursor);
+        let owned = apply_json_trust(&mut value, spec).unwrap();
+        assert_eq!(strip_json_trust(&mut value, spec, Some(&owned[..1])), 1);
+        assert!(json_change_is_present(&value, &owned[1]));
+    }
+
+    #[test]
+    fn legacy_json_cleanup_removes_exact_matches() {
+        let mut value = json!({
+            "permissions": {"allow": [
+                "Read",
+                "mcp__icm__icm_memory_recall",
+                "mcp__icm__icm_memory_store"
+            ]}
+        });
+        assert_eq!(
+            strip_json_trust(&mut value, json_spec(ProviderId::Claude), None),
+            2
+        );
+        assert_eq!(value, json!({"permissions": {"allow": ["Read"]}}));
+    }
+
+    #[test]
+    fn no_op_strip_does_not_clean_empty_user_containers() {
+        let mut value = json!({"agent": {"tool_permissions": {"tools": {}}}});
+        let before = value.clone();
+        assert_eq!(
+            strip_json_trust(&mut value, json_spec(ProviderId::Zed), None),
+            0
+        );
+        assert_eq!(value, before);
+    }
+
+    #[test]
+    fn recorded_empty_codex_ownership_preserves_matching_value() {
+        let mut value: toml::Value = r#"
+            [mcp_servers.icm.tools.icm_memory_recall]
+            approval_mode = "approve"
+        "#
+        .parse()
+        .unwrap();
+        let before = value.clone();
+        let spec = toml_spec(ProviderId::Codex);
+        assert!(discover_toml_trust(&value, spec, Some(&[])).is_empty());
+        assert_eq!(strip_toml_trust(&mut value, spec, Some(&[])), 0);
+        assert_eq!(value, before);
+    }
+}

--- a/crates/icm-cli/src/uninstall/discover.rs
+++ b/crates/icm-cli/src/uninstall/discover.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use serde_json::Value;
 
-use super::locations::{HookCommandField, LocationKind, LocationSpec};
+use super::locations::{HookCommandField, JsonTrustLocation, LocationKind, LocationSpec};
 
 /// Per-hit detail. Drives the report formatter and, later, the mutator.
 #[derive(Clone, Debug)]
@@ -21,6 +21,8 @@ pub(crate) enum HitDetail {
     JsonServer { pointer: String },
     /// JSON: at least one hook command matches `icm hook`.
     JsonHook { event: String, command: String },
+    /// A provider-described trust value owned by ICM was found.
+    TrustPermission { client: &'static str, rule: String },
     /// TOML: `<table>.<entry>` table was found.
     TomlTable { table: String },
     /// YAML: a candidate `- name: icm` block was found.
@@ -101,6 +103,62 @@ pub(crate) fn scan(specs: &[LocationSpec], include_data: bool) -> Result<Removal
     Ok(plan)
 }
 
+/// Drop provenance for values that are provably absent or user-modified.
+/// Parse failures deliberately keep the old record so uncertainty cannot turn
+/// into an accidental claim or a silent loss of cleanup information.
+pub(crate) fn reconcile_trust_ownership(
+    specs: &[LocationSpec],
+    manifest: &mut crate::install_manifest::InstallManifest,
+) -> bool {
+    let mut changed = false;
+    for location in specs {
+        let present = match &location.kind {
+            LocationKind::JsonHooksWithTrust { trust }
+            | LocationKind::JsonTrust { trust }
+            | LocationKind::JsonMcpWithTrust { trust, .. } => {
+                let Some(owned) = trust.owned_changes.as_deref() else {
+                    continue;
+                };
+                if owned.is_empty() {
+                    continue;
+                }
+                if location.path.exists() {
+                    let Ok(value) = crate::parse_json_config(&location.path) else {
+                        continue;
+                    };
+                    crate::trusted_mcp::discover_json_trust(&value, trust.spec, Some(owned))
+                } else {
+                    Vec::new()
+                }
+            }
+            LocationKind::TomlMcp {
+                trust: Some(trust), ..
+            } => {
+                let Some(owned) = trust.owned_changes.as_deref() else {
+                    continue;
+                };
+                if owned.is_empty() {
+                    continue;
+                }
+                if location.path.exists() {
+                    let Ok(content) = std::fs::read_to_string(&location.path) else {
+                        continue;
+                    };
+                    let Ok(value) = content.parse::<toml::Value>() else {
+                        continue;
+                    };
+                    crate::trusted_mcp::discover_toml_trust(&value, trust.spec, Some(owned))
+                } else {
+                    Vec::new()
+                }
+            }
+            _ => continue,
+        };
+        changed |= manifest.replace_recorded_trust_changes(&location.path, present);
+    }
+    changed
+}
+
 /// Dispatch on the spec's kind. Returns zero or more hits.
 fn scan_spec(spec: &LocationSpec) -> Result<Vec<LocationHit>> {
     if !spec.path.exists() {
@@ -112,7 +170,22 @@ fn scan_spec(spec: &LocationSpec) -> Result<Vec<LocationHit>> {
             has_hooks,
             hooks_field,
         } => scan_json(spec, servers_key.as_deref(), *has_hooks, *hooks_field),
-        LocationKind::TomlMcp { table, entry } => scan_toml(spec, table, entry),
+        LocationKind::JsonHooksWithTrust { trust } => {
+            let mut hits = scan_json(spec, None, true, HookCommandField::Command)?;
+            hits.extend(scan_json_trust(spec, trust)?);
+            Ok(hits)
+        }
+        LocationKind::JsonTrust { trust } => scan_json_trust(spec, trust),
+        LocationKind::JsonMcpWithTrust { servers_key, trust } => {
+            let mut hits = scan_json(spec, Some(servers_key), false, HookCommandField::Command)?;
+            hits.extend(scan_json_trust(spec, trust)?);
+            Ok(hits)
+        }
+        LocationKind::TomlMcp {
+            table,
+            entry,
+            trust,
+        } => scan_toml(spec, table, entry, trust.as_ref()),
         LocationKind::YamlContinue => scan_yaml_continue(spec),
         LocationKind::MarkdownBlock => scan_markdown(spec),
         LocationKind::OwnedFile => Ok(vec![LocationHit {
@@ -124,6 +197,25 @@ fn scan_spec(spec: &LocationSpec) -> Result<Vec<LocationHit>> {
         }]),
         LocationKind::DataDir => scan_data_dir(spec),
     }
+}
+
+fn scan_json_trust(spec: &LocationSpec, trust: &JsonTrustLocation) -> Result<Vec<LocationHit>> {
+    let value = crate::parse_json_config(&spec.path)?;
+    Ok(
+        crate::trusted_mcp::discover_json_trust(&value, trust.spec, trust.owned_changes.as_deref())
+            .into_iter()
+            .filter_map(|change| {
+                change.permission_label().map(|rule| LocationHit {
+                    spec_label: spec.label,
+                    path: spec.path.clone(),
+                    detail: HitDetail::TrustPermission {
+                        client: trust.spec.client(),
+                        rule: rule.to_string(),
+                    },
+                })
+            })
+            .collect(),
+    )
 }
 
 fn scan_json(
@@ -206,7 +298,12 @@ fn lookup_dotted<'a>(value: &'a Value, dotted: &str) -> Option<&'a Value> {
     Some(cur)
 }
 
-fn scan_toml(spec: &LocationSpec, table: &str, entry: &str) -> Result<Vec<LocationHit>> {
+fn scan_toml(
+    spec: &LocationSpec,
+    table: &str,
+    entry: &str,
+    trust: Option<&super::locations::TomlTrustLocation>,
+) -> Result<Vec<LocationHit>> {
     let content = std::fs::read_to_string(&spec.path)?;
     let parsed: toml::Value = content.parse()?;
     let mut hits = Vec::new();
@@ -220,6 +317,26 @@ fn scan_toml(spec: &LocationSpec, table: &str, entry: &str) -> Result<Vec<Locati
                 },
             });
         }
+    }
+    if let Some(trust) = trust {
+        hits.extend(
+            crate::trusted_mcp::discover_toml_trust(
+                &parsed,
+                trust.spec,
+                trust.owned_changes.as_deref(),
+            )
+            .into_iter()
+            .filter_map(|change| {
+                change.permission_label().map(|rule| LocationHit {
+                    spec_label: spec.label,
+                    path: spec.path.clone(),
+                    detail: HitDetail::TrustPermission {
+                        client: trust.spec.client(),
+                        rule: rule.to_string(),
+                    },
+                })
+            }),
+        );
     }
     Ok(hits)
 }
@@ -356,7 +473,9 @@ fn walk_size(path: &Path, bytes: &mut u64, files: &mut usize) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::uninstall::locations::{build_locations, dir_context_under};
+    use crate::uninstall::locations::{
+        apply_manifest_ownership, build_locations, dir_context_under,
+    };
     use std::fs;
     use std::io::Write;
 
@@ -442,6 +561,169 @@ mod tests {
             }
             _ => unreachable!(),
         }
+    }
+
+    #[test]
+    fn scan_detects_only_exact_icm_permission_rules() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dir_context_under(tmp.path());
+        let settings = dirs.claude_dir.join("settings.json");
+        write(
+            &settings,
+            r#"{"permissions":{"allow":[
+                "Read",
+                "mcp__icm__icm_memory_recall",
+                "mcp__icm__icm_memory_store",
+                "mcp__icm__icm_memory_forget"
+            ]}}"#,
+        );
+        write(
+            &dirs.home.join(".cursor/permissions.json"),
+            r#"{"mcpAllowlist":[
+                "icm:icm_memory_recall",
+                "icm:icm_memory_store",
+                "icm:icm_memory_forget"
+            ]}"#,
+        );
+        write(
+            &dirs.home.join(".config/opencode/opencode.json"),
+            r#"{"permission":{
+                "icm_icm_memory_recall":"allow",
+                "icm_icm_memory_store":"allow",
+                "icm_icm_memory_forget":"deny"
+            }}"#,
+        );
+        write(
+            &dirs.zed_settings,
+            r#"{"agent":{"tool_permissions":{"tools":{
+                "mcp:icm:icm_memory_recall":{"default":"allow"},
+                "mcp:icm:icm_memory_store":{"default":"allow"},
+                "mcp:icm:icm_memory_forget":{"default":"deny"}
+            }}}}"#,
+        );
+        let plan = scan(&build_locations(&dirs), false).unwrap();
+        let client_rules: Vec<(&str, &str)> = plan
+            .hits
+            .iter()
+            .filter_map(|hit| match &hit.detail {
+                HitDetail::TrustPermission { client, rule } => Some((*client, rule.as_str())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            client_rules,
+            vec![
+                ("Claude Code", "mcp__icm__icm_memory_recall"),
+                ("Claude Code", "mcp__icm__icm_memory_store"),
+                ("Cursor", "icm:icm_memory_recall"),
+                ("Cursor", "icm:icm_memory_store"),
+                ("Zed", "mcp:icm:icm_memory_recall"),
+                ("Zed", "mcp:icm:icm_memory_store"),
+                ("OpenCode", "icm_icm_memory_recall"),
+                ("OpenCode", "icm_icm_memory_store"),
+            ]
+        );
+    }
+
+    #[test]
+    fn scan_respects_recorded_trust_ownership() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dir_context_under(tmp.path());
+        let settings = dirs.claude_dir.join("settings.json");
+        write(
+            &settings,
+            r#"{"permissions":{"allow":[
+                "mcp__icm__icm_memory_recall",
+                "mcp__icm__icm_memory_store"
+            ]}}"#,
+        );
+
+        let mut manifest = crate::install_manifest::InstallManifest::empty();
+        let entry = crate::install_manifest::InstallManifest::entry_from_disk(
+            &settings,
+            "Claude Code",
+            crate::install_manifest::EntryKind::JsonHooks,
+        )
+        .unwrap();
+        manifest.record(entry);
+
+        let mut specs = build_locations(&dirs);
+        apply_manifest_ownership(&mut specs, &manifest);
+        let plan = scan(&specs, false).unwrap();
+        assert!(
+            !plan
+                .hits
+                .iter()
+                .any(|hit| matches!(hit.detail, HitDetail::TrustPermission { .. })),
+            "Some([]) must preserve matching user-authored permissions: {plan:#?}"
+        );
+
+        let mut generated = serde_json::json!({});
+        let spec = crate::trusted_mcp::trusted_provider(crate::trusted_mcp::ProviderId::Claude)
+            .json_spec()
+            .unwrap();
+        let changes = crate::trusted_mcp::apply_json_trust(&mut generated, spec).unwrap();
+        manifest.record_trust_changes(&settings, vec![changes[0].clone()]);
+        apply_manifest_ownership(&mut specs, &manifest);
+        let plan = scan(&specs, false).unwrap();
+        let rules: Vec<_> = plan
+            .hits
+            .iter()
+            .filter_map(|hit| match &hit.detail {
+                HitDetail::TrustPermission { rule, .. } => Some(rule.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(rules, vec!["mcp__icm__icm_memory_recall"]);
+    }
+
+    #[test]
+    fn absent_owned_cursor_rules_cannot_claim_later_user_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dir_context_under(tmp.path());
+        let permissions = dirs.home.join(".cursor/permissions.json");
+        write(&permissions, r#"{"mcpAllowlist":["other:tool"]}"#);
+
+        let mut manifest = crate::install_manifest::InstallManifest::empty();
+        manifest.record(
+            crate::install_manifest::InstallManifest::entry_from_disk(
+                &permissions,
+                "Cursor",
+                crate::install_manifest::EntryKind::JsonHooks,
+            )
+            .unwrap(),
+        );
+        let mut generated = serde_json::json!({});
+        let spec = crate::trusted_mcp::trusted_provider(crate::trusted_mcp::ProviderId::Cursor)
+            .json_spec()
+            .unwrap();
+        let changes = crate::trusted_mcp::apply_json_trust(&mut generated, spec).unwrap();
+        manifest.record_trust_changes(&permissions, changes);
+
+        let mut specs = build_locations(&dirs);
+        apply_manifest_ownership(&mut specs, &manifest);
+        assert!(reconcile_trust_ownership(&specs, &mut manifest));
+        assert_eq!(
+            manifest.trust_changes_for(&permissions),
+            Some(&[] as &[crate::trusted_mcp::TrustChange])
+        );
+
+        write(
+            &permissions,
+            r#"{"mcpAllowlist":[
+                "icm:icm_memory_recall",
+                "icm:icm_memory_store"
+            ]}"#,
+        );
+        apply_manifest_ownership(&mut specs, &manifest);
+        let plan = scan(&specs, false).unwrap();
+        assert!(
+            !plan
+                .hits
+                .iter()
+                .any(|hit| matches!(hit.detail, HitDetail::TrustPermission { .. })),
+            "consumed ownership must not claim a later identical user value: {plan:#?}"
+        );
     }
 
     /// Audit regression: hook detection used to accept any command

--- a/crates/icm-cli/src/uninstall/formats.rs
+++ b/crates/icm-cli/src/uninstall/formats.rs
@@ -10,7 +10,7 @@
 use anyhow::{Context, Result};
 use serde_json::Value;
 
-use super::locations::HookCommandField;
+use super::locations::{HookCommandField, JsonTrustLocation, TomlTrustLocation};
 
 /// Outcome of a stripper run.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -441,21 +441,90 @@ pub(crate) fn rewrite_json_hooks(
     Ok(result)
 }
 
+pub(crate) fn rewrite_json_trust(
+    path: &std::path::Path,
+    trust: &JsonTrustLocation,
+) -> Result<StripResult> {
+    let mut value = crate::parse_json_config(path)?;
+    let removed = crate::trusted_mcp::strip_json_trust(
+        &mut value,
+        trust.spec,
+        trust.owned_changes.as_deref(),
+    );
+    if removed > 0 {
+        let out = serde_json::to_string_pretty(&value)?;
+        super::atomic_write(path, out.as_bytes())
+            .with_context(|| format!("cannot write {}", path.display()))?;
+    }
+    Ok(if removed == 0 {
+        StripResult::NoOp
+    } else {
+        StripResult::Removed { removed }
+    })
+}
+
+/// Rewrite a shared JSON settings file once even when it contains hooks or an
+/// MCP server alongside trust values.
+pub(crate) fn rewrite_json_with_trust(
+    path: &std::path::Path,
+    servers_key: Option<&str>,
+    hooks_field: Option<HookCommandField>,
+    trust: &JsonTrustLocation,
+) -> Result<StripResult> {
+    let mut value = crate::parse_json_config(path)?;
+    let mut removed = 0;
+    if let Some(key) = servers_key {
+        if let StripResult::Removed { removed: count } = strip_json_mcp_server(&mut value, key) {
+            removed += count;
+        }
+    }
+    if let Some(field) = hooks_field {
+        if let StripResult::Removed { removed: count } = strip_json_hooks(&mut value, field) {
+            removed += count;
+        }
+    }
+    removed += crate::trusted_mcp::strip_json_trust(
+        &mut value,
+        trust.spec,
+        trust.owned_changes.as_deref(),
+    );
+    if removed > 0 {
+        let out = serde_json::to_string_pretty(&value)?;
+        super::atomic_write(path, out.as_bytes())
+            .with_context(|| format!("cannot write {}", path.display()))?;
+    }
+    Ok(if removed == 0 {
+        StripResult::NoOp
+    } else {
+        StripResult::Removed { removed }
+    })
+}
+
 pub(crate) fn rewrite_toml(
     path: &std::path::Path,
     table: &str,
     entry: &str,
+    trust: Option<&TomlTrustLocation>,
 ) -> Result<StripResult> {
     let content =
         std::fs::read_to_string(path).with_context(|| format!("cannot read {}", path.display()))?;
     let mut value: toml::Value = content.parse()?;
-    let result = strip_toml_table(&mut value, table, entry);
-    if matches!(result, StripResult::Removed { .. }) {
+    let mut removed = trust.map_or(0, |trust| {
+        crate::trusted_mcp::strip_toml_trust(&mut value, trust.spec, trust.owned_changes.as_deref())
+    });
+    if let StripResult::Removed { removed: count } = strip_toml_table(&mut value, table, entry) {
+        removed += count;
+    }
+    if removed > 0 {
         let out = toml::to_string(&value)?;
         super::atomic_write(path, out.as_bytes())
             .with_context(|| format!("cannot write {}", path.display()))?;
     }
-    Ok(result)
+    Ok(if removed == 0 {
+        StripResult::NoOp
+    } else {
+        StripResult::Removed { removed }
+    })
 }
 
 pub(crate) fn rewrite_yaml_continue(path: &std::path::Path) -> Result<StripResult> {

--- a/crates/icm-cli/src/uninstall/locations.rs
+++ b/crates/icm-cli/src/uninstall/locations.rs
@@ -13,12 +13,32 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 
+use crate::install_manifest::InstallManifest;
+use crate::trusted_mcp::{
+    JsonTrustSpec, ProviderConfig, ProviderPathContext, TomlTrustSpec, TrustChange,
+    TRUSTED_PROVIDERS,
+};
+
 /// Shape of the command field inside a hook entry. Copilot uses a
 /// top-level `bash` field; every other CLI uses `hooks[].command`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum HookCommandField {
     Command,
     BashTopLevel,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct JsonTrustLocation {
+    pub spec: JsonTrustSpec,
+    /// `None` keeps legacy exact-match cleanup; `Some` is authoritative,
+    /// including an empty list that owns nothing.
+    pub owned_changes: Option<Vec<TrustChange>>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TomlTrustLocation {
+    pub spec: TomlTrustSpec,
+    pub owned_changes: Option<Vec<TrustChange>>,
 }
 
 /// One *category* of artifact init produces. Drives the matching strategy
@@ -34,11 +54,22 @@ pub(crate) enum LocationKind {
         has_hooks: bool,
         hooks_field: HookCommandField,
     },
+    /// A JSON hook file that also carries provider-described trust values.
+    JsonHooksWithTrust { trust: JsonTrustLocation },
+    /// A JSON file containing only provider-described trust values.
+    JsonTrust { trust: JsonTrustLocation },
+    /// A JSON settings file containing both an ICM MCP server and
+    /// client-specific ICM permission rules.
+    JsonMcpWithTrust {
+        servers_key: &'static str,
+        trust: JsonTrustLocation,
+    },
     /// TOML file with `[<table>.<entry>]` to remove, plus dotted child
     /// keys like `<table>.<entry>.env`.
     TomlMcp {
         table: &'static str,
         entry: &'static str,
+        trust: Option<TomlTrustLocation>,
     },
     /// Continue.dev YAML — regex-stripped block under `mcpServers:`.
     YamlContinue,
@@ -153,6 +184,56 @@ pub(crate) fn build_locations(d: &DirContext) -> Vec<LocationSpec> {
 
     let mut specs = Vec::with_capacity(40);
 
+    let provider_paths = ProviderPathContext {
+        home: &d.home,
+        claude_dir: &d.claude_dir,
+        codex_dir: &d.codex_dir,
+        zed_settings: &d.zed_settings,
+    };
+    for provider in TRUSTED_PROVIDERS {
+        let kind = match provider.config {
+            ProviderConfig::JsonTrust {
+                spec,
+                has_hooks: true,
+            } => K::JsonHooksWithTrust {
+                trust: JsonTrustLocation {
+                    spec,
+                    owned_changes: None,
+                },
+            },
+            ProviderConfig::JsonTrust {
+                spec,
+                has_hooks: false,
+            } => K::JsonTrust {
+                trust: JsonTrustLocation {
+                    spec,
+                    owned_changes: None,
+                },
+            },
+            ProviderConfig::JsonMcp { spec, servers_key } => K::JsonMcpWithTrust {
+                servers_key,
+                trust: JsonTrustLocation {
+                    spec,
+                    owned_changes: None,
+                },
+            },
+            ProviderConfig::TomlMcp { spec, table, entry } => K::TomlMcp {
+                table,
+                entry,
+                trust: Some(TomlTrustLocation {
+                    spec,
+                    owned_changes: None,
+                }),
+            },
+        };
+        specs.push(LocationSpec {
+            label: provider.uninstall_label,
+            path: provider.config_path(&provider_paths),
+            kind,
+            purge_data_only: false,
+        });
+    }
+
     // --- Claude Code (mcpServers + hooks + skills + cwd CLAUDE.md) ---
     specs.push(LocationSpec {
         label: "Claude Code MCP",
@@ -160,16 +241,6 @@ pub(crate) fn build_locations(d: &DirContext) -> Vec<LocationSpec> {
         kind: K::JsonConfig {
             servers_key: Some("mcpServers"),
             has_hooks: false,
-            hooks_field: F::Command,
-        },
-        purge_data_only: false,
-    });
-    specs.push(LocationSpec {
-        label: "Claude Code hooks",
-        path: d.claude_dir.join("settings.json"),
-        kind: K::JsonConfig {
-            servers_key: None,
-            has_hooks: true,
             hooks_field: F::Command,
         },
         purge_data_only: false,
@@ -200,15 +271,6 @@ pub(crate) fn build_locations(d: &DirContext) -> Vec<LocationSpec> {
     });
 
     // --- Codex CLI (TOML MCP + JSON hooks) ---
-    specs.push(LocationSpec {
-        label: "Codex CLI MCP",
-        path: d.codex_dir.join("config.toml"),
-        kind: K::TomlMcp {
-            table: "mcp_servers",
-            entry: "icm",
-        },
-        purge_data_only: false,
-    });
     specs.push(LocationSpec {
         label: "Codex CLI hooks",
         path: d.codex_dir.join("hooks.json"),
@@ -346,29 +408,7 @@ pub(crate) fn build_locations(d: &DirContext) -> Vec<LocationSpec> {
         purge_data_only: false,
     });
 
-    // --- Zed ---
-    specs.push(LocationSpec {
-        label: "Zed MCP",
-        path: d.zed_settings.clone(),
-        kind: K::JsonConfig {
-            servers_key: Some("context_servers"),
-            has_hooks: false,
-            hooks_field: F::Command,
-        },
-        purge_data_only: false,
-    });
-
     // --- OpenCode (different JSON shape under "mcp" + TS plugin) ---
-    specs.push(LocationSpec {
-        label: "OpenCode MCP",
-        path: d.home.join(".config/opencode/opencode.json"),
-        kind: K::JsonConfig {
-            servers_key: Some("mcp"),
-            has_hooks: false,
-            hooks_field: F::Command,
-        },
-        purge_data_only: false,
-    });
     specs.push(LocationSpec {
         label: "OpenCode plugin",
         path: d.home.join(".config/opencode/plugins/icm.ts"),
@@ -487,6 +527,29 @@ pub(crate) fn build_locations(d: &DirContext) -> Vec<LocationSpec> {
     specs
 }
 
+/// Attach the ownership snapshot before discovery so the read-only plan and
+/// the later mutation use the same provenance boundary.
+pub(crate) fn apply_manifest_ownership(specs: &mut [LocationSpec], manifest: &InstallManifest) {
+    for location in specs {
+        let owned = manifest
+            .trust_changes_for(&location.path)
+            .map(<[TrustChange]>::to_vec);
+        match &mut location.kind {
+            LocationKind::JsonHooksWithTrust { trust }
+            | LocationKind::JsonTrust { trust }
+            | LocationKind::JsonMcpWithTrust { trust, .. } => {
+                trust.owned_changes = owned;
+            }
+            LocationKind::TomlMcp {
+                trust: Some(trust), ..
+            } => {
+                trust.owned_changes = owned;
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Convenience for tests: build a `DirContext` rooted at `root`, so the
 /// real `$HOME` is not touched.
 #[cfg(test)]
@@ -519,6 +582,59 @@ mod tests {
     use super::*;
 
     #[test]
+    fn trusted_provider_registry_drives_every_uninstall_location() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dirs = dir_context_under(tmp.path());
+        let paths = ProviderPathContext {
+            home: &dirs.home,
+            claude_dir: &dirs.claude_dir,
+            codex_dir: &dirs.codex_dir,
+            zed_settings: &dirs.zed_settings,
+        };
+        let locations = build_locations(&dirs);
+
+        for provider in TRUSTED_PROVIDERS {
+            let expected_path = provider.config_path(&paths);
+            let matches = locations
+                .iter()
+                .filter(|location| {
+                    location.label == provider.uninstall_label && location.path == expected_path
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(matches.len(), 1, "{} uninstall location", provider.client);
+
+            let wired = match (provider.config, &matches[0].kind) {
+                (
+                    ProviderConfig::JsonTrust {
+                        spec: expected,
+                        has_hooks: true,
+                    },
+                    LocationKind::JsonHooksWithTrust { trust },
+                )
+                | (
+                    ProviderConfig::JsonTrust {
+                        spec: expected,
+                        has_hooks: false,
+                    },
+                    LocationKind::JsonTrust { trust },
+                )
+                | (
+                    ProviderConfig::JsonMcp { spec: expected, .. },
+                    LocationKind::JsonMcpWithTrust { trust, .. },
+                ) => trust.spec == expected,
+                (
+                    ProviderConfig::TomlMcp { spec: expected, .. },
+                    LocationKind::TomlMcp {
+                        trust: Some(trust), ..
+                    },
+                ) => trust.spec == expected,
+                _ => false,
+            };
+            assert!(wired, "{} registry config was not wired", provider.client);
+        }
+    }
+
+    #[test]
     fn build_locations_covers_every_tool_family_under_fake_home() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let d = dir_context_under(tmp.path());
@@ -529,7 +645,7 @@ mod tests {
         let labels: Vec<&str> = specs.iter().map(|s| s.label).collect();
         for expected in [
             "Claude Code MCP",
-            "Claude Code hooks",
+            "Claude Code settings",
             "Claude Code /recall",
             "Claude Code /remember",
             "Claude Desktop MCP",

--- a/crates/icm-cli/src/uninstall/mod.rs
+++ b/crates/icm-cli/src/uninstall/mod.rs
@@ -100,7 +100,11 @@ pub mod exit_codes {
 /// for invoking `std::process::exit`.
 pub fn run(opts: UninstallOpts) -> Result<i32> {
     let dirs = locations::DirContext::from_env()?;
-    let specs = locations::build_locations(&dirs);
+    let mut specs = locations::build_locations(&dirs);
+    let install_manifest_path = crate::install_manifest::default_manifest_path();
+    let mut install_manifest =
+        crate::install_manifest::InstallManifest::load(&install_manifest_path)?;
+    locations::apply_manifest_ownership(&mut specs, &install_manifest);
     let mut plan = discover::scan(&specs, opts.purge_data)?;
     if let Some(dir) = opts.scan_dir.as_deref() {
         plan.scan_dir_hits = scan_dir::scan_dir(dir)?;
@@ -130,6 +134,9 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
 
     // --- Mutating run ---
     if plan.is_empty() {
+        if discover::reconcile_trust_ownership(&specs, &mut install_manifest) {
+            install_manifest.save(&install_manifest_path)?;
+        }
         println!("Nothing to uninstall — already clean.");
         return Ok(exit_codes::CLEAN);
     }
@@ -138,6 +145,10 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
     if !opts.yes && !mutate::confirm("Proceed with removal?") {
         println!("Aborted (no changes made).");
         return Ok(exit_codes::USER_DECLINED);
+    }
+
+    if discover::reconcile_trust_ownership(&specs, &mut install_manifest) {
+        install_manifest.save(&install_manifest_path)?;
     }
 
     // Resolve the default backup root via ProjectDirs so the layout
@@ -162,6 +173,19 @@ pub fn run(opts: UninstallOpts) -> Result<i32> {
     let outcomes = mutate::apply(&plan, &specs, &mut backup_session);
     for o in &outcomes {
         summary.record(o);
+    }
+
+    let mut ownership_consumed = false;
+    for outcome in &outcomes {
+        if matches!(
+            &outcome.result,
+            Ok(formats::StripResult::Removed { .. } | formats::StripResult::DeleteFile)
+        ) {
+            ownership_consumed |= install_manifest.clear_trust_changes(&outcome.path);
+        }
+    }
+    if ownership_consumed {
+        install_manifest.save(&install_manifest_path)?;
     }
 
     // Persist the manifest **before** any --purge-data step: when the

--- a/crates/icm-cli/src/uninstall/mutate.rs
+++ b/crates/icm-cli/src/uninstall/mutate.rs
@@ -9,8 +9,8 @@ use anyhow::Result;
 use super::backup::BackupSession;
 use super::discover::{HitDetail, LocationHit, RemovalPlan};
 use super::formats::{
-    rewrite_json_hooks, rewrite_json_mcp, rewrite_markdown, rewrite_toml, rewrite_yaml_continue,
-    StripResult,
+    rewrite_json_hooks, rewrite_json_mcp, rewrite_json_trust, rewrite_json_with_trust,
+    rewrite_markdown, rewrite_toml, rewrite_yaml_continue, StripResult,
 };
 use super::locations::{HookCommandField, LocationKind, LocationSpec};
 
@@ -81,7 +81,21 @@ pub(crate) fn apply(
                     has_hooks,
                     hooks_field,
                 } => apply_json(&hit.path, servers_key, has_hooks, hooks_field, hit),
-                LocationKind::TomlMcp { table, entry } => rewrite_toml(&hit.path, table, entry),
+                LocationKind::JsonHooksWithTrust { trust } => rewrite_json_with_trust(
+                    &hit.path,
+                    None,
+                    Some(HookCommandField::Command),
+                    &trust,
+                ),
+                LocationKind::JsonTrust { trust } => rewrite_json_trust(&hit.path, &trust),
+                LocationKind::JsonMcpWithTrust { servers_key, trust } => {
+                    rewrite_json_with_trust(&hit.path, Some(servers_key), None, &trust)
+                }
+                LocationKind::TomlMcp {
+                    table,
+                    entry,
+                    trust,
+                } => rewrite_toml(&hit.path, table, entry, trust.as_ref()),
                 LocationKind::YamlContinue => rewrite_yaml_continue(&hit.path),
                 LocationKind::MarkdownBlock => rewrite_markdown(&hit.path),
                 LocationKind::OwnedFile => {

--- a/crates/icm-cli/src/uninstall/report.rs
+++ b/crates/icm-cli/src/uninstall/report.rs
@@ -64,6 +64,9 @@ fn print_section(title: &str, hits: &[super::discover::LocationHit], purge_data:
             HitDetail::JsonHook { event, command } => {
                 println!("  hook {event}: {command}");
             }
+            HitDetail::TrustPermission { client, rule } => {
+                println!("  {client} permission allow: {rule}");
+            }
             HitDetail::TomlTable { table } => {
                 println!("  TOML table {table}");
             }

--- a/crates/icm-cli/tests/init_secure_integration.rs
+++ b/crates/icm-cli/tests/init_secure_integration.rs
@@ -247,6 +247,81 @@ fn hook_only_mode_no_longer_crashes_on_fresh_home() {
     );
 }
 
+#[test]
+fn local_mcp_trust_configures_only_core_tools() {
+    let (tmp, cwd) = make_home();
+    let out = icm_in(
+        tmp.path(),
+        &cwd,
+        "/dev/null",
+        &["init", "--mode", "mcp", "--force", "--trust-local-mcp"],
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let claude: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(tmp.path().join(".claude/settings.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        claude["permissions"]["allow"],
+        serde_json::json!(["mcp__icm__icm_memory_recall", "mcp__icm__icm_memory_store"])
+    );
+
+    let codex: toml::Value = std::fs::read_to_string(tmp.path().join(".codex/config.toml"))
+        .unwrap()
+        .parse()
+        .unwrap();
+    let tools = &codex["mcp_servers"]["icm"]["tools"];
+    assert_eq!(
+        tools["icm_memory_recall"]["approval_mode"].as_str(),
+        Some("approve")
+    );
+    assert_eq!(
+        tools["icm_memory_store"]["approval_mode"].as_str(),
+        Some("approve")
+    );
+    assert!(tools.get("icm_memory_forget").is_none());
+
+    let cursor: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(tmp.path().join(".cursor/permissions.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        cursor["mcpAllowlist"],
+        serde_json::json!(["icm:icm_memory_recall", "icm:icm_memory_store"])
+    );
+
+    let opencode: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(tmp.path().join(".config/opencode/opencode.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        opencode["permission"],
+        serde_json::json!({
+            "icm_icm_memory_recall": "allow",
+            "icm_icm_memory_store": "allow"
+        })
+    );
+
+    let zed_path = if cfg!(target_os = "macos") {
+        tmp.path().join(".zed/settings.json")
+    } else {
+        tmp.path().join(".config/zed/settings.json")
+    };
+    let zed: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(zed_path).unwrap()).unwrap();
+    let zed_tools = &zed["agent"]["tool_permissions"]["tools"];
+    assert_eq!(zed_tools["mcp:icm:icm_memory_recall"]["default"], "allow");
+    assert_eq!(zed_tools["mcp:icm:icm_memory_store"]["default"], "allow");
+    assert!(zed_tools.get("mcp:icm:icm_memory_forget").is_none());
+}
+
 /// Walk `home` and return every regular file path EXCLUDING data dirs
 /// `.local/share/icm/` and `.cache/icm/` (those exist by side effect of
 /// the SQLite store being opened at startup).


### PR DESCRIPTION
## Summary

Add explicit opt-in trust configuration for ICM's core MCP recall and store tools.

## Motivation

Local ICM calls have been denied in Codex and Claude Code, and the same client-side approval boundary exists in Cursor, OpenCode, and Zed. MCP annotations are advisory; a local stdio server cannot grant itself trust.

## Changes

- add `icm init --mode mcp --trust-local-mcp`
- configure only `icm_memory_recall` and `icm_memory_store`
- define every supported client's location, format, and trust rules in one source-controlled provider registry shared by discovery, init, uninstall, and tests
- support Codex CLI per-tool approval modes
- support Claude Code user permission rules
- support Cursor IDE `mcpAllowlist` entries
- support OpenCode 1.x per-tool permission entries
- support Zed per-tool MCP permission defaults
- preserve unrelated settings and existing deny or confirm rules
- make init idempotent
- make uninstall detect and remove only rules added by ICM
- upgrade the install manifest to schema 2, record the exact changes owned by ICM, and persist that provenance immediately after each client configuration write for crash-safe cleanup
- reconcile stale provenance after confirmed uninstall while retaining ownership information when a configuration cannot be parsed safely

## Compatibility and safety

The default init path is unchanged. There is no server-wide wildcard, unrestricted mode, or MCP protocol change. Store may trigger configured consolidation, and recall updates access and decay metadata, so the flag is explicit and neither tool is described as read-only. Managed policies and separate safety checks may still reject calls.

Provider specifications are source-controlled rather than arbitrary user configuration because they define which client settings ICM is allowed to trust and later remove. Schema-1 manifests remain readable; schema 2 adds precise ownership so cleanup does not remove pre-existing user rules.

## Validation

```bash
cargo test -p icm-cli --locked --offline \
  --no-default-features --features backend-sqlite,embeddings-dynamic
cargo clippy -p icm-cli --bin icm --tests --locked --offline \
  --no-default-features --features backend-sqlite,embeddings-dynamic -- -D warnings
cargo fmt --all -- --check
```

The final suite passed 374 unit tests and 17 integration tests, with 2 tests ignored. Focused provider tests exercise every registry entry through discovery, installation, exact-change recording, schema-2 save and reload, interrupted multi-client installation, ownership-aware uninstall, and reconciliation without duplicating provider-specific expectations.

Manual verification:

```bash
icm init --mode mcp --trust-local-mcp
icm uninstall --dry-run
```

Inspect the detected clients' configuration files and verify that only recall and store were added.