### PR TITLE
Add typed MCP transcript outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -163,7 +163,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -286,6 +286,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +356,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -458,7 +485,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -710,7 +737,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -723,7 +750,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -734,7 +761,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -745,7 +772,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -758,6 +785,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,7 +798,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -786,7 +819,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -796,7 +829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -859,14 +892,29 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -900,7 +948,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -959,6 +1007,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastembed"
 version = "4.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,7 +1057,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1035,6 +1094,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -1080,6 +1150,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,7 +1189,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1168,9 +1248,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1460,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.54"
+version = "0.10.61"
 dependencies = [
  "anyhow",
  "axum",
@@ -1521,6 +1603,8 @@ dependencies = [
  "chrono",
  "icm-core",
  "icm-store",
+ "jsonschema",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
@@ -1746,7 +1830,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1757,7 +1841,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1824,6 +1908,58 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.49.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257549c093d8f3d043337ba0d507e8eeace2447dfae3f0ee37eb0f57d3df7655"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.49.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "474790e948498099d61ec85c10dc72d459d61298b7975eda7fb163af1934b134"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.49.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8212315eb8e0bc44959d1af653cd5ec515771a3cdca966cfc0a10999bff144b9"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
 ]
 
 [[package]]
@@ -2021,6 +2157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,7 +2225,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2169,6 +2311,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +2333,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -2195,7 +2357,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2204,6 +2366,16 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
  "num-traits",
 ]
 
@@ -2308,7 +2480,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2369,6 +2541,12 @@ dependencies = [
  "tar",
  "ureq",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -2561,7 +2739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2589,7 +2767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2695,7 +2873,7 @@ dependencies = [
  "itertools 0.13.0",
  "lru 0.12.5",
  "paste",
- "strum",
+ "strum 0.26.3",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
@@ -2815,6 +2993,43 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "referencing"
+version = "0.49.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf1a74e036be2546c0c81cdfad6b2def6a25bf31c4e34a468037058d3bd05c6"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.0",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -2953,7 +3168,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -3059,6 +3274,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3120,7 +3361,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3360,7 +3612,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -3373,7 +3634,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3387,6 +3660,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3410,7 +3694,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3475,7 +3759,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3582,7 +3866,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3752,7 +4036,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3827,6 +4111,12 @@ name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"
@@ -3950,6 +4240,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "v_frame"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3977,6 +4277,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -4085,7 +4391,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4254,7 +4560,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4265,7 +4571,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4507,7 +4813,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4523,7 +4829,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4606,7 +4912,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4627,7 +4933,7 @@ checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4647,7 +4953,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4687,7 +4993,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ fastembed = { version = "4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_json_lenient = { version = "0.2", features = ["preserve_order"] }
+schemars = { version = "1", features = ["chrono04", "preserve_order"] }
 toml = "0.8"
 
 # Error handling

--- a/crates/icm-mcp/Cargo.toml
+++ b/crates/icm-mcp/Cargo.toml
@@ -23,8 +23,10 @@ icm-store = { path = "../icm-store", default-features = false }
 chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+schemars = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+jsonschema = { version = "0.49", default-features = false }
 tempfile = "3"

--- a/crates/icm-mcp/src/lib.rs
+++ b/crates/icm-mcp/src/lib.rs
@@ -1,3 +1,4 @@
+mod output;
 pub mod protocol;
 pub mod server;
 pub mod tools;

--- a/crates/icm-mcp/src/output/memory.rs
+++ b/crates/icm-mcp/src/output/memory.rs
@@ -1,0 +1,260 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use icm_core::{Importance, Memory, MemorySource, Scope, StoreStats};
+
+use super::TypedTool;
+
+pub(crate) struct RecallTool;
+
+impl TypedTool for RecallTool {
+    const NAME: &'static str = "icm_memory_recall";
+    type Output = RecallOutput;
+}
+
+pub(crate) struct ListTopicsTool;
+
+impl TypedTool for ListTopicsTool {
+    const NAME: &'static str = "icm_memory_list_topics";
+    type Output = ListTopicsOutput;
+}
+
+pub(crate) struct StatsTool;
+
+impl TypedTool for StatsTool {
+    const NAME: &'static str = "icm_memory_stats";
+    type Output = StatsOutput;
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct RecallOutput {
+    count: usize,
+    memories: Vec<RecallMemoryOutput>,
+}
+
+impl RecallOutput {
+    pub(crate) fn from_memories(memories: &[(Memory, f32)]) -> Self {
+        let memories = memories
+            .iter()
+            .map(RecallMemoryOutput::from)
+            .collect::<Vec<_>>();
+        Self {
+            count: memories.len(),
+            memories,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+struct RecallMemoryOutput {
+    id: String,
+    topic: String,
+    summary: String,
+    raw_excerpt: Option<String>,
+    keywords: Vec<String>,
+    importance: ImportanceOutput,
+    source: MemorySourceOutput,
+    scope: ScopeOutput,
+    related_ids: Vec<String>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    last_accessed: DateTime<Utc>,
+    access_count: u32,
+    weight: f32,
+    score: Option<f32>,
+}
+
+impl From<&(Memory, f32)> for RecallMemoryOutput {
+    fn from((memory, score): &(Memory, f32)) -> Self {
+        Self {
+            id: memory.id.clone(),
+            topic: memory.topic.clone(),
+            summary: memory.summary.clone(),
+            raw_excerpt: memory.raw_excerpt.clone(),
+            keywords: memory.keywords.clone(),
+            importance: memory.importance.into(),
+            source: (&memory.source).into(),
+            scope: memory.scope.into(),
+            related_ids: memory.related_ids.clone(),
+            created_at: memory.created_at,
+            updated_at: memory.updated_at,
+            last_accessed: memory.last_accessed,
+            access_count: memory.access_count,
+            weight: memory.weight,
+            score: (*score >= 0.0).then_some(*score),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+enum ImportanceOutput {
+    Critical,
+    High,
+    Medium,
+    Low,
+}
+
+impl From<Importance> for ImportanceOutput {
+    fn from(value: Importance) -> Self {
+        match value {
+            Importance::Critical => Self::Critical,
+            Importance::High => Self::High,
+            Importance::Medium => Self::Medium,
+            Importance::Low => Self::Low,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[schemars(deny_unknown_fields)]
+enum MemorySourceOutput {
+    ClaudeCode {
+        session_id: String,
+        file_path: Option<String>,
+    },
+    Conversation {
+        thread_id: String,
+    },
+    Manual,
+}
+
+impl From<&MemorySource> for MemorySourceOutput {
+    fn from(value: &MemorySource) -> Self {
+        match value {
+            MemorySource::ClaudeCode {
+                session_id,
+                file_path,
+            } => Self::ClaudeCode {
+                session_id: session_id.clone(),
+                file_path: file_path.clone(),
+            },
+            MemorySource::Conversation { thread_id } => Self::Conversation {
+                thread_id: thread_id.clone(),
+            },
+            MemorySource::Manual => Self::Manual,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+enum ScopeOutput {
+    User,
+    Project,
+    Org,
+}
+
+impl From<Scope> for ScopeOutput {
+    fn from(value: Scope) -> Self {
+        match value {
+            Scope::User => Self::User,
+            Scope::Project => Self::Project,
+            Scope::Org => Self::Org,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct ListTopicsOutput {
+    total_topics: usize,
+    total_memories: usize,
+    topics: Vec<TopicOutput>,
+}
+
+impl ListTopicsOutput {
+    pub(crate) fn from_topics(topics: &[(String, usize)]) -> Self {
+        Self {
+            total_topics: topics.len(),
+            total_memories: topics.iter().map(|(_, count)| count).sum(),
+            topics: topics
+                .iter()
+                .map(|(name, count)| TopicOutput {
+                    name: name.clone(),
+                    count: *count,
+                })
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct TopicOutput {
+    name: String,
+    count: usize,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct StatsOutput {
+    total_memories: usize,
+    total_topics: usize,
+    average_weight: f32,
+    oldest_memory: Option<DateTime<Utc>>,
+    newest_memory: Option<DateTime<Utc>>,
+}
+
+impl From<&StoreStats> for StatsOutput {
+    fn from(stats: &StoreStats) -> Self {
+        Self {
+            total_memories: stats.total_memories,
+            total_topics: stats.total_topics,
+            average_weight: stats.avg_weight,
+            oldest_memory: stats.oldest_memory,
+            newest_memory: stats.newest_memory,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::*;
+
+    #[test]
+    fn schemas_are_inline_closed_and_lean() {
+        for schema in [
+            RecallTool::output_schema(),
+            ListTopicsTool::output_schema(),
+            StatsTool::output_schema(),
+        ] {
+            assert_eq!(schema["type"], "object");
+            assert_eq!(schema["additionalProperties"], false);
+            assert!(schema.get("$schema").is_none());
+            assert!(schema.get("$defs").is_none());
+            assert!(schema.get("title").is_none());
+            assert!(jsonschema::draft202012::meta::is_valid(&schema));
+        }
+    }
+
+    #[test]
+    fn recall_schema_preserves_wire_enums_nullability_and_dates() {
+        let schema = RecallTool::output_schema();
+        let memory = &schema["properties"]["memories"]["items"];
+
+        assert_eq!(memory["additionalProperties"], false);
+        assert_eq!(memory["properties"]["createdAt"]["format"], "date-time");
+        assert_eq!(
+            memory["properties"]["importance"]["enum"],
+            serde_json::json!(["critical", "high", "medium", "low"])
+        );
+        assert!(memory["required"]
+            .as_array()
+            .is_some_and(|required| required.iter().any(|name| name == "score")));
+        assert!(jsonschema::draft202012::is_valid(
+            &memory["properties"]["score"],
+            &Value::Null
+        ));
+    }
+}

--- a/crates/icm-mcp/src/output/mod.rs
+++ b/crates/icm-mcp/src/output/mod.rs
@@ -1,4 +1,5 @@
 mod memory;
+mod transcript;
 
 use schemars::{generate::SchemaSettings, JsonSchema};
 use serde::Serialize;
@@ -8,6 +9,11 @@ use crate::protocol::ToolResult;
 
 pub(crate) use memory::{
     ListTopicsOutput, ListTopicsTool, RecallOutput, RecallTool, StatsOutput, StatsTool,
+};
+pub(crate) use transcript::{
+    TranscriptRecordOutput, TranscriptRecordTool, TranscriptSearchOutput, TranscriptSearchTool,
+    TranscriptShowOutput, TranscriptShowTool, TranscriptStartSessionOutput,
+    TranscriptStartSessionTool, TranscriptStatsOutput, TranscriptStatsTool,
 };
 
 pub(crate) trait ToolOutput: Serialize + JsonSchema {}

--- a/crates/icm-mcp/src/output/mod.rs
+++ b/crates/icm-mcp/src/output/mod.rs
@@ -1,0 +1,47 @@
+mod memory;
+
+use schemars::{generate::SchemaSettings, JsonSchema};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::protocol::ToolResult;
+
+pub(crate) use memory::{
+    ListTopicsOutput, ListTopicsTool, RecallOutput, RecallTool, StatsOutput, StatsTool,
+};
+
+pub(crate) trait ToolOutput: Serialize + JsonSchema {}
+
+impl<T> ToolOutput for T where T: Serialize + JsonSchema {}
+
+/// Associates one MCP tool name with the only structured output it may emit.
+pub(crate) trait TypedTool {
+    const NAME: &'static str;
+    type Output: ToolOutput;
+
+    fn output_schema() -> Value {
+        output_schema::<Self::Output>()
+    }
+
+    fn result(text: String, output: Self::Output, summary: String) -> ToolResult
+    where
+        Self: Sized,
+    {
+        ToolResult::structured::<Self>(text, output, summary)
+    }
+}
+
+fn output_schema<T: ToolOutput>() -> Value {
+    let settings = SchemaSettings::draft2020_12()
+        .for_serialize()
+        .with(|settings| {
+            settings.inline_subschemas = true;
+            settings.meta_schema = None;
+        });
+    let mut schema = settings.into_generator().into_root_schema_for::<T>();
+
+    // MCP embeds this inside a tool definition, where root document metadata
+    // adds bytes without helping clients interpret the output contract.
+    schema.remove("title");
+    schema.to_value()
+}

--- a/crates/icm-mcp/src/output/transcript.rs
+++ b/crates/icm-mcp/src/output/transcript.rs
@@ -1,0 +1,444 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Serialize, Serializer};
+
+use icm_core::{Message, Role, Session, TranscriptHit, TranscriptStats};
+
+use super::TypedTool;
+
+// Preserve the original structured-output builders' explicit UTC offset.
+#[derive(Debug, JsonSchema)]
+#[serde(transparent)]
+struct Rfc3339Timestamp(DateTime<Utc>);
+
+impl From<DateTime<Utc>> for Rfc3339Timestamp {
+    fn from(value: DateTime<Utc>) -> Self {
+        Self(value)
+    }
+}
+
+impl Serialize for Rfc3339Timestamp {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0.to_rfc3339())
+    }
+}
+
+pub(crate) struct TranscriptStartSessionTool;
+
+impl TypedTool for TranscriptStartSessionTool {
+    const NAME: &'static str = "icm_transcript_start_session";
+    type Output = TranscriptStartSessionOutput;
+}
+
+pub(crate) struct TranscriptRecordTool;
+
+impl TypedTool for TranscriptRecordTool {
+    const NAME: &'static str = "icm_transcript_record";
+    type Output = TranscriptRecordOutput;
+}
+
+pub(crate) struct TranscriptSearchTool;
+
+impl TypedTool for TranscriptSearchTool {
+    const NAME: &'static str = "icm_transcript_search";
+    type Output = TranscriptSearchOutput;
+}
+
+pub(crate) struct TranscriptShowTool;
+
+impl TypedTool for TranscriptShowTool {
+    const NAME: &'static str = "icm_transcript_show";
+    type Output = TranscriptShowOutput;
+}
+
+pub(crate) struct TranscriptStatsTool;
+
+impl TypedTool for TranscriptStatsTool {
+    const NAME: &'static str = "icm_transcript_stats";
+    type Output = TranscriptStatsOutput;
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct TranscriptStartSessionOutput {
+    session_id: String,
+}
+
+impl TranscriptStartSessionOutput {
+    pub(crate) fn new(session_id: String) -> Self {
+        Self { session_id }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct TranscriptRecordOutput {
+    message_id: String,
+    session_id: String,
+}
+
+impl TranscriptRecordOutput {
+    pub(crate) fn new(message_id: String, session_id: String) -> Self {
+        Self {
+            message_id,
+            session_id,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct TranscriptSearchOutput {
+    count: usize,
+    hits: Vec<TranscriptHitOutput>,
+}
+
+impl TranscriptSearchOutput {
+    pub(crate) fn from_hits(hits: &[TranscriptHit]) -> Self {
+        Self {
+            count: hits.len(),
+            hits: hits.iter().map(TranscriptHitOutput::from).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+struct TranscriptHitOutput {
+    message: TranscriptMessageOutput,
+    session: TranscriptSessionOutput,
+    score: f64,
+}
+
+impl From<&TranscriptHit> for TranscriptHitOutput {
+    fn from(hit: &TranscriptHit) -> Self {
+        Self {
+            message: (&hit.message).into(),
+            session: (&hit.session).into(),
+            score: hit.score,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct TranscriptShowOutput {
+    session: TranscriptSessionOutput,
+    message_count: usize,
+    messages: Vec<TranscriptMessageOutput>,
+}
+
+impl TranscriptShowOutput {
+    pub(crate) fn new(session: &Session, messages: &[Message]) -> Self {
+        Self {
+            session: session.into(),
+            message_count: messages.len(),
+            messages: messages.iter().map(TranscriptMessageOutput::from).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+struct TranscriptSessionOutput {
+    id: String,
+    agent: String,
+    project: Option<String>,
+    started_at: Rfc3339Timestamp,
+    updated_at: Rfc3339Timestamp,
+    metadata: String,
+}
+
+impl From<&Session> for TranscriptSessionOutput {
+    fn from(session: &Session) -> Self {
+        Self {
+            id: session.id.clone(),
+            agent: session.agent.clone(),
+            project: session.project.clone(),
+            started_at: session.started_at.into(),
+            updated_at: session.updated_at.into(),
+            metadata: session.metadata.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+struct TranscriptMessageOutput {
+    id: String,
+    session_id: String,
+    role: TranscriptRoleOutput,
+    content: String,
+    tool_name: Option<String>,
+    tokens: Option<i64>,
+    timestamp: Rfc3339Timestamp,
+    metadata: String,
+}
+
+impl From<&Message> for TranscriptMessageOutput {
+    fn from(message: &Message) -> Self {
+        Self {
+            id: message.id.clone(),
+            session_id: message.session_id.clone(),
+            role: message.role.into(),
+            content: message.content.clone(),
+            tool_name: message.tool_name.clone(),
+            tokens: message.tokens,
+            timestamp: message.ts.into(),
+            metadata: message.metadata.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+enum TranscriptRoleOutput {
+    User,
+    Assistant,
+    System,
+    Tool,
+}
+
+impl From<Role> for TranscriptRoleOutput {
+    fn from(role: Role) -> Self {
+        match role {
+            Role::User => Self::User,
+            Role::Assistant => Self::Assistant,
+            Role::System => Self::System,
+            Role::Tool => Self::Tool,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct TranscriptStatsOutput {
+    total_sessions: usize,
+    total_messages: usize,
+    total_bytes: u64,
+    by_role: Vec<RoleCountOutput>,
+    by_agent: Vec<AgentCountOutput>,
+    top_sessions: Vec<SessionCountOutput>,
+    oldest: Option<Rfc3339Timestamp>,
+    newest: Option<Rfc3339Timestamp>,
+}
+
+impl From<&TranscriptStats> for TranscriptStatsOutput {
+    fn from(stats: &TranscriptStats) -> Self {
+        Self {
+            total_sessions: stats.total_sessions,
+            total_messages: stats.total_messages,
+            total_bytes: stats.total_bytes,
+            by_role: stats.by_role.iter().map(RoleCountOutput::from).collect(),
+            by_agent: stats.by_agent.iter().map(AgentCountOutput::from).collect(),
+            top_sessions: stats
+                .top_sessions
+                .iter()
+                .map(SessionCountOutput::from)
+                .collect(),
+            oldest: stats.oldest.map(Into::into),
+            newest: stats.newest.map(Into::into),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct RoleCountOutput {
+    role: String,
+    count: usize,
+}
+
+impl From<&(String, usize)> for RoleCountOutput {
+    fn from((role, count): &(String, usize)) -> Self {
+        Self {
+            role: role.clone(),
+            count: *count,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct AgentCountOutput {
+    agent: String,
+    count: usize,
+}
+
+impl From<&(String, usize)> for AgentCountOutput {
+    fn from((agent, count): &(String, usize)) -> Self {
+        Self {
+            agent: agent.clone(),
+            count: *count,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+struct SessionCountOutput {
+    session_id: String,
+    count: usize,
+}
+
+impl From<&(String, usize)> for SessionCountOutput {
+    fn from((session_id, count): &(String, usize)) -> Self {
+        Self {
+            session_id: session_id.clone(),
+            count: *count,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn schemas_are_inline_closed_and_valid() {
+        for schema in [
+            TranscriptStartSessionTool::output_schema(),
+            TranscriptRecordTool::output_schema(),
+            TranscriptSearchTool::output_schema(),
+            TranscriptShowTool::output_schema(),
+            TranscriptStatsTool::output_schema(),
+        ] {
+            assert_eq!(schema["type"], "object");
+            assert_eq!(schema["additionalProperties"], false);
+            assert!(schema.get("$schema").is_none());
+            assert!(schema.get("$defs").is_none());
+            assert!(schema.get("title").is_none());
+            assert!(jsonschema::draft202012::meta::is_valid(&schema));
+        }
+    }
+
+    #[test]
+    fn nested_schemas_preserve_wire_names_roles_and_dates() {
+        let search = TranscriptSearchTool::output_schema();
+        let message = &search["properties"]["hits"]["items"]["properties"]["message"];
+        let session = &search["properties"]["hits"]["items"]["properties"]["session"];
+
+        assert_eq!(message["additionalProperties"], false);
+        assert_eq!(session["additionalProperties"], false);
+        assert_eq!(message["properties"]["timestamp"]["format"], "date-time");
+        assert_eq!(session["properties"]["startedAt"]["format"], "date-time");
+        assert_eq!(
+            message["properties"]["role"]["enum"],
+            json!(["user", "assistant", "system", "tool"])
+        );
+
+        let stats = TranscriptStatsTool::output_schema();
+        assert_eq!(
+            stats["properties"]["topSessions"]["items"]["required"],
+            json!(["sessionId", "count"])
+        );
+        assert_eq!(stats["properties"]["oldest"]["format"], "date-time");
+        assert_eq!(stats["properties"]["newest"]["format"], "date-time");
+    }
+
+    #[test]
+    fn typed_outputs_preserve_prior_timestamp_wire_shape() {
+        let timestamp = "2026-08-04T18:30:00Z".parse::<DateTime<Utc>>().unwrap();
+        let timestamp_text = timestamp.to_rfc3339();
+        let session = Session {
+            id: "session-1".into(),
+            agent: "codex".into(),
+            project: Some("icm".into()),
+            started_at: timestamp,
+            updated_at: timestamp,
+            metadata: "{}".into(),
+        };
+        let message = Message {
+            id: "message-1".into(),
+            session_id: session.id.clone(),
+            role: Role::Assistant,
+            content: "completed".into(),
+            tool_name: Some("icm_memory_store".into()),
+            tokens: Some(12),
+            ts: timestamp,
+            metadata: "{}".into(),
+        };
+        let session_value = json!({
+            "id": session.id,
+            "agent": session.agent,
+            "project": session.project,
+            "startedAt": timestamp_text,
+            "updatedAt": timestamp_text,
+            "metadata": session.metadata
+        });
+        let message_value = json!({
+            "id": message.id,
+            "sessionId": message.session_id,
+            "role": message.role.as_str(),
+            "content": message.content,
+            "toolName": message.tool_name,
+            "tokens": message.tokens,
+            "timestamp": timestamp_text,
+            "metadata": message.metadata
+        });
+        let hit = TranscriptHit {
+            message: message.clone(),
+            session: session.clone(),
+            score: 0.75,
+        };
+
+        assert_eq!(
+            serde_json::to_value(TranscriptSearchOutput::from_hits(&[hit])).unwrap(),
+            json!({
+                "count": 1,
+                "hits": [{
+                    "message": message_value,
+                    "session": session_value,
+                    "score": 0.75
+                }]
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(TranscriptShowOutput::new(&session, &[message])).unwrap(),
+            json!({
+                "session": session_value,
+                "messageCount": 1,
+                "messages": [message_value]
+            })
+        );
+
+        let stats = TranscriptStats {
+            total_sessions: 1,
+            total_messages: 1,
+            total_bytes: 9,
+            by_role: vec![("assistant".into(), 1)],
+            by_agent: vec![("codex".into(), 1)],
+            top_sessions: vec![("session-1".into(), 1)],
+            oldest: Some(timestamp),
+            newest: Some(timestamp),
+        };
+        assert_eq!(
+            serde_json::to_value(TranscriptStatsOutput::from(&stats)).unwrap(),
+            json!({
+                "totalSessions": 1,
+                "totalMessages": 1,
+                "totalBytes": 9,
+                "byRole": [{"role": "assistant", "count": 1}],
+                "byAgent": [{"agent": "codex", "count": 1}],
+                "topSessions": [{"sessionId": "session-1", "count": 1}],
+                "oldest": timestamp_text,
+                "newest": timestamp_text
+            })
+        );
+        assert!(timestamp_text.ends_with("+00:00"));
+    }
+}

--- a/crates/icm-mcp/src/protocol.rs
+++ b/crates/icm-mcp/src/protocol.rs
@@ -46,6 +46,8 @@ pub struct JsonRpcResponse {
 pub struct JsonRpcError {
     pub code: i64,
     pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
 }
 
 impl JsonRpcResponse {
@@ -63,7 +65,24 @@ impl JsonRpcResponse {
             jsonrpc: "2.0".into(),
             id,
             result: None,
-            error: Some(JsonRpcError { code, message }),
+            error: Some(JsonRpcError {
+                code,
+                message,
+                data: None,
+            }),
+        }
+    }
+
+    pub fn err_with_data(id: Value, code: i64, message: String, data: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".into(),
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message,
+                data: Some(data),
+            }),
         }
     }
 

--- a/crates/icm-mcp/src/protocol.rs
+++ b/crates/icm-mcp/src/protocol.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::output::TypedTool;
+
 // ---------------------------------------------------------------------------
 // JSON-RPC 2.0 message types
 // ---------------------------------------------------------------------------
@@ -100,6 +102,12 @@ pub struct ToolResult {
     pub content: Vec<TextContent>,
     #[serde(rename = "isError", skip_serializing_if = "std::ops::Not::not")]
     pub is_error: bool,
+    #[serde(rename = "structuredContent", skip_serializing_if = "Option::is_none")]
+    pub structured_content: Option<Value>,
+    /// Short text fallback used only when structured output is emitted.
+    /// Legacy clients still receive the full human-readable `content`.
+    #[serde(skip)]
+    pub structured_summary: Option<Box<String>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -117,6 +125,8 @@ impl ToolResult {
                 text,
             }],
             is_error: false,
+            structured_content: None,
+            structured_summary: None,
         }
     }
 
@@ -127,6 +137,33 @@ impl ToolResult {
                 text,
             }],
             is_error: true,
+            structured_content: None,
+            structured_summary: None,
+        }
+    }
+
+    pub(crate) fn structured<T: TypedTool>(
+        text: String,
+        output: T::Output,
+        structured_summary: String,
+    ) -> Self {
+        match serde_json::to_value(output) {
+            Ok(data) => Self {
+                content: vec![TextContent {
+                    content_type: "text".into(),
+                    text,
+                }],
+                is_error: false,
+                structured_content: Some(data),
+                structured_summary: Some(Box::new(structured_summary)),
+            },
+            Err(error) => {
+                tracing::error!(tool = T::NAME, %error, "failed to serialize MCP structured output");
+                Self::error(format!(
+                    "failed to serialize structured output for {}",
+                    T::NAME
+                ))
+            }
         }
     }
 
@@ -135,13 +172,29 @@ impl ToolResult {
         if let Some(last) = self.content.last_mut() {
             last.text.push_str(hint);
         }
+        if let Some(summary) = self.structured_summary.as_mut() {
+            summary.push_str(hint);
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use schemars::JsonSchema;
     use serde_json::json;
+
+    #[derive(JsonSchema, Serialize)]
+    struct TestOutput {
+        count: usize,
+    }
+
+    struct TestTool;
+
+    impl TypedTool for TestTool {
+        const NAME: &'static str = "test_tool";
+        type Output = TestOutput;
+    }
 
     /// Audit regression: a Request with `"id": null` (legal per JSON-RPC
     /// 2.0, if discouraged) must still be recognized as a Request needing a
@@ -178,6 +231,7 @@ mod tests {
         assert_eq!(result.content.len(), 1);
         assert_eq!(result.content[0].text, "hello");
         assert_eq!(result.content[0].content_type, "text");
+        assert!(result.structured_content.is_none());
     }
 
     #[test]
@@ -185,6 +239,7 @@ mod tests {
         let result = ToolResult::error("boom".into());
         assert!(result.is_error);
         assert_eq!(result.content[0].text, "boom");
+        assert!(result.structured_content.is_none());
     }
 
     #[test]
@@ -199,6 +254,8 @@ mod tests {
         let mut result = ToolResult {
             content: vec![],
             is_error: false,
+            structured_content: None,
+            structured_summary: None,
         };
         result.append_hint("[hint]");
         assert!(result.content.is_empty());
@@ -258,8 +315,63 @@ mod tests {
         let json = serde_json::to_value(&result).unwrap();
         assert_eq!(json["content"][0]["type"], "text");
         assert_eq!(json["content"][0]["text"], "hello");
+        assert!(json.get("structuredContent").is_none());
         // isError should be absent when false (skip_serializing_if)
         assert!(json.get("isError").is_none());
+    }
+
+    #[test]
+    fn structured_summary_is_internal_and_preserves_hints() {
+        let mut result = TestTool::result(
+            "full legacy text".into(),
+            TestOutput { count: 1 },
+            "1 structured result".into(),
+        );
+        result.append_hint("\n[nudge]");
+        let json = serde_json::to_value(&result).unwrap();
+
+        assert_eq!(result.content[0].text, "full legacy text\n[nudge]");
+        assert_eq!(
+            result.structured_summary.as_deref().map(String::as_str),
+            Some("1 structured result\n[nudge]")
+        );
+        assert!(json.get("structured_summary").is_none());
+    }
+
+    #[test]
+    fn structured_serialization_errors_become_tool_errors() {
+        #[derive(JsonSchema)]
+        struct FailingOutput;
+
+        impl Serialize for FailingOutput {
+            fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                Err(<S::Error as serde::ser::Error>::custom("fixture failure"))
+            }
+        }
+
+        struct FailingTool;
+
+        impl TypedTool for FailingTool {
+            const NAME: &'static str = "failing_tool";
+            type Output = FailingOutput;
+        }
+
+        let result = FailingTool::result(
+            "legacy text".into(),
+            FailingOutput,
+            "structured summary".into(),
+        );
+
+        assert!(result.is_error);
+        assert!(result.structured_content.is_none());
+        assert!(result.structured_summary.is_none());
+        assert_eq!(
+            result.content[0].text,
+            "failed to serialize structured output for failing_tool"
+        );
     }
 
     #[test]
@@ -267,5 +379,6 @@ mod tests {
         let result = ToolResult::error("fail".into());
         let json = serde_json::to_value(&result).unwrap();
         assert_eq!(json["isError"], true);
+        assert!(json.get("structuredContent").is_none());
     }
 }

--- a/crates/icm-mcp/src/server.rs
+++ b/crates/icm-mcp/src/server.rs
@@ -7,13 +7,49 @@ use icm_core::Embedder;
 use icm_store::Store;
 
 use crate::protocol::{JsonRpcMessage, JsonRpcResponse};
-use crate::tools::{self, AutoConsolidate};
+use crate::tools::{self, AutoConsolidate, ToolDefinitionOptions};
 
 const SERVER_NAME: &str = "icm";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const LEGACY_PROTOCOL_VERSION: &str = "2024-11-05";
 const PREVIOUS_PROTOCOL_VERSION: &str = "2025-06-18";
-const LATEST_PROTOCOL_VERSION: &str = "2025-11-25";
+const LATEST_LEGACY_PROTOCOL_VERSION: &str = "2025-11-25";
+const MODERN_PROTOCOL_VERSION: &str = "2026-07-28";
+const SUPPORTED_PROTOCOL_VERSIONS: [&str; 4] = [
+    MODERN_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
+    PREVIOUS_PROTOCOL_VERSION,
+    LEGACY_PROTOCOL_VERSION,
+];
+const DISCOVERY_TTL_MS: u64 = 60 * 60 * 1000;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum ConnectionEra {
+    Undetermined,
+    Legacy(&'static str),
+    Modern,
+}
+
+#[derive(Debug, PartialEq)]
+enum RequestMetadata {
+    Legacy,
+    Modern(String),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum DispatchProtocol {
+    Legacy(&'static str),
+    Modern,
+}
+
+#[derive(Debug, PartialEq)]
+enum ProtocolSelectionError {
+    Invalid(&'static str),
+    Unsupported {
+        requested: String,
+        supported: Vec<&'static str>,
+    },
+}
 
 /// Number of non-store tool calls before we nudge the agent to store.
 const STORE_NUDGE_THRESHOLD: u32 = 10;
@@ -65,10 +101,7 @@ pub fn run_server(
     let mut reader = stdin.lock();
     let mut stdout = io::stdout();
     let mut calls_since_store: u32 = 0;
-    // Default to the historical protocol until initialization succeeds. This
-    // preserves the legacy tools/list shape for old or non-conforming clients
-    // that call it before initialize.
-    let mut negotiated_protocol_version = LEGACY_PROTOCOL_VERSION;
+    let mut connection_era = ConnectionEra::Undetermined;
     let mut buf: Vec<u8> = Vec::new();
 
     loop {
@@ -118,27 +151,56 @@ pub fn run_server(
             None => continue,
         };
 
-        let response = match method {
-            "initialize" => {
-                negotiated_protocol_version = negotiate_protocol_version(&msg.params);
-                handle_initialize(id, negotiated_protocol_version)
+        let protocol = match select_request_protocol(&mut connection_era, method, &msg.params) {
+            Ok(protocol) => protocol,
+            Err(error) => {
+                write_response(&mut stdout, &protocol_error_response(id, error))?;
+                continue;
             }
-            "ping" => JsonRpcResponse::ok(id, json!({})),
-            "tools/list" => handle_tools_list(
-                id,
-                embedder.is_some(),
-                supports_tool_annotations(negotiated_protocol_version),
-            ),
-            "tools/call" => handle_tools_call(
-                id,
-                &msg.params,
-                store,
-                embedder,
-                compact,
-                auto_consolidate,
-                &mut calls_since_store,
-            ),
-            other => JsonRpcResponse::method_not_found(id, other),
+        };
+
+        let response = match protocol {
+            DispatchProtocol::Modern => {
+                let mut response = match method {
+                    "server/discover" => handle_server_discover(id, embedder.is_some()),
+                    "tools/list" => handle_tools_list(
+                        id,
+                        embedder.is_some(),
+                        tool_definition_options(MODERN_PROTOCOL_VERSION),
+                    ),
+                    "tools/call" => handle_tools_call(
+                        id,
+                        &msg.params,
+                        store,
+                        embedder,
+                        compact,
+                        auto_consolidate,
+                        &mut calls_since_store,
+                    ),
+                    other => JsonRpcResponse::method_not_found(id, other),
+                };
+                add_modern_result_metadata(&mut response, method);
+                response
+            }
+            DispatchProtocol::Legacy(protocol_version) => match method {
+                "initialize" => handle_initialize(id, protocol_version),
+                "ping" => JsonRpcResponse::ok(id, json!({})),
+                "tools/list" => handle_tools_list(
+                    id,
+                    embedder.is_some(),
+                    tool_definition_options(protocol_version),
+                ),
+                "tools/call" => handle_tools_call(
+                    id,
+                    &msg.params,
+                    store,
+                    embedder,
+                    compact,
+                    auto_consolidate,
+                    &mut calls_since_store,
+                ),
+                other => JsonRpcResponse::method_not_found(id, other),
+            },
         };
 
         write_response(&mut stdout, &response)?;
@@ -154,7 +216,97 @@ fn write_response(stdout: &mut io::Stdout, resp: &JsonRpcResponse) -> anyhow::Re
     Ok(())
 }
 
-fn negotiate_protocol_version(params: &Option<Value>) -> &'static str {
+fn request_metadata(params: &Option<Value>) -> Result<RequestMetadata, &'static str> {
+    let Some(meta) = params.as_ref().and_then(|params| params.get("_meta")) else {
+        return Ok(RequestMetadata::Legacy);
+    };
+    let Some(meta) = meta.as_object() else {
+        return Err("_meta must be an object");
+    };
+
+    let protocol_key = "io.modelcontextprotocol/protocolVersion";
+    let capabilities_key = "io.modelcontextprotocol/clientCapabilities";
+    let client_info_key = "io.modelcontextprotocol/clientInfo";
+    let has_modern_metadata = [protocol_key, capabilities_key, client_info_key]
+        .iter()
+        .any(|key| meta.contains_key(*key));
+    if !has_modern_metadata {
+        return Ok(RequestMetadata::Legacy);
+    }
+
+    let protocol_version = meta
+        .get(protocol_key)
+        .and_then(Value::as_str)
+        .ok_or("modern requests require a string protocolVersion")?;
+    if !meta.get(capabilities_key).is_some_and(Value::is_object) {
+        return Err("modern requests require an object clientCapabilities");
+    }
+    if let Some(client_info) = meta.get(client_info_key) {
+        let valid = client_info.as_object().is_some_and(|client_info| {
+            client_info.get("name").is_some_and(Value::is_string)
+                && client_info.get("version").is_some_and(Value::is_string)
+        });
+        if !valid {
+            return Err("clientInfo must contain string name and version fields");
+        }
+    }
+
+    Ok(RequestMetadata::Modern(protocol_version.to_owned()))
+}
+
+fn select_request_protocol(
+    connection_era: &mut ConnectionEra,
+    method: &str,
+    params: &Option<Value>,
+) -> Result<DispatchProtocol, ProtocolSelectionError> {
+    let metadata = request_metadata(params).map_err(ProtocolSelectionError::Invalid)?;
+
+    match (*connection_era, metadata) {
+        (ConnectionEra::Undetermined, RequestMetadata::Legacy) => {
+            let version = if method == "initialize" {
+                negotiate_legacy_protocol_version(params)
+            } else {
+                // Preserve ICM's historical support for legacy clients that
+                // call a method before initialize.
+                LEGACY_PROTOCOL_VERSION
+            };
+            *connection_era = ConnectionEra::Legacy(version);
+            Ok(DispatchProtocol::Legacy(version))
+        }
+        (ConnectionEra::Undetermined, RequestMetadata::Modern(requested)) => {
+            *connection_era = ConnectionEra::Modern;
+            select_modern_version(requested)
+        }
+        (ConnectionEra::Legacy(version), RequestMetadata::Legacy) => {
+            Ok(DispatchProtocol::Legacy(version))
+        }
+        (ConnectionEra::Legacy(version), RequestMetadata::Modern(requested)) => {
+            Err(ProtocolSelectionError::Unsupported {
+                requested,
+                supported: vec![version],
+            })
+        }
+        (ConnectionEra::Modern, RequestMetadata::Modern(requested)) => {
+            select_modern_version(requested)
+        }
+        (ConnectionEra::Modern, RequestMetadata::Legacy) => Err(ProtocolSelectionError::Invalid(
+            "modern connections require per-request metadata",
+        )),
+    }
+}
+
+fn select_modern_version(requested: String) -> Result<DispatchProtocol, ProtocolSelectionError> {
+    if requested == MODERN_PROTOCOL_VERSION {
+        Ok(DispatchProtocol::Modern)
+    } else {
+        Err(ProtocolSelectionError::Unsupported {
+            requested,
+            supported: SUPPORTED_PROTOCOL_VERSIONS.to_vec(),
+        })
+    }
+}
+
+fn negotiate_legacy_protocol_version(params: &Option<Value>) -> &'static str {
     match params
         .as_ref()
         .and_then(|value| value.get("protocolVersion"))
@@ -164,18 +316,37 @@ fn negotiate_protocol_version(params: &Option<Value>) -> &'static str {
         // server supports it.
         Some(LEGACY_PROTOCOL_VERSION) => LEGACY_PROTOCOL_VERSION,
         Some(PREVIOUS_PROTOCOL_VERSION) => PREVIOUS_PROTOCOL_VERSION,
-        Some(LATEST_PROTOCOL_VERSION) => LATEST_PROTOCOL_VERSION,
+        Some(LATEST_LEGACY_PROTOCOL_VERSION) => LATEST_LEGACY_PROTOCOL_VERSION,
         // Keep accepting clients that omit the required field, matching ICM's
         // pre-negotiation behavior rather than breaking them on upgrade.
         None => LEGACY_PROTOCOL_VERSION,
-        // For unsupported versions, advertise the latest version ICM supports
-        // and let the client accept it or disconnect per the MCP lifecycle.
-        Some(_) => LATEST_PROTOCOL_VERSION,
+        // Legacy clients cannot fall forward to the stateless 2026 protocol,
+        // so offer the newest handshake-based version instead.
+        Some(_) => LATEST_LEGACY_PROTOCOL_VERSION,
     }
 }
 
-fn supports_tool_annotations(protocol_version: &str) -> bool {
-    protocol_version != LEGACY_PROTOCOL_VERSION
+fn tool_definition_options(protocol_version: &str) -> ToolDefinitionOptions {
+    if protocol_version == LEGACY_PROTOCOL_VERSION {
+        ToolDefinitionOptions::none()
+    } else {
+        ToolDefinitionOptions::none()
+            .with_annotations()
+            .with_output_schemas()
+    }
+}
+
+fn server_info() -> Value {
+    json!({
+        "name": SERVER_NAME,
+        "version": SERVER_VERSION
+    })
+}
+
+fn server_capabilities() -> Value {
+    json!({
+        "tools": {}
+    })
 }
 
 fn handle_initialize(id: Value, protocol_version: &str) -> JsonRpcResponse {
@@ -183,16 +354,68 @@ fn handle_initialize(id: Value, protocol_version: &str) -> JsonRpcResponse {
         id,
         json!({
             "protocolVersion": protocol_version,
-            "capabilities": {
-                "tools": {}
-            },
-            "serverInfo": {
-                "name": SERVER_NAME,
-                "version": SERVER_VERSION
-            },
+            "capabilities": server_capabilities(),
+            "serverInfo": server_info(),
             "instructions": ICM_INSTRUCTIONS
         }),
     )
+}
+
+fn handle_server_discover(id: Value, has_embedder: bool) -> JsonRpcResponse {
+    JsonRpcResponse::ok(
+        id,
+        json!({
+            "supportedVersions": SUPPORTED_PROTOCOL_VERSIONS,
+            "capabilities": server_capabilities(),
+            "instructions": ICM_INSTRUCTIONS,
+            "ttlMs": DISCOVERY_TTL_MS,
+            "cacheScope": "private",
+            "_meta": {
+                "io.modelcontextprotocol/serverInfo": server_info(),
+                "io.icm/embeddingsAvailable": has_embedder
+            }
+        }),
+    )
+}
+
+fn protocol_error_response(id: Value, error: ProtocolSelectionError) -> JsonRpcResponse {
+    match error {
+        ProtocolSelectionError::Invalid(message) => {
+            JsonRpcResponse::err(id, -32602, message.into())
+        }
+        ProtocolSelectionError::Unsupported {
+            requested,
+            supported,
+        } => JsonRpcResponse::err_with_data(
+            id,
+            -32022,
+            "Unsupported protocol version".into(),
+            json!({
+                "supported": supported,
+                "requested": requested
+            }),
+        ),
+    }
+}
+
+fn add_modern_result_metadata(response: &mut JsonRpcResponse, method: &str) {
+    let Some(result) = response.result.as_mut().and_then(Value::as_object_mut) else {
+        return;
+    };
+
+    result.insert("resultType".into(), json!("complete"));
+    let meta = result
+        .entry("_meta")
+        .or_insert_with(|| json!({}))
+        .as_object_mut();
+    if let Some(meta) = meta {
+        meta.insert("io.modelcontextprotocol/serverInfo".into(), server_info());
+    }
+
+    if method == "tools/list" {
+        result.insert("ttlMs".into(), json!(DISCOVERY_TTL_MS));
+        result.insert("cacheScope".into(), json!("private"));
+    }
 }
 
 const ICM_INSTRUCTIONS: &str = "\
@@ -214,10 +437,14 @@ Do NOT store: trivial details, information already in CLAUDE.md, ephemeral state
 \n\
 Importance levels: critical (never forgotten), high (slow decay), medium (normal), low (fast decay).";
 
-fn handle_tools_list(id: Value, has_embedder: bool, include_annotations: bool) -> JsonRpcResponse {
+fn handle_tools_list(
+    id: Value,
+    has_embedder: bool,
+    options: ToolDefinitionOptions,
+) -> JsonRpcResponse {
     JsonRpcResponse::ok(
         id,
-        tools::tool_definitions_with_annotations(has_embedder, include_annotations),
+        tools::tool_definitions_with_options(has_embedder, options),
     )
 }
 
@@ -291,17 +518,40 @@ mod tests {
         })
     }
 
+    fn modern_params(protocol_version: &str) -> Option<Value> {
+        Some(json!({
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": protocol_version,
+                "io.modelcontextprotocol/clientCapabilities": {},
+                "io.modelcontextprotocol/clientInfo": {
+                    "name": "test-client",
+                    "version": "1.0.0"
+                }
+            }
+        }))
+    }
+
     #[test]
     fn protocol_negotiation_echoes_supported_versions() {
-        for (version, has_annotations) in [
-            (LEGACY_PROTOCOL_VERSION, false),
-            (PREVIOUS_PROTOCOL_VERSION, true),
-            (LATEST_PROTOCOL_VERSION, true),
+        for (version, options) in [
+            (LEGACY_PROTOCOL_VERSION, ToolDefinitionOptions::none()),
+            (
+                PREVIOUS_PROTOCOL_VERSION,
+                ToolDefinitionOptions::none()
+                    .with_annotations()
+                    .with_output_schemas(),
+            ),
+            (
+                LATEST_LEGACY_PROTOCOL_VERSION,
+                ToolDefinitionOptions::none()
+                    .with_annotations()
+                    .with_output_schemas(),
+            ),
         ] {
             let params = initialize_params(Some(version));
-            let negotiated = negotiate_protocol_version(&params);
+            let negotiated = negotiate_legacy_protocol_version(&params);
             assert_eq!(negotiated, version);
-            assert_eq!(supports_tool_annotations(negotiated), has_annotations);
+            assert_eq!(tool_definition_options(negotiated), options);
 
             let response = handle_initialize(json!(1), negotiated);
             assert_eq!(response.result.unwrap()["protocolVersion"], version);
@@ -310,26 +560,170 @@ mod tests {
 
     #[test]
     fn protocol_negotiation_uses_compatible_fallbacks() {
-        assert_eq!(negotiate_protocol_version(&None), LEGACY_PROTOCOL_VERSION);
+        assert_eq!(
+            negotiate_legacy_protocol_version(&None),
+            LEGACY_PROTOCOL_VERSION
+        );
 
         let params = initialize_params(Some("2099-01-01"));
-        assert_eq!(negotiate_protocol_version(&params), LATEST_PROTOCOL_VERSION);
+        assert_eq!(
+            negotiate_legacy_protocol_version(&params),
+            LATEST_LEGACY_PROTOCOL_VERSION
+        );
+    }
+
+    #[test]
+    fn modern_request_metadata_is_validated() {
+        let params = modern_params(MODERN_PROTOCOL_VERSION);
+        assert_eq!(
+            request_metadata(&params),
+            Ok(RequestMetadata::Modern(MODERN_PROTOCOL_VERSION.into()))
+        );
+        assert_eq!(request_metadata(&None), Ok(RequestMetadata::Legacy));
+
+        for (params, expected) in [
+            (
+                Some(json!({
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION
+                    }
+                })),
+                "modern requests require an object clientCapabilities",
+            ),
+            (
+                Some(json!({
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
+                        "io.modelcontextprotocol/clientCapabilities": "invalid"
+                    }
+                })),
+                "modern requests require an object clientCapabilities",
+            ),
+            (
+                Some(json!({
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": 20260728,
+                        "io.modelcontextprotocol/clientCapabilities": {}
+                    }
+                })),
+                "modern requests require a string protocolVersion",
+            ),
+            (
+                Some(json!({
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": MODERN_PROTOCOL_VERSION,
+                        "io.modelcontextprotocol/clientCapabilities": {},
+                        "io.modelcontextprotocol/clientInfo": {"name": "missing-version"}
+                    }
+                })),
+                "clientInfo must contain string name and version fields",
+            ),
+        ] {
+            assert_eq!(request_metadata(&params), Err(expected));
+        }
+    }
+
+    #[test]
+    fn connection_era_is_selected_once() {
+        let mut legacy = ConnectionEra::Undetermined;
+        assert_eq!(
+            select_request_protocol(
+                &mut legacy,
+                "initialize",
+                &initialize_params(Some(LEGACY_PROTOCOL_VERSION))
+            ),
+            Ok(DispatchProtocol::Legacy(LEGACY_PROTOCOL_VERSION))
+        );
+        assert_eq!(
+            select_request_protocol(
+                &mut legacy,
+                "tools/list",
+                &modern_params(MODERN_PROTOCOL_VERSION)
+            ),
+            Err(ProtocolSelectionError::Unsupported {
+                requested: MODERN_PROTOCOL_VERSION.into(),
+                supported: vec![LEGACY_PROTOCOL_VERSION]
+            })
+        );
+
+        let mut modern = ConnectionEra::Undetermined;
+        assert_eq!(
+            select_request_protocol(
+                &mut modern,
+                "server/discover",
+                &modern_params(MODERN_PROTOCOL_VERSION)
+            ),
+            Ok(DispatchProtocol::Modern)
+        );
+        assert_eq!(
+            select_request_protocol(&mut modern, "tools/list", &None),
+            Err(ProtocolSelectionError::Invalid(
+                "modern connections require per-request metadata"
+            ))
+        );
+    }
+
+    #[test]
+    fn discovery_advertises_both_protocol_eras() {
+        let mut response = handle_server_discover(json!(1), true);
+        add_modern_result_metadata(&mut response, "server/discover");
+        let result = response.result.unwrap();
+
+        assert_eq!(result["resultType"], "complete");
+        assert_eq!(
+            result["supportedVersions"],
+            json!(SUPPORTED_PROTOCOL_VERSIONS)
+        );
+        assert_eq!(result["capabilities"]["tools"], json!({}));
+        assert_eq!(
+            result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+            SERVER_NAME
+        );
+        assert_eq!(result["_meta"]["io.icm/embeddingsAvailable"], true);
+    }
+
+    #[test]
+    fn unsupported_modern_version_lists_supported_versions() {
+        let error = select_modern_version("2099-01-01".into()).unwrap_err();
+        let response = protocol_error_response(json!(7), error);
+        let error = response.error.unwrap();
+        assert_eq!(error.code, -32022);
+        assert_eq!(
+            error.data.as_ref().unwrap()["supported"],
+            json!(SUPPORTED_PROTOCOL_VERSIONS)
+        );
+        assert_eq!(error.data.unwrap()["requested"], "2099-01-01");
     }
 
     #[test]
     fn tools_list_shape_follows_negotiated_protocol() {
-        let legacy = handle_tools_list(json!(1), true, false).result.unwrap();
+        let legacy = handle_tools_list(json!(1), true, ToolDefinitionOptions::none())
+            .result
+            .unwrap();
         assert!(legacy["tools"]
             .as_array()
             .unwrap()
             .iter()
             .all(|tool| tool.get("annotations").is_none()));
 
-        let modern = handle_tools_list(json!(2), true, true).result.unwrap();
+        let modern = handle_tools_list(
+            json!(2),
+            true,
+            tool_definition_options(MODERN_PROTOCOL_VERSION),
+        )
+        .result
+        .unwrap();
         assert!(modern["tools"]
             .as_array()
             .unwrap()
             .iter()
             .all(|tool| tool.get("annotations").is_some()));
+
+        let mut modern_response = JsonRpcResponse::ok(json!(2), modern);
+        add_modern_result_metadata(&mut modern_response, "tools/list");
+        let modern = modern_response.result.unwrap();
+        assert_eq!(modern["resultType"], "complete");
+        assert_eq!(modern["ttlMs"], DISCOVERY_TTL_MS);
+        assert_eq!(modern["cacheScope"], "private");
     }
 }

--- a/crates/icm-mcp/src/server.rs
+++ b/crates/icm-mcp/src/server.rs
@@ -11,7 +11,9 @@ use crate::tools::{self, AutoConsolidate};
 
 const SERVER_NAME: &str = "icm";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
-const PROTOCOL_VERSION: &str = "2024-11-05";
+const LEGACY_PROTOCOL_VERSION: &str = "2024-11-05";
+const PREVIOUS_PROTOCOL_VERSION: &str = "2025-06-18";
+const LATEST_PROTOCOL_VERSION: &str = "2025-11-25";
 
 /// Number of non-store tool calls before we nudge the agent to store.
 const STORE_NUDGE_THRESHOLD: u32 = 10;
@@ -63,6 +65,10 @@ pub fn run_server(
     let mut reader = stdin.lock();
     let mut stdout = io::stdout();
     let mut calls_since_store: u32 = 0;
+    // Default to the historical protocol until initialization succeeds. This
+    // preserves the legacy tools/list shape for old or non-conforming clients
+    // that call it before initialize.
+    let mut negotiated_protocol_version = LEGACY_PROTOCOL_VERSION;
     let mut buf: Vec<u8> = Vec::new();
 
     loop {
@@ -113,9 +119,16 @@ pub fn run_server(
         };
 
         let response = match method {
-            "initialize" => handle_initialize(id),
+            "initialize" => {
+                negotiated_protocol_version = negotiate_protocol_version(&msg.params);
+                handle_initialize(id, negotiated_protocol_version)
+            }
             "ping" => JsonRpcResponse::ok(id, json!({})),
-            "tools/list" => handle_tools_list(id, embedder.is_some()),
+            "tools/list" => handle_tools_list(
+                id,
+                embedder.is_some(),
+                supports_tool_annotations(negotiated_protocol_version),
+            ),
             "tools/call" => handle_tools_call(
                 id,
                 &msg.params,
@@ -141,11 +154,35 @@ fn write_response(stdout: &mut io::Stdout, resp: &JsonRpcResponse) -> anyhow::Re
     Ok(())
 }
 
-fn handle_initialize(id: Value) -> JsonRpcResponse {
+fn negotiate_protocol_version(params: &Option<Value>) -> &'static str {
+    match params
+        .as_ref()
+        .and_then(|value| value.get("protocolVersion"))
+        .and_then(Value::as_str)
+    {
+        // The MCP lifecycle requires echoing a requested version when the
+        // server supports it.
+        Some(LEGACY_PROTOCOL_VERSION) => LEGACY_PROTOCOL_VERSION,
+        Some(PREVIOUS_PROTOCOL_VERSION) => PREVIOUS_PROTOCOL_VERSION,
+        Some(LATEST_PROTOCOL_VERSION) => LATEST_PROTOCOL_VERSION,
+        // Keep accepting clients that omit the required field, matching ICM's
+        // pre-negotiation behavior rather than breaking them on upgrade.
+        None => LEGACY_PROTOCOL_VERSION,
+        // For unsupported versions, advertise the latest version ICM supports
+        // and let the client accept it or disconnect per the MCP lifecycle.
+        Some(_) => LATEST_PROTOCOL_VERSION,
+    }
+}
+
+fn supports_tool_annotations(protocol_version: &str) -> bool {
+    protocol_version != LEGACY_PROTOCOL_VERSION
+}
+
+fn handle_initialize(id: Value, protocol_version: &str) -> JsonRpcResponse {
     JsonRpcResponse::ok(
         id,
         json!({
-            "protocolVersion": PROTOCOL_VERSION,
+            "protocolVersion": protocol_version,
             "capabilities": {
                 "tools": {}
             },
@@ -177,8 +214,11 @@ Do NOT store: trivial details, information already in CLAUDE.md, ephemeral state
 \n\
 Importance levels: critical (never forgotten), high (slow decay), medium (normal), low (fast decay).";
 
-fn handle_tools_list(id: Value, has_embedder: bool) -> JsonRpcResponse {
-    JsonRpcResponse::ok(id, tools::tool_definitions(has_embedder))
+fn handle_tools_list(id: Value, has_embedder: bool, include_annotations: bool) -> JsonRpcResponse {
+    JsonRpcResponse::ok(
+        id,
+        tools::tool_definitions_with_annotations(has_embedder, include_annotations),
+    )
 }
 
 fn handle_tools_call(
@@ -232,4 +272,64 @@ fn handle_tools_call(
     }
 
     JsonRpcResponse::ok(id, serde_json::to_value(result).unwrap_or(json!(null)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn initialize_params(protocol_version: Option<&str>) -> Option<Value> {
+        protocol_version.map(|version| {
+            json!({
+                "protocolVersion": version,
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "test-client",
+                    "version": "1.0.0"
+                }
+            })
+        })
+    }
+
+    #[test]
+    fn protocol_negotiation_echoes_supported_versions() {
+        for (version, has_annotations) in [
+            (LEGACY_PROTOCOL_VERSION, false),
+            (PREVIOUS_PROTOCOL_VERSION, true),
+            (LATEST_PROTOCOL_VERSION, true),
+        ] {
+            let params = initialize_params(Some(version));
+            let negotiated = negotiate_protocol_version(&params);
+            assert_eq!(negotiated, version);
+            assert_eq!(supports_tool_annotations(negotiated), has_annotations);
+
+            let response = handle_initialize(json!(1), negotiated);
+            assert_eq!(response.result.unwrap()["protocolVersion"], version);
+        }
+    }
+
+    #[test]
+    fn protocol_negotiation_uses_compatible_fallbacks() {
+        assert_eq!(negotiate_protocol_version(&None), LEGACY_PROTOCOL_VERSION);
+
+        let params = initialize_params(Some("2099-01-01"));
+        assert_eq!(negotiate_protocol_version(&params), LATEST_PROTOCOL_VERSION);
+    }
+
+    #[test]
+    fn tools_list_shape_follows_negotiated_protocol() {
+        let legacy = handle_tools_list(json!(1), true, false).result.unwrap();
+        assert!(legacy["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|tool| tool.get("annotations").is_none()));
+
+        let modern = handle_tools_list(json!(2), true, true).result.unwrap();
+        assert!(modern["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|tool| tool.get("annotations").is_some()));
+    }
 }

--- a/crates/icm-mcp/src/server.rs
+++ b/crates/icm-mcp/src/server.rs
@@ -6,7 +6,7 @@ use tracing::{debug, error};
 use icm_core::Embedder;
 use icm_store::Store;
 
-use crate::protocol::{JsonRpcMessage, JsonRpcResponse};
+use crate::protocol::{JsonRpcMessage, JsonRpcResponse, ToolResult};
 use crate::tools::{self, AutoConsolidate, ToolDefinitionOptions};
 
 const SERVER_NAME: &str = "icm";
@@ -49,6 +49,13 @@ enum ProtocolSelectionError {
         requested: String,
         supported: Vec<&'static str>,
     },
+}
+
+#[derive(Clone, Copy)]
+struct ToolCallOptions {
+    compact: bool,
+    auto_consolidate: AutoConsolidate,
+    include_structured_output: bool,
 }
 
 /// Number of non-store tool calls before we nudge the agent to store.
@@ -173,8 +180,11 @@ pub fn run_server(
                         &msg.params,
                         store,
                         embedder,
-                        compact,
-                        auto_consolidate,
+                        ToolCallOptions {
+                            compact,
+                            auto_consolidate,
+                            include_structured_output: true,
+                        },
                         &mut calls_since_store,
                     ),
                     other => JsonRpcResponse::method_not_found(id, other),
@@ -195,8 +205,12 @@ pub fn run_server(
                     &msg.params,
                     store,
                     embedder,
-                    compact,
-                    auto_consolidate,
+                    ToolCallOptions {
+                        compact,
+                        auto_consolidate,
+                        include_structured_output: tool_definition_options(protocol_version)
+                            .includes_output_schemas(),
+                    },
                     &mut calls_since_store,
                 ),
                 other => JsonRpcResponse::method_not_found(id, other),
@@ -453,8 +467,7 @@ fn handle_tools_call(
     params: &Option<Value>,
     store: &Store,
     embedder: Option<&dyn Embedder>,
-    compact: bool,
-    auto_consolidate: AutoConsolidate,
+    options: ToolCallOptions,
     calls_since_store: &mut u32,
 ) -> JsonRpcResponse {
     let params = match params {
@@ -480,8 +493,14 @@ fn handle_tools_call(
         *calls_since_store += 1;
     }
 
-    let mut result =
-        tools::call_tool_with_config(store, embedder, tool_name, &args, compact, auto_consolidate);
+    let mut result = tools::call_tool_with_config(
+        store,
+        embedder,
+        tool_name,
+        &args,
+        options.compact,
+        options.auto_consolidate,
+    );
 
     // Nudge: remind the agent to store on every THRESHOLD-th call without a
     // store (10, 20, 30, …) — previously the hint was appended to *every*
@@ -498,12 +517,59 @@ fn handle_tools_call(
         ));
     }
 
-    JsonRpcResponse::ok(id, serde_json::to_value(result).unwrap_or(json!(null)))
+    JsonRpcResponse::ok(
+        id,
+        serialize_tool_result(result, options.include_structured_output),
+    )
+}
+
+fn serialize_tool_result(result: ToolResult, include_structured_output: bool) -> Value {
+    let mut result = result;
+    if include_structured_output && result.structured_content.is_some() {
+        if let Some(summary) = result.structured_summary.take() {
+            result.content = vec![crate::protocol::TextContent {
+                content_type: "text".into(),
+                text: *summary,
+            }];
+        }
+    }
+    let mut result = serde_json::to_value(result).unwrap_or(json!(null));
+    if !include_structured_output {
+        if let Some(object) = result.as_object_mut() {
+            object.remove("structuredContent");
+        }
+    }
+    result
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::output::TypedTool;
+    use schemars::JsonSchema;
+    use serde::Serialize;
+
+    #[derive(JsonSchema, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    #[schemars(deny_unknown_fields)]
+    struct TestStructuredOutput {
+        count: usize,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        memories: Option<Vec<TestStructuredMemory>>,
+    }
+
+    #[derive(JsonSchema, Serialize)]
+    #[schemars(deny_unknown_fields)]
+    struct TestStructuredMemory {
+        summary: String,
+    }
+
+    struct TestStructuredTool;
+
+    impl TypedTool for TestStructuredTool {
+        const NAME: &'static str = "test_structured_tool";
+        type Output = TestStructuredOutput;
+    }
 
     fn initialize_params(protocol_version: Option<&str>) -> Option<Value> {
         protocol_version.map(|version| {
@@ -725,5 +791,70 @@ mod tests {
         assert_eq!(modern["resultType"], "complete");
         assert_eq!(modern["ttlMs"], DISCOVERY_TTL_MS);
         assert_eq!(modern["cacheScope"], "private");
+    }
+
+    #[test]
+    fn structured_content_is_limited_to_typed_modern_results() {
+        let result = TestStructuredTool::result(
+            "full legacy result".into(),
+            TestStructuredOutput {
+                count: 1,
+                memories: None,
+            },
+            "one structured result".into(),
+        );
+        let legacy = serialize_tool_result(result, false);
+        assert!(legacy.get("structuredContent").is_none());
+        assert_eq!(legacy["content"][0]["text"], "full legacy result");
+
+        let result = TestStructuredTool::result(
+            "full legacy result".into(),
+            TestStructuredOutput {
+                count: 1,
+                memories: None,
+            },
+            "one structured result".into(),
+        );
+        let modern = serialize_tool_result(result, true);
+        assert_eq!(modern["structuredContent"]["count"], 1);
+        assert_eq!(modern["content"][0]["text"], "one structured result");
+
+        let plain = serialize_tool_result(ToolResult::text("ok".into()), true);
+        assert!(plain.get("structuredContent").is_none());
+    }
+
+    #[test]
+    fn modern_structured_summary_does_not_duplicate_legacy_payload() {
+        let legacy_text = "detailed memory result ".repeat(100);
+        let duplicated = serialize_tool_result(
+            TestStructuredTool::result(
+                legacy_text.clone(),
+                TestStructuredOutput {
+                    count: 1,
+                    memories: Some(vec![TestStructuredMemory {
+                        summary: legacy_text.clone(),
+                    }]),
+                },
+                legacy_text.clone(),
+            ),
+            true,
+        );
+        let compact = serialize_tool_result(
+            TestStructuredTool::result(
+                legacy_text,
+                TestStructuredOutput {
+                    count: 1,
+                    memories: Some(vec![TestStructuredMemory {
+                        summary: "detailed memory result ".repeat(100),
+                    }]),
+                },
+                "1 memory returned in structuredContent.".into(),
+            ),
+            true,
+        );
+
+        let duplicated_bytes = serde_json::to_vec(&duplicated).unwrap().len();
+        let compact_bytes = serde_json::to_vec(&compact).unwrap().len();
+        assert!(compact_bytes + 2_000 < duplicated_bytes);
     }
 }

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -13,7 +13,10 @@ use icm_core::{
 use icm_store::Store;
 
 use crate::output::{
-    ListTopicsOutput, ListTopicsTool, RecallOutput, RecallTool, StatsOutput, StatsTool, TypedTool,
+    ListTopicsOutput, ListTopicsTool, RecallOutput, RecallTool, StatsOutput, StatsTool,
+    TranscriptRecordOutput, TranscriptRecordTool, TranscriptSearchOutput, TranscriptSearchTool,
+    TranscriptShowOutput, TranscriptShowTool, TranscriptStartSessionOutput,
+    TranscriptStartSessionTool, TranscriptStatsOutput, TranscriptStatsTool, TypedTool,
 };
 use crate::protocol::ToolResult;
 
@@ -900,7 +903,7 @@ fn tool_catalog() -> &'static [ToolSpec] {
             }
         }),
         // --- Transcript tools (verbatim session replay) ---
-        tool_spec!("icm_transcript_start_session", ToolBehavior::additive(), handler = |context| {
+        tool_spec!(typed TranscriptStartSessionTool, ToolBehavior::additive(), handler = |context| {
             tool_transcript_start_session(context.store, context.args)
         }, {
             "description": "Create a new transcript session for verbatim message capture. Returns the session_id used by subsequent icm_transcript_record calls. Use once per conversation or debugging session.",
@@ -922,7 +925,7 @@ fn tool_catalog() -> &'static [ToolSpec] {
                 }
             }
         }),
-        tool_spec!("icm_transcript_record", ToolBehavior::additive(), handler = |context| {
+        tool_spec!(typed TranscriptRecordTool, ToolBehavior::additive(), handler = |context| {
             tool_transcript_record(context.store, context.args)
         }, {
             "description": "Append a verbatim message to a transcript session. Stores the raw content with no summarization. Use once per user turn, assistant reply, or tool call for full replay fidelity.",
@@ -958,7 +961,7 @@ fn tool_catalog() -> &'static [ToolSpec] {
                 "required": ["session_id", "role", "content"]
             }
         }),
-        tool_spec!("icm_transcript_search", ToolBehavior::read_only(), handler = |context| {
+        tool_spec!(typed TranscriptSearchTool, ToolBehavior::read_only(), handler = |context| {
             tool_transcript_search(context.store, context.args)
         }, {
             "description": "Full-text search across recorded transcript messages (FTS5 BM25). Supports boolean operators, phrase matches, and prefix queries. Use to recall exact quotes or debug past decisions.",
@@ -987,7 +990,7 @@ fn tool_catalog() -> &'static [ToolSpec] {
                 "required": ["query"]
             }
         }),
-        tool_spec!("icm_transcript_show", ToolBehavior::read_only(), handler = |context| {
+        tool_spec!(typed TranscriptShowTool, ToolBehavior::read_only(), handler = |context| {
             tool_transcript_show(context.store, context.args)
         }, {
             "description": "Replay the full message thread of a transcript session, chronologically. Returns up to `limit` messages with role, content, tool name, timestamp.",
@@ -1000,7 +1003,7 @@ fn tool_catalog() -> &'static [ToolSpec] {
                 "required": ["session_id"]
             }
         }),
-        tool_spec!("icm_transcript_stats", ToolBehavior::read_only(), handler = |context| {
+        tool_spec!(typed TranscriptStatsTool, ToolBehavior::read_only(), handler = |context| {
             tool_transcript_stats(context.store)
         }, {
             "description": "Global transcript statistics: session count, message count, total bytes, breakdown by role and agent, top sessions by message count.",
@@ -1124,7 +1127,14 @@ fn tool_transcript_start_session(store: &Store, args: &Value) -> ToolResult {
     let project = args.get("project").and_then(|v| v.as_str());
     let metadata = args.get("metadata").and_then(|v| v.as_str());
     match store.create_session(agent, project, metadata) {
-        Ok(id) => ToolResult::text(format!("{{\"session_id\":\"{id}\"}}")),
+        Ok(id) => {
+            let text = format!("{{\"session_id\":\"{id}\"}}");
+            TranscriptStartSessionTool::result(
+                text,
+                TranscriptStartSessionOutput::new(id),
+                "Transcript session started; sessionId is in structuredContent.".into(),
+            )
+        }
         Err(e) => ToolResult::error(format!("start_session failed: {e}")),
     }
 }
@@ -1155,7 +1165,14 @@ fn tool_transcript_record(store: &Store, args: &Value) -> ToolResult {
     let tokens = args.get("tokens").and_then(|v| v.as_i64());
     let metadata = args.get("metadata").and_then(|v| v.as_str());
     match store.record_message(session_id, role, content, tool_name, tokens, metadata) {
-        Ok(id) => ToolResult::text(format!("{{\"message_id\":\"{id}\"}}")),
+        Ok(id) => {
+            let text = format!("{{\"message_id\":\"{id}\"}}");
+            TranscriptRecordTool::result(
+                text,
+                TranscriptRecordOutput::new(id, session_id.to_owned()),
+                "Transcript message recorded; identifiers are in structuredContent.".into(),
+            )
+        }
         Err(e) => ToolResult::error(format!("record failed: {e}")),
     }
 }
@@ -1176,7 +1193,12 @@ fn tool_transcript_search(store: &Store, args: &Value) -> ToolResult {
     match store.search_transcripts(query, session_id, project, limit) {
         Ok(hits) => {
             let json = serde_json::to_string(&hits).unwrap_or_else(|_| "[]".into());
-            ToolResult::text(json)
+            let summary = format!(
+                "{} transcript search hit{} returned in structuredContent.",
+                hits.len(),
+                if hits.len() == 1 { "" } else { "s" }
+            );
+            TranscriptSearchTool::result(json, TranscriptSearchOutput::from_hits(&hits), summary)
         }
         Err(e) => ToolResult::error(format!("search failed: {e}")),
     }
@@ -1203,13 +1225,26 @@ fn tool_transcript_show(store: &Store, args: &Value) -> ToolResult {
         Err(e) => return ToolResult::error(format!("list_messages failed: {e}")),
     };
     let body = json!({ "session": sess, "messages": msgs });
-    ToolResult::text(body.to_string())
+    let summary = format!(
+        "{} transcript message{} returned in structuredContent.",
+        msgs.len(),
+        if msgs.len() == 1 { "" } else { "s" }
+    );
+    TranscriptShowTool::result(
+        body.to_string(),
+        TranscriptShowOutput::new(&sess, &msgs),
+        summary,
+    )
 }
 
 fn tool_transcript_stats(store: &Store) -> ToolResult {
     use icm_core::TranscriptStore;
     match store.transcript_stats() {
-        Ok(s) => ToolResult::text(serde_json::to_string(&s).unwrap_or_else(|_| "{}".into())),
+        Ok(stats) => TranscriptStatsTool::result(
+            serde_json::to_string(&stats).unwrap_or_else(|_| "{}".into()),
+            TranscriptStatsOutput::from(&stats),
+            "Transcript statistics returned in structuredContent.".into(),
+        ),
         Err(e) => ToolResult::error(format!("stats failed: {e}")),
     }
 }
@@ -3147,6 +3182,113 @@ mod tests {
                 T::NAME
             );
         }
+    }
+
+    #[test]
+    fn transcript_tools_return_typed_receipts_results_and_stats() {
+        let store = test_store();
+        let started = call_tool(
+            &store,
+            None,
+            "icm_transcript_start_session",
+            &json!({"agent": "test-agent", "project": "icm"}),
+            false,
+        );
+        assert_structured_result_matches::<TranscriptStartSessionTool>(&started);
+        let session_id = started.structured_content.as_ref().unwrap()["sessionId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(
+            started.content[0].text,
+            format!("{{\"session_id\":\"{session_id}\"}}")
+        );
+
+        let recorded = call_tool(
+            &store,
+            None,
+            "icm_transcript_record",
+            &json!({
+                "session_id": session_id,
+                "role": "assistant",
+                "content": "structured transcript needle",
+                "tokens": 3
+            }),
+            false,
+        );
+        assert_structured_result_matches::<TranscriptRecordTool>(&recorded);
+        let receipt = recorded.structured_content.as_ref().unwrap();
+        assert_eq!(receipt["sessionId"], session_id);
+        let message_id = receipt["messageId"].as_str().unwrap();
+        assert_eq!(
+            recorded.content[0].text,
+            format!("{{\"message_id\":\"{message_id}\"}}")
+        );
+
+        let search = call_tool(
+            &store,
+            None,
+            "icm_transcript_search",
+            &json!({"query": "structured transcript needle"}),
+            false,
+        );
+        assert_structured_result_matches::<TranscriptSearchTool>(&search);
+        let search_data = search.structured_content.as_ref().unwrap();
+        assert_eq!(search_data["count"], 1);
+        assert_eq!(search_data["hits"][0]["message"]["sessionId"], session_id);
+        assert_eq!(search_data["hits"][0]["message"]["role"], "assistant");
+        assert_eq!(search_data["hits"][0]["session"]["agent"], "test-agent");
+        let legacy_search: Value = serde_json::from_str(&search.content[0].text).unwrap();
+        assert_eq!(legacy_search[0]["message"]["session_id"], session_id);
+        assert!(legacy_search[0]["message"].get("sessionId").is_none());
+
+        let shown = call_tool(
+            &store,
+            None,
+            "icm_transcript_show",
+            &json!({"session_id": session_id}),
+            false,
+        );
+        assert_structured_result_matches::<TranscriptShowTool>(&shown);
+        let shown_data = shown.structured_content.as_ref().unwrap();
+        assert_eq!(shown_data["messageCount"], 1);
+        assert_eq!(shown_data["session"]["id"], session_id);
+        assert_eq!(shown_data["messages"][0]["tokens"], 3);
+        let legacy_show: Value = serde_json::from_str(&shown.content[0].text).unwrap();
+        assert_eq!(legacy_show["messages"][0]["session_id"], session_id);
+
+        let stats = call_tool(&store, None, "icm_transcript_stats", &json!({}), false);
+        assert_structured_result_matches::<TranscriptStatsTool>(&stats);
+        let stats_data = stats.structured_content.as_ref().unwrap();
+        assert_eq!(stats_data["totalSessions"], 1);
+        assert_eq!(stats_data["totalMessages"], 1);
+        assert_eq!(stats_data["byRole"][0]["role"], "assistant");
+        assert_eq!(stats_data["byAgent"][0]["agent"], "test-agent");
+        assert!(stats_data["topSessions"][0]["sessionId"].as_str().is_some());
+        let legacy_stats: Value = serde_json::from_str(&stats.content[0].text).unwrap();
+        assert_eq!(legacy_stats["total_sessions"], 1);
+        assert!(legacy_stats.get("totalSessions").is_none());
+    }
+
+    #[test]
+    fn transcript_output_schemas_are_specific_and_closed() {
+        let definitions = tool_definitions(true);
+        let search = &tool_named(&definitions, "icm_transcript_search")["outputSchema"];
+        assert_eq!(search["required"], json!(["count", "hits"]));
+        assert_eq!(
+            search["properties"]["hits"]["items"]["properties"]["message"]["additionalProperties"],
+            false
+        );
+
+        let stats = &tool_named(&definitions, "icm_transcript_stats")["outputSchema"];
+        assert_eq!(
+            stats["properties"]["byRole"]["items"]["required"],
+            json!(["role", "count"])
+        );
+        assert_eq!(
+            stats["properties"]["topSessions"]["items"]["required"],
+            json!(["sessionId", "count"])
+        );
     }
 
     /// Audit regression: `format_memory_output` (icm_memory_recall's text

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use chrono::Utc;
 use serde_json::{json, Value};
 
@@ -103,14 +105,260 @@ fn try_auto_consolidate(
 }
 
 // ---------------------------------------------------------------------------
-// Tool schemas for tools/list
+// Tool catalog for tools/list
 // ---------------------------------------------------------------------------
 
-pub fn tool_definitions(has_embedder: bool) -> Value {
-    let mut tools = vec![
-        // --- Memory tools ---
+#[derive(Clone, Copy)]
+struct ToolBehavior {
+    read_only: bool,
+    destructive: bool,
+    idempotent: bool,
+    open_world: bool,
+}
+
+impl ToolBehavior {
+    const fn read_only() -> Self {
+        Self {
+            read_only: true,
+            destructive: false,
+            idempotent: true,
+            open_world: false,
+        }
+    }
+
+    const fn additive() -> Self {
+        Self {
+            read_only: false,
+            destructive: false,
+            idempotent: false,
+            open_world: false,
+        }
+    }
+
+    const fn destructive() -> Self {
+        Self {
+            read_only: false,
+            destructive: true,
+            idempotent: false,
+            open_world: false,
+        }
+    }
+
+    const fn idempotent_update() -> Self {
+        Self {
+            read_only: false,
+            destructive: false,
+            idempotent: true,
+            open_world: false,
+        }
+    }
+
+    const fn open_world(mut self) -> Self {
+        self.open_world = true;
+        self
+    }
+
+    fn annotations(self) -> Value {
         json!({
-            "name": "icm_memory_store",
+            "readOnlyHint": self.read_only,
+            "destructiveHint": self.destructive,
+            "idempotentHint": self.idempotent,
+            "openWorldHint": self.open_world
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ToolAvailability {
+    Always,
+    RequiresEmbedder,
+}
+
+impl ToolAvailability {
+    fn is_available(self, has_embedder: bool) -> bool {
+        match self {
+            Self::Always => true,
+            Self::RequiresEmbedder => has_embedder,
+        }
+    }
+}
+
+type ToolOutputSchema = fn() -> Value;
+type ToolHandler = for<'a> fn(ToolCallContext<'a>) -> ToolResult;
+
+#[derive(Clone, Copy)]
+struct ToolCallContext<'a> {
+    store: &'a Store,
+    embedder: Option<&'a dyn Embedder>,
+    args: &'a Value,
+    compact: bool,
+    auto_consolidate: AutoConsolidate,
+}
+
+struct ToolSpec {
+    name: &'static str,
+    definition: Value,
+    behavior: ToolBehavior,
+    availability: ToolAvailability,
+    output_schema: Option<ToolOutputSchema>,
+    handler: ToolHandler,
+}
+
+impl ToolSpec {
+    fn new(
+        name: &'static str,
+        definition: Value,
+        behavior: ToolBehavior,
+        availability: ToolAvailability,
+        output_schema: Option<ToolOutputSchema>,
+        handler: ToolHandler,
+    ) -> Self {
+        Self {
+            name,
+            definition,
+            behavior,
+            availability,
+            output_schema,
+            handler,
+        }
+    }
+
+    fn render(&self, include_annotations: bool) -> Value {
+        let mut definition = self.definition.clone();
+        if let Some(object) = definition.as_object_mut() {
+            object.insert("name".into(), self.name.into());
+            if include_annotations {
+                object.insert("annotations".into(), self.behavior.annotations());
+            }
+            if let Some(output_schema) = self.output_schema {
+                object.insert("outputSchema".into(), output_schema());
+            }
+        }
+        definition
+    }
+
+    fn call(&self, context: ToolCallContext<'_>) -> ToolResult {
+        (self.handler)(context)
+    }
+}
+
+macro_rules! tool_spec {
+    (
+        @build
+        $name:literal,
+        $behavior:expr,
+        $availability:expr,
+        $output_schema:expr,
+        $handler:expr,
+        { $($definition:tt)* }
+    ) => {
+        ToolSpec::new(
+            $name,
+            json!({ $($definition)* }),
+            $behavior,
+            $availability,
+            $output_schema,
+            $handler,
+        )
+    };
+    ($name:literal, $behavior:expr, handler = $handler:expr, { $($definition:tt)* }) => {
+        tool_spec!(
+            @build
+            $name,
+            $behavior,
+            ToolAvailability::Always,
+            None,
+            $handler,
+            { $($definition)* }
+        )
+    };
+    (
+        $name:literal,
+        $behavior:expr,
+        output_schema = $output_schema:path,
+        handler = $handler:expr,
+        { $($definition:tt)* }
+    ) => {
+        tool_spec!(
+            @build
+            $name,
+            $behavior,
+            ToolAvailability::Always,
+            Some($output_schema),
+            $handler,
+            { $($definition)* }
+        )
+    };
+    (
+        $name:literal,
+        $behavior:expr,
+        requires_embedder,
+        handler = $handler:expr,
+        { $($definition:tt)* }
+    ) => {
+        tool_spec!(
+            @build
+            $name,
+            $behavior,
+            ToolAvailability::RequiresEmbedder,
+            None,
+            $handler,
+            { $($definition)* }
+        )
+    };
+    (
+        $name:literal,
+        $behavior:expr,
+        requires_embedder,
+        output_schema = $output_schema:path,
+        handler = $handler:expr,
+        { $($definition:tt)* }
+    ) => {
+        tool_spec!(
+            @build
+            $name,
+            $behavior,
+            ToolAvailability::RequiresEmbedder,
+            Some($output_schema),
+            $handler,
+            { $($definition)* }
+        )
+    };
+}
+
+pub fn tool_definitions(has_embedder: bool) -> Value {
+    tool_definitions_with_annotations(has_embedder, true)
+}
+
+pub(crate) fn tool_definitions_with_annotations(
+    has_embedder: bool,
+    include_annotations: bool,
+) -> Value {
+    let tools = tool_catalog()
+        .iter()
+        .filter(|spec| spec.availability.is_available(has_embedder))
+        .map(|spec| spec.render(include_annotations))
+        .collect::<Vec<_>>();
+
+    json!({ "tools": tools })
+}
+
+fn tool_catalog() -> &'static [ToolSpec] {
+    static CATALOG: OnceLock<Vec<ToolSpec>> = OnceLock::new();
+
+    CATALOG.get_or_init(|| vec![
+        // --- Memory tools ---
+        // Storing can trigger auto-consolidation, which replaces a topic's
+        // entries with a consolidated memory.
+        tool_spec!("icm_memory_store", ToolBehavior::destructive(), handler = |context| {
+            tool_store(
+                context.store,
+                context.embedder,
+                context.args,
+                context.compact,
+                context.auto_consolidate,
+            )
+        }, {
             "description": "Store important information in ICM long-term memory. Use to save decisions, preferences, project context, resolved errors — anything that should persist between sessions.",
             "inputSchema": {
                 "type": "object",
@@ -142,8 +390,16 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["topic", "content"]
             }
         }),
-        json!({
-            "name": "icm_memory_recall",
+        // Recall updates access counters and may run auto-decay, so it is not
+        // read-only or idempotent despite returning query data.
+        tool_spec!("icm_memory_recall", ToolBehavior::additive(), handler = |context| {
+            tool_recall(
+                context.store,
+                context.embedder,
+                context.args,
+                context.compact,
+            )
+        }, {
             "description": "Search ICM long-term memory. Use to find past decisions, project context, preferences, or solutions to previously encountered problems.",
             "inputSchema": {
                 "type": "object",
@@ -175,8 +431,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["query"]
             }
         }),
-        json!({
-            "name": "icm_memory_forget",
+        tool_spec!("icm_memory_forget", ToolBehavior::destructive(), handler = |context| {
+            tool_forget(context.store, context.args)
+        }, {
             "description": "Delete a specific memory by its ID. Use when information is obsolete or incorrect.",
             "inputSchema": {
                 "type": "object",
@@ -189,8 +446,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["id"]
             }
         }),
-        json!({
-            "name": "icm_memory_forget_topic",
+        tool_spec!("icm_memory_forget_topic", ToolBehavior::destructive(), handler = |context| {
+            tool_forget_topic(context.store, context.args)
+        }, {
             "description": "Delete ALL memories in a topic. Use to clear an entire topic at once.",
             "inputSchema": {
                 "type": "object",
@@ -203,8 +461,11 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["topic"]
             }
         }),
-        json!({
-            "name": "icm_learn",
+        // Learning scans a caller-selected directory outside ICM's closed
+        // memory domain before adding the discovered project knowledge.
+        tool_spec!("icm_learn", ToolBehavior::additive().open_world(), handler = |context| {
+            tool_learn(context.store, context.args)
+        }, {
             "description": "Scan a project directory and create a Memoir knowledge graph with its structure, dependencies, modules, and config files.",
             "inputSchema": {
                 "type": "object",
@@ -220,8 +481,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 }
             }
         }),
-        json!({
-            "name": "icm_memory_consolidate",
+        tool_spec!("icm_memory_consolidate", ToolBehavior::destructive(), handler = |context| {
+            tool_consolidate(context.store, context.embedder, context.args)
+        }, {
             "description": "Consolidate all memories of a topic into a single summary. Useful when a topic accumulates too many entries.",
             "inputSchema": {
                 "type": "object",
@@ -238,24 +500,27 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["topic", "summary"]
             }
         }),
-        json!({
-            "name": "icm_memory_list_topics",
+        tool_spec!("icm_memory_list_topics", ToolBehavior::read_only(), handler = |context| {
+            tool_list_topics(context.store)
+        }, {
             "description": "List all available topics in memory with their counts.",
             "inputSchema": {
                 "type": "object",
                 "properties": {}
             }
         }),
-        json!({
-            "name": "icm_memory_stats",
+        tool_spec!("icm_memory_stats", ToolBehavior::read_only(), handler = |context| {
+            tool_stats(context.store)
+        }, {
             "description": "Get global ICM memory statistics.",
             "inputSchema": {
                 "type": "object",
                 "properties": {}
             }
         }),
-        json!({
-            "name": "icm_memory_update",
+        tool_spec!("icm_memory_update", ToolBehavior::destructive(), handler = |context| {
+            tool_update(context.store, context.embedder, context.args)
+        }, {
             "description": "Update an existing memory in-place. Use to correct, refresh, or extend a memory without creating a duplicate.",
             "inputSchema": {
                 "type": "object",
@@ -282,8 +547,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["id", "content"]
             }
         }),
-        json!({
-            "name": "icm_memory_health",
+        tool_spec!("icm_memory_health", ToolBehavior::read_only(), handler = |context| {
+            tool_health(context.store, context.args)
+        }, {
             "description": "Get health stats for all topics: entry count, staleness, consolidation needs. Use to audit memory hygiene.",
             "inputSchema": {
                 "type": "object",
@@ -296,8 +562,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
             }
         }),
         // --- Memoir tools ---
-        json!({
-            "name": "icm_memoir_create",
+        tool_spec!("icm_memoir_create", ToolBehavior::additive(), handler = |context| {
+            tool_memoir_create(context.store, context.args)
+        }, {
             "description": "Create a new memoir — a permanent knowledge container. Memoirs hold concepts that never decay.",
             "inputSchema": {
                 "type": "object",
@@ -314,16 +581,18 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["name"]
             }
         }),
-        json!({
-            "name": "icm_memoir_list",
+        tool_spec!("icm_memoir_list", ToolBehavior::read_only(), handler = |context| {
+            tool_memoir_list(context.store)
+        }, {
             "description": "List all memoirs with their concept counts.",
             "inputSchema": {
                 "type": "object",
                 "properties": {}
             }
         }),
-        json!({
-            "name": "icm_memoir_show",
+        tool_spec!("icm_memoir_show", ToolBehavior::read_only(), handler = |context| {
+            tool_memoir_show(context.store, context.args)
+        }, {
             "description": "Show a memoir's stats, labels, and all its concepts.",
             "inputSchema": {
                 "type": "object",
@@ -336,8 +605,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["name"]
             }
         }),
-        json!({
-            "name": "icm_memoir_add_concept",
+        tool_spec!("icm_memoir_add_concept", ToolBehavior::additive(), handler = |context| {
+            tool_memoir_add_concept(context.store, context.args)
+        }, {
             "description": "Add a permanent concept to a memoir. Concepts are knowledge nodes that get refined, never decayed.",
             "inputSchema": {
                 "type": "object",
@@ -362,8 +632,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["memoir", "name", "definition"]
             }
         }),
-        json!({
-            "name": "icm_memoir_refine",
+        tool_spec!("icm_memoir_refine", ToolBehavior::destructive(), handler = |context| {
+            tool_memoir_refine(context.store, context.args)
+        }, {
             "description": "Refine an existing concept with a new, improved definition. Bumps revision and boosts confidence.",
             "inputSchema": {
                 "type": "object",
@@ -384,8 +655,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["memoir", "name", "definition"]
             }
         }),
-        json!({
-            "name": "icm_memoir_search",
+        tool_spec!("icm_memoir_search", ToolBehavior::read_only(), handler = |context| {
+            tool_memoir_search(context.store, context.args)
+        }, {
             "description": "Full-text search concepts within a memoir.",
             "inputSchema": {
                 "type": "object",
@@ -411,8 +683,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["memoir", "query"]
             }
         }),
-        json!({
-            "name": "icm_memoir_link",
+        tool_spec!("icm_memoir_link", ToolBehavior::additive(), handler = |context| {
+            tool_memoir_link(context.store, context.args)
+        }, {
             "description": "Create a directed, typed edge between two concepts in the same memoir.",
             "inputSchema": {
                 "type": "object",
@@ -438,8 +711,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["memoir", "from", "to", "relation"]
             }
         }),
-        json!({
-            "name": "icm_memoir_inspect",
+        tool_spec!("icm_memoir_inspect", ToolBehavior::read_only(), handler = |context| {
+            tool_memoir_inspect(context.store, context.args)
+        }, {
             "description": "Inspect a concept and its graph neighborhood (BFS).",
             "inputSchema": {
                 "type": "object",
@@ -461,8 +735,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["memoir", "name"]
             }
         }),
-        json!({
-            "name": "icm_memoir_export",
+        tool_spec!("icm_memoir_export", ToolBehavior::read_only(), handler = |context| {
+            tool_memoir_export(context.store, context.args)
+        }, {
             "description": "Export a memoir's full concept graph. Formats: json (structured), dot (Graphviz), ascii (visual), ai (compact markdown for LLM context).",
             "inputSchema": {
                 "type": "object",
@@ -481,8 +756,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["name"]
             }
         }),
-        json!({
-            "name": "icm_memory_extract_patterns",
+        tool_spec!("icm_memory_extract_patterns", ToolBehavior::additive(), handler = |context| {
+            tool_extract_patterns(context.store, context.args)
+        }, {
             "description": "Detect recurring patterns in a topic by keyword similarity. Optionally create concepts in a memoir from detected patterns.",
             "inputSchema": {
                 "type": "object",
@@ -505,8 +781,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["topic"]
             }
         }),
-        json!({
-            "name": "icm_memoir_search_all",
+        tool_spec!("icm_memoir_search_all", ToolBehavior::read_only(), handler = |context| {
+            tool_memoir_search_all(context.store, context.args)
+        }, {
             "description": "Full-text search concepts across all memoirs.",
             "inputSchema": {
                 "type": "object",
@@ -525,8 +802,14 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
             }
         }),
         // --- Feedback tools ---
-        json!({
-            "name": "icm_feedback_record",
+        tool_spec!("icm_feedback_record", ToolBehavior::additive(), handler = |context| {
+            tool_feedback_record(
+                context.store,
+                context.embedder,
+                context.args,
+                context.compact,
+            )
+        }, {
             "description": "Record a correction/feedback when an AI prediction was wrong. Helps improve future predictions by learning from mistakes.",
             "inputSchema": {
                 "type": "object",
@@ -559,8 +842,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["topic", "context", "predicted", "corrected"]
             }
         }),
-        json!({
-            "name": "icm_feedback_search",
+        tool_spec!("icm_feedback_search", ToolBehavior::read_only(), handler = |context| {
+            tool_feedback_search(context.store, context.embedder, context.args)
+        }, {
             "description": "Search past feedback/corrections to inform current predictions. Use before making predictions to learn from past mistakes.",
             "inputSchema": {
                 "type": "object",
@@ -584,8 +868,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["query"]
             }
         }),
-        json!({
-            "name": "icm_feedback_stats",
+        tool_spec!("icm_feedback_stats", ToolBehavior::read_only(), handler = |context| {
+            tool_feedback_stats(context.store)
+        }, {
             "description": "Get feedback statistics: total count, breakdown by topic, most applied corrections.",
             "inputSchema": {
                 "type": "object",
@@ -593,8 +878,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
             }
         }),
         // --- Transcript tools (verbatim session replay) ---
-        json!({
-            "name": "icm_transcript_start_session",
+        tool_spec!("icm_transcript_start_session", ToolBehavior::additive(), handler = |context| {
+            tool_transcript_start_session(context.store, context.args)
+        }, {
             "description": "Create a new transcript session for verbatim message capture. Returns the session_id used by subsequent icm_transcript_record calls. Use once per conversation or debugging session.",
             "inputSchema": {
                 "type": "object",
@@ -614,8 +900,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 }
             }
         }),
-        json!({
-            "name": "icm_transcript_record",
+        tool_spec!("icm_transcript_record", ToolBehavior::additive(), handler = |context| {
+            tool_transcript_record(context.store, context.args)
+        }, {
             "description": "Append a verbatim message to a transcript session. Stores the raw content with no summarization. Use once per user turn, assistant reply, or tool call for full replay fidelity.",
             "inputSchema": {
                 "type": "object",
@@ -649,8 +936,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["session_id", "role", "content"]
             }
         }),
-        json!({
-            "name": "icm_transcript_search",
+        tool_spec!("icm_transcript_search", ToolBehavior::read_only(), handler = |context| {
+            tool_transcript_search(context.store, context.args)
+        }, {
             "description": "Full-text search across recorded transcript messages (FTS5 BM25). Supports boolean operators, phrase matches, and prefix queries. Use to recall exact quotes or debug past decisions.",
             "inputSchema": {
                 "type": "object",
@@ -677,8 +965,9 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["query"]
             }
         }),
-        json!({
-            "name": "icm_transcript_show",
+        tool_spec!("icm_transcript_show", ToolBehavior::read_only(), handler = |context| {
+            tool_transcript_show(context.store, context.args)
+        }, {
             "description": "Replay the full message thread of a transcript session, chronologically. Returns up to `limit` messages with role, content, tool name, timestamp.",
             "inputSchema": {
                 "type": "object",
@@ -689,16 +978,18 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 "required": ["session_id"]
             }
         }),
-        json!({
-            "name": "icm_transcript_stats",
+        tool_spec!("icm_transcript_stats", ToolBehavior::read_only(), handler = |context| {
+            tool_transcript_stats(context.store)
+        }, {
             "description": "Global transcript statistics: session count, message count, total bytes, breakdown by role and agent, top sessions by message count.",
             "inputSchema": {
                 "type": "object",
                 "properties": {}
             }
         }),
-        json!({
-            "name": "icm_wake_up",
+        tool_spec!("icm_wake_up", ToolBehavior::read_only(), handler = |context| {
+            tool_wake_up(context.store, context.args)
+        }, {
             "description": "Build a compact critical-facts pack for LLM system-prompt injection. Selects critical/high memories (and preferences) optionally scoped by project, ranks by importance × recency × weight, and truncates to a token budget. Use at session start to hydrate an agent with the most load-bearing context.",
             "inputSchema": {
                 "type": "object",
@@ -728,25 +1019,29 @@ pub fn tool_definitions(has_embedder: bool) -> Value {
                 }
             }
         }),
-    ];
-
-    if has_embedder {
-        tools.push(json!({
-            "name": "icm_memory_embed_all",
-            "description": "Generate embeddings for all memories that don't have one yet. Use this to backfill vector search capability.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "topic": {
-                        "type": "string",
-                        "description": "Only embed memories in this topic (optional)"
+        // This only fills missing embeddings, so repeating it with the same
+        // arguments has no further effect.
+        tool_spec!(
+            "icm_memory_embed_all",
+            ToolBehavior::idempotent_update(),
+            requires_embedder,
+            handler = |context| {
+                tool_embed_all(context.store, context.embedder, context.args)
+            },
+            {
+                "description": "Generate embeddings for all memories that don't have one yet. Use this to backfill vector search capability.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "topic": {
+                            "type": "string",
+                            "description": "Only embed memories in this topic (optional)"
+                        }
                     }
                 }
             }
-        }));
-    }
-
-    json!({ "tools": tools })
+        ),
+    ])
 }
 
 // ---------------------------------------------------------------------------
@@ -781,46 +1076,20 @@ pub fn call_tool_with_config(
     compact: bool,
     auto_consolidate: AutoConsolidate,
 ) -> ToolResult {
-    match name {
-        // Memory tools
-        "icm_memory_store" => tool_store(store, embedder, args, compact, auto_consolidate),
-        "icm_memory_recall" => tool_recall(store, embedder, args, compact),
-        "icm_memory_forget" => tool_forget(store, args),
-        "icm_memory_forget_topic" => tool_forget_topic(store, args),
-        "icm_memory_update" => tool_update(store, embedder, args),
-        "icm_memory_consolidate" => tool_consolidate(store, embedder, args),
-        "icm_memory_list_topics" => tool_list_topics(store),
-        "icm_memory_stats" => tool_stats(store),
-        "icm_memory_health" => tool_health(store, args),
-        "icm_memory_extract_patterns" => tool_extract_patterns(store, args),
-        "icm_memory_embed_all" => tool_embed_all(store, embedder, args),
-        // Memoir tools
-        "icm_memoir_create" => tool_memoir_create(store, args),
-        "icm_memoir_list" => tool_memoir_list(store),
-        "icm_memoir_show" => tool_memoir_show(store, args),
-        "icm_memoir_add_concept" => tool_memoir_add_concept(store, args),
-        "icm_memoir_refine" => tool_memoir_refine(store, args),
-        "icm_memoir_search" => tool_memoir_search(store, args),
-        "icm_memoir_search_all" => tool_memoir_search_all(store, args),
-        "icm_memoir_link" => tool_memoir_link(store, args),
-        "icm_memoir_inspect" => tool_memoir_inspect(store, args),
-        "icm_memoir_export" => tool_memoir_export(store, args),
-        // Learn tool
-        "icm_learn" => tool_learn(store, args),
-        // Feedback tools
-        "icm_feedback_record" => tool_feedback_record(store, embedder, args, compact),
-        "icm_feedback_search" => tool_feedback_search(store, embedder, args),
-        "icm_feedback_stats" => tool_feedback_stats(store),
-        // Transcript tools
-        "icm_transcript_start_session" => tool_transcript_start_session(store, args),
-        "icm_transcript_record" => tool_transcript_record(store, args),
-        "icm_transcript_search" => tool_transcript_search(store, args),
-        "icm_transcript_show" => tool_transcript_show(store, args),
-        "icm_transcript_stats" => tool_transcript_stats(store),
-        // Wake-up tool
-        "icm_wake_up" => tool_wake_up(store, args),
-        _ => ToolResult::error(format!("unknown tool: {name}")),
-    }
+    let context = ToolCallContext {
+        store,
+        embedder,
+        args,
+        compact,
+        auto_consolidate,
+    };
+    tool_catalog()
+        .iter()
+        .find(|spec| spec.name == name)
+        .map_or_else(
+            || ToolResult::error(format!("unknown tool: {name}")),
+            |spec| spec.call(context),
+        )
 }
 
 // ---------------------------------------------------------------------------
@@ -2536,10 +2805,174 @@ fn tool_feedback_stats(store: &Store) -> ToolResult {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
 
     fn test_store() -> Store {
         Store::in_memory().unwrap()
+    }
+
+    fn tool_named<'a>(definitions: &'a Value, name: &str) -> &'a Value {
+        definitions["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|tool| tool["name"] == name)
+            .unwrap_or_else(|| panic!("tool not listed: {name}"))
+    }
+
+    #[test]
+    fn tool_catalog_is_cached_unique_ordered_and_dispatchable() {
+        let catalog = tool_catalog();
+        assert!(std::ptr::eq(catalog, tool_catalog()));
+        let mut names = HashSet::new();
+
+        for spec in catalog {
+            assert!(names.insert(spec.name), "duplicate tool: {}", spec.name);
+            let definition = spec
+                .definition
+                .as_object()
+                .unwrap_or_else(|| panic!("{} has a non-object definition", spec.name));
+            assert!(
+                definition.get("name").is_none(),
+                "{} duplicates its catalog name in the definition",
+                spec.name
+            );
+            assert!(
+                definition.get("description").is_some_and(Value::is_string),
+                "{} has no description",
+                spec.name
+            );
+            assert!(
+                definition.get("inputSchema").is_some_and(Value::is_object),
+                "{} has no input schema",
+                spec.name
+            );
+            if let Some(output_schema) = spec.output_schema {
+                assert!(
+                    output_schema().is_object(),
+                    "{} has a non-object output schema",
+                    spec.name
+                );
+            }
+        }
+
+        let expected_names = catalog.iter().map(|spec| spec.name).collect::<Vec<_>>();
+        let definitions = tool_definitions(true);
+        let actual_names = definitions["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool["name"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(actual_names, expected_names, "tools/list order changed");
+
+        let store = test_store();
+        let through_catalog = call_tool(&store, None, "icm_memory_stats", &json!({}), false);
+        let direct = tool_stats(&store);
+        assert_eq!(
+            serde_json::to_value(through_catalog).unwrap(),
+            serde_json::to_value(direct).unwrap(),
+            "catalog dispatch changed the registered handler"
+        );
+
+        let without_embedder = tool_definitions(false);
+        assert!(
+            without_embedder["tools"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|tool| tool["name"] != "icm_memory_embed_all"),
+            "embed-only tool was listed without an embedder"
+        );
+        assert_eq!(
+            catalog
+                .iter()
+                .filter(|spec| spec.availability == ToolAvailability::RequiresEmbedder)
+                .map(|spec| spec.name)
+                .collect::<Vec<_>>(),
+            vec!["icm_memory_embed_all"]
+        );
+        let hidden_but_registered =
+            call_tool(&store, None, "icm_memory_embed_all", &json!({}), false);
+        assert_eq!(
+            hidden_but_registered.content[0].text,
+            "embeddings not available"
+        );
+    }
+
+    #[test]
+    fn tool_definitions_are_annotated_without_changing_legacy_shape() {
+        let definitions = tool_definitions(true);
+        let tools = definitions["tools"].as_array().unwrap();
+
+        for tool in tools {
+            let name = tool["name"].as_str().unwrap();
+            let annotations = tool
+                .get("annotations")
+                .unwrap_or_else(|| panic!("missing annotations for {name}"));
+            for hint in [
+                "readOnlyHint",
+                "destructiveHint",
+                "idempotentHint",
+                "openWorldHint",
+            ] {
+                assert!(
+                    annotations[hint].is_boolean(),
+                    "{name} has no boolean {hint}"
+                );
+            }
+            if name != "icm_learn" {
+                assert_eq!(
+                    annotations["openWorldHint"], false,
+                    "{name} must describe ICM's closed-world memory domain"
+                );
+            }
+        }
+
+        let recall = &tool_named(&definitions, "icm_memory_recall")["annotations"];
+        assert_eq!(recall["readOnlyHint"], false);
+        assert_eq!(recall["destructiveHint"], false);
+        assert_eq!(recall["idempotentHint"], false);
+
+        let learn = &tool_named(&definitions, "icm_learn")["annotations"];
+        assert_eq!(learn["readOnlyHint"], false);
+        assert_eq!(learn["openWorldHint"], true);
+
+        let store = &tool_named(&definitions, "icm_memory_store")["annotations"];
+        assert_eq!(store["readOnlyHint"], false);
+        assert_eq!(store["destructiveHint"], true);
+        assert_eq!(store["idempotentHint"], false);
+
+        let create = &tool_named(&definitions, "icm_memoir_create")["annotations"];
+        assert_eq!(create["readOnlyHint"], false);
+        assert_eq!(create["destructiveHint"], false);
+        assert_eq!(create["idempotentHint"], false);
+
+        let embed = &tool_named(&definitions, "icm_memory_embed_all")["annotations"];
+        assert_eq!(embed["readOnlyHint"], false);
+        assert_eq!(embed["destructiveHint"], false);
+        assert_eq!(embed["idempotentHint"], true);
+
+        let legacy = tool_definitions_with_annotations(true, false);
+        let mut modern_without_annotations = definitions;
+
+        for tool in legacy["tools"].as_array().unwrap() {
+            assert!(
+                tool.get("annotations").is_none(),
+                "legacy tool unexpectedly included annotations: {}",
+                tool["name"]
+            );
+        }
+        for tool in modern_without_annotations["tools"].as_array_mut().unwrap() {
+            tool.as_object_mut().unwrap().remove("annotations");
+        }
+
+        assert_eq!(
+            legacy, modern_without_annotations,
+            "legacy clients must receive the pre-annotation tools/list shape"
+        );
     }
 
     /// Audit regression: `format_memory_output` (icm_memory_recall's text
@@ -2662,7 +3095,7 @@ mod tests {
         let store = test_store();
         let result = call_tool(&store, None, "nonexistent_tool", &json!({}), false);
         assert!(result.is_error);
-        assert!(result.content[0].text.contains("unknown tool"));
+        assert_eq!(result.content[0].text, "unknown tool: nonexistent_tool");
     }
 
     #[test]
@@ -2758,6 +3191,11 @@ mod tests {
         );
         assert!(!recall_result.is_error);
         assert!(recall_result.content[0].text.contains("Rust"));
+        let recalled = store.get_by_topic("test-project").unwrap();
+        assert_eq!(
+            recalled[0].access_count, 1,
+            "recall mutates access metadata and must not be annotated read-only"
+        );
     }
 
     /// Audit regression: a 64 KB raw_excerpt was dumped in full for every

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -195,6 +195,31 @@ struct ToolCallContext<'a> {
     auto_consolidate: AutoConsolidate,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ToolDefinitionOptions {
+    annotations: bool,
+    output_schemas: bool,
+}
+
+impl ToolDefinitionOptions {
+    pub(crate) const fn none() -> Self {
+        Self {
+            annotations: false,
+            output_schemas: false,
+        }
+    }
+
+    pub(crate) const fn with_annotations(mut self) -> Self {
+        self.annotations = true;
+        self
+    }
+
+    pub(crate) const fn with_output_schemas(mut self) -> Self {
+        self.output_schemas = true;
+        self
+    }
+}
+
 struct ToolSpec {
     name: &'static str,
     definition: Value,
@@ -223,14 +248,14 @@ impl ToolSpec {
         }
     }
 
-    fn render(&self, include_annotations: bool) -> Value {
+    fn render(&self, options: ToolDefinitionOptions) -> Value {
         let mut definition = self.definition.clone();
         if let Some(object) = definition.as_object_mut() {
             object.insert("name".into(), self.name.into());
-            if include_annotations {
+            if options.annotations {
                 object.insert("annotations".into(), self.behavior.annotations());
             }
-            if let Some(output_schema) = self.output_schema {
+            if let (true, Some(output_schema)) = (options.output_schemas, self.output_schema) {
                 object.insert("outputSchema".into(), output_schema());
             }
         }
@@ -327,17 +352,22 @@ macro_rules! tool_spec {
 }
 
 pub fn tool_definitions(has_embedder: bool) -> Value {
-    tool_definitions_with_annotations(has_embedder, true)
+    tool_definitions_with_options(
+        has_embedder,
+        ToolDefinitionOptions::none()
+            .with_annotations()
+            .with_output_schemas(),
+    )
 }
 
-pub(crate) fn tool_definitions_with_annotations(
+pub(crate) fn tool_definitions_with_options(
     has_embedder: bool,
-    include_annotations: bool,
+    options: ToolDefinitionOptions,
 ) -> Value {
     let tools = tool_catalog()
         .iter()
         .filter(|spec| spec.availability.is_available(has_embedder))
-        .map(|spec| spec.render(include_annotations))
+        .map(|spec| spec.render(options))
         .collect::<Vec<_>>();
 
     json!({ "tools": tools })
@@ -2903,6 +2933,52 @@ mod tests {
     }
 
     #[test]
+    fn tool_definition_options_are_independent() {
+        fn fixture_output_schema() -> Value {
+            json!({ "type": "object" })
+        }
+
+        let render = |options| {
+            tool_spec!(
+                "fixture",
+                ToolBehavior::read_only(),
+                output_schema = fixture_output_schema,
+                handler = |_| ToolResult::text("fixture".into()),
+                {
+                    "description": "Fixture tool",
+                    "inputSchema": { "type": "object" }
+                }
+            )
+            .render(options)
+        };
+
+        for (options, has_annotations, has_output_schema) in [
+            (ToolDefinitionOptions::none(), false, false),
+            (
+                ToolDefinitionOptions::none().with_annotations(),
+                true,
+                false,
+            ),
+            (
+                ToolDefinitionOptions::none().with_output_schemas(),
+                false,
+                true,
+            ),
+            (
+                ToolDefinitionOptions::none()
+                    .with_annotations()
+                    .with_output_schemas(),
+                true,
+                true,
+            ),
+        ] {
+            let definition = render(options);
+            assert_eq!(definition.get("annotations").is_some(), has_annotations);
+            assert_eq!(definition.get("outputSchema").is_some(), has_output_schema);
+        }
+    }
+
+    #[test]
     fn tool_definitions_are_annotated_without_changing_legacy_shape() {
         let definitions = tool_definitions(true);
         let tools = definitions["tools"].as_array().unwrap();
@@ -2955,7 +3031,7 @@ mod tests {
         assert_eq!(embed["destructiveHint"], false);
         assert_eq!(embed["idempotentHint"], true);
 
-        let legacy = tool_definitions_with_annotations(true, false);
+        let legacy = tool_definitions_with_options(true, ToolDefinitionOptions::none());
         let mut modern_without_annotations = definitions;
 
         for tool in legacy["tools"].as_array().unwrap() {

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -12,6 +12,9 @@ use icm_core::{
 };
 use icm_store::Store;
 
+use crate::output::{
+    ListTopicsOutput, ListTopicsTool, RecallOutput, RecallTool, StatsOutput, StatsTool, TypedTool,
+};
 use crate::protocol::ToolResult;
 
 /// Historical default threshold for auto-consolidation. The live value comes
@@ -218,6 +221,10 @@ impl ToolDefinitionOptions {
         self.output_schemas = true;
         self
     }
+
+    pub(crate) const fn includes_output_schemas(self) -> bool {
+        self.output_schemas
+    }
 }
 
 struct ToolSpec {
@@ -235,7 +242,6 @@ impl ToolSpec {
         definition: Value,
         behavior: ToolBehavior,
         availability: ToolAvailability,
-        output_schema: Option<ToolOutputSchema>,
         handler: ToolHandler,
     ) -> Self {
         Self {
@@ -243,7 +249,23 @@ impl ToolSpec {
             definition,
             behavior,
             availability,
-            output_schema,
+            output_schema: None,
+            handler,
+        }
+    }
+
+    fn typed<T: TypedTool>(
+        definition: Value,
+        behavior: ToolBehavior,
+        availability: ToolAvailability,
+        handler: ToolHandler,
+    ) -> Self {
+        Self {
+            name: T::NAME,
+            definition,
+            behavior,
+            availability,
+            output_schema: Some(T::output_schema),
             handler,
         }
     }
@@ -268,85 +290,55 @@ impl ToolSpec {
 }
 
 macro_rules! tool_spec {
+    ($name:literal, $behavior:expr, handler = $handler:expr, { $($definition:tt)* }) => {
+        ToolSpec::new(
+            $name,
+            json!({ $($definition)* }),
+            $behavior,
+            ToolAvailability::Always,
+            $handler,
+        )
+    };
     (
-        @build
         $name:literal,
         $behavior:expr,
-        $availability:expr,
-        $output_schema:expr,
-        $handler:expr,
+        requires_embedder,
+        handler = $handler:expr,
         { $($definition:tt)* }
     ) => {
         ToolSpec::new(
             $name,
             json!({ $($definition)* }),
             $behavior,
-            $availability,
-            $output_schema,
+            ToolAvailability::RequiresEmbedder,
             $handler,
-        )
-    };
-    ($name:literal, $behavior:expr, handler = $handler:expr, { $($definition:tt)* }) => {
-        tool_spec!(
-            @build
-            $name,
-            $behavior,
-            ToolAvailability::Always,
-            None,
-            $handler,
-            { $($definition)* }
         )
     };
     (
-        $name:literal,
+        typed $tool:ty,
         $behavior:expr,
-        output_schema = $output_schema:path,
         handler = $handler:expr,
         { $($definition:tt)* }
     ) => {
-        tool_spec!(
-            @build
-            $name,
+        ToolSpec::typed::<$tool>(
+            json!({ $($definition)* }),
             $behavior,
             ToolAvailability::Always,
-            Some($output_schema),
             $handler,
-            { $($definition)* }
         )
     };
     (
-        $name:literal,
+        typed $tool:ty,
         $behavior:expr,
         requires_embedder,
         handler = $handler:expr,
         { $($definition:tt)* }
     ) => {
-        tool_spec!(
-            @build
-            $name,
+        ToolSpec::typed::<$tool>(
+            json!({ $($definition)* }),
             $behavior,
             ToolAvailability::RequiresEmbedder,
-            None,
             $handler,
-            { $($definition)* }
-        )
-    };
-    (
-        $name:literal,
-        $behavior:expr,
-        requires_embedder,
-        output_schema = $output_schema:path,
-        handler = $handler:expr,
-        { $($definition:tt)* }
-    ) => {
-        tool_spec!(
-            @build
-            $name,
-            $behavior,
-            ToolAvailability::RequiresEmbedder,
-            Some($output_schema),
-            $handler,
-            { $($definition)* }
         )
     };
 }
@@ -422,7 +414,7 @@ fn tool_catalog() -> &'static [ToolSpec] {
         }),
         // Recall updates access counters and may run auto-decay, so it is not
         // read-only or idempotent despite returning query data.
-        tool_spec!("icm_memory_recall", ToolBehavior::additive(), handler = |context| {
+        tool_spec!(typed RecallTool, ToolBehavior::additive(), handler = |context| {
             tool_recall(
                 context.store,
                 context.embedder,
@@ -530,7 +522,7 @@ fn tool_catalog() -> &'static [ToolSpec] {
                 "required": ["topic", "summary"]
             }
         }),
-        tool_spec!("icm_memory_list_topics", ToolBehavior::read_only(), handler = |context| {
+        tool_spec!(typed ListTopicsTool, ToolBehavior::read_only(), handler = |context| {
             tool_list_topics(context.store)
         }, {
             "description": "List all available topics in memory with their counts.",
@@ -539,7 +531,7 @@ fn tool_catalog() -> &'static [ToolSpec] {
                 "properties": {}
             }
         }),
-        tool_spec!("icm_memory_stats", ToolBehavior::read_only(), handler = |context| {
+        tool_spec!(typed StatsTool, ToolBehavior::read_only(), handler = |context| {
             tool_stats(context.store)
         }, {
             "description": "Get global ICM memory statistics.",
@@ -1539,6 +1531,26 @@ fn format_memory_output(memories: &[(Memory, f32)], compact: bool) -> String {
     output
 }
 
+fn recall_result(memories: &[(Memory, f32)], compact: bool) -> ToolResult {
+    RecallTool::result(
+        format_memory_output(memories, compact),
+        RecallOutput::from_memories(memories),
+        format!(
+            "{} memor{} returned in structuredContent.",
+            memories.len(),
+            if memories.len() == 1 { "y" } else { "ies" }
+        ),
+    )
+}
+
+fn empty_recall_result() -> ToolResult {
+    RecallTool::result(
+        MSG_NO_MEMORIES.into(),
+        RecallOutput::from_memories(&[]),
+        MSG_NO_MEMORIES.into(),
+    )
+}
+
 fn tool_recall(
     store: &Store,
     embedder: Option<&dyn Embedder>,
@@ -1639,10 +1651,10 @@ fn tool_recall(
                 let _ = store.batch_update_access(&ids);
 
                 if expanded.is_empty() {
-                    return ToolResult::text(MSG_NO_MEMORIES.into());
+                    return empty_recall_result();
                 }
 
-                return ToolResult::text(format_memory_output(&expanded, compact));
+                return recall_result(&expanded, compact);
             }
         }
     }
@@ -1695,13 +1707,13 @@ fn tool_recall(
     let _ = store.batch_update_access(&ids);
 
     if expanded.is_empty() {
-        return ToolResult::text(MSG_NO_MEMORIES.into());
+        return empty_recall_result();
     }
 
     // FTS-path results have synthetic scores — reset to -1.0 for display
     // so we don't claim a hybrid-search confidence we didn't compute.
     let for_display: Vec<(Memory, f32)> = expanded.into_iter().map(|(m, _)| (m, -1.0)).collect();
-    ToolResult::text(format_memory_output(&for_display, compact))
+    recall_result(&for_display, compact)
 }
 
 fn tool_forget(store: &Store, args: &Value) -> ToolResult {
@@ -1782,7 +1794,11 @@ fn tool_list_topics(store: &Store) -> ToolResult {
     match store.list_topics() {
         Ok(topics) => {
             if topics.is_empty() {
-                return ToolResult::text("No topics yet.".into());
+                return ListTopicsTool::result(
+                    "No topics yet.".into(),
+                    ListTopicsOutput::from_topics(&topics),
+                    "No topics yet.".into(),
+                );
             }
 
             // Group topics by scope prefix (before ':')
@@ -1817,7 +1833,11 @@ fn tool_list_topics(store: &Store) -> ToolResult {
                 }
             }
 
-            ToolResult::text(output)
+            ListTopicsTool::result(
+                output,
+                ListTopicsOutput::from_topics(&topics),
+                format!("{} topics returned in structuredContent.", topics.len()),
+            )
         }
         Err(e) => ToolResult::error(format!("failed to list topics: {e}")),
     }
@@ -1830,19 +1850,23 @@ fn tool_stats(store: &Store) -> ToolResult {
                 "Memories: {}\nTopics: {}\nAvg weight: {:.3}\n",
                 stats.total_memories, stats.total_topics, stats.avg_weight
             );
-            if let Some(oldest) = stats.oldest_memory {
+            if let Some(oldest) = &stats.oldest_memory {
                 output.push_str(&format!(
                     "Oldest: {}\n",
-                    format_local(&oldest, "%Y-%m-%d %H:%M")
+                    format_local(oldest, "%Y-%m-%d %H:%M")
                 ));
             }
-            if let Some(newest) = stats.newest_memory {
+            if let Some(newest) = &stats.newest_memory {
                 output.push_str(&format!(
                     "Newest: {}\n",
-                    format_local(&newest, "%Y-%m-%d %H:%M")
+                    format_local(newest, "%Y-%m-%d %H:%M")
                 ));
             }
-            ToolResult::text(output)
+            StatsTool::result(
+                output,
+                StatsOutput::from(&stats),
+                "Memory statistics returned in structuredContent.".into(),
+            )
         }
         Err(e) => ToolResult::error(format!("failed to get stats: {e}")),
     }
@@ -2934,15 +2958,10 @@ mod tests {
 
     #[test]
     fn tool_definition_options_are_independent() {
-        fn fixture_output_schema() -> Value {
-            json!({ "type": "object" })
-        }
-
         let render = |options| {
             tool_spec!(
-                "fixture",
+                typed RecallTool,
                 ToolBehavior::read_only(),
-                output_schema = fixture_output_schema,
                 handler = |_| ToolResult::text("fixture".into()),
                 {
                     "description": "Fixture tool",
@@ -2980,6 +2999,7 @@ mod tests {
 
     #[test]
     fn tool_definitions_are_annotated_without_changing_legacy_shape() {
+        let catalog = tool_catalog();
         let definitions = tool_definitions(true);
         let tools = definitions["tools"].as_array().unwrap();
 
@@ -3005,6 +3025,16 @@ mod tests {
                     "{name} must describe ICM's closed-world memory domain"
                 );
             }
+            let expected_output_schema = catalog
+                .iter()
+                .find(|spec| spec.name == name)
+                .and_then(|spec| spec.output_schema)
+                .map(|output_schema| output_schema());
+            assert_eq!(
+                tool.get("outputSchema"),
+                expected_output_schema.as_ref(),
+                "unexpected outputSchema policy for {name}"
+            );
         }
 
         let recall = &tool_named(&definitions, "icm_memory_recall")["annotations"];
@@ -3040,15 +3070,83 @@ mod tests {
                 "legacy tool unexpectedly included annotations: {}",
                 tool["name"]
             );
+            assert!(
+                tool.get("outputSchema").is_none(),
+                "legacy tool unexpectedly included outputSchema: {}",
+                tool["name"]
+            );
         }
         for tool in modern_without_annotations["tools"].as_array_mut().unwrap() {
-            tool.as_object_mut().unwrap().remove("annotations");
+            let object = tool.as_object_mut().unwrap();
+            object.remove("annotations");
+            object.remove("outputSchema");
         }
 
         assert_eq!(
             legacy, modern_without_annotations,
-            "legacy clients must receive the pre-annotation tools/list shape"
+            "legacy clients must receive the pre-modern tools/list shape"
         );
+    }
+
+    #[test]
+    fn memory_discovery_tools_return_machine_readable_data() {
+        let store = test_store();
+        let mut memory = Memory::new(
+            "test-topic".into(),
+            "structured recall needle".into(),
+            icm_core::Importance::High,
+        );
+        memory.keywords = vec!["needle".into()];
+        let id = memory.id.clone();
+        store.store(memory).unwrap();
+
+        let recall = tool_recall(
+            &store,
+            None,
+            &json!({"query": "needle", "project": ""}),
+            false,
+        );
+        assert_structured_result_matches::<RecallTool>(&recall);
+        let recall_data = recall.structured_content.as_ref().unwrap();
+        assert_eq!(recall_data["count"], 1);
+        assert_eq!(recall_data["memories"][0]["id"], id);
+        assert_eq!(recall_data["memories"][0]["importance"], "high");
+        assert_eq!(recall_data["memories"][0]["source"]["type"], "manual");
+        assert_eq!(recall_data["memories"][0]["scope"], "user");
+        assert!(recall_data["memories"][0].get("embedding").is_none());
+
+        let topics = tool_list_topics(&store);
+        assert_structured_result_matches::<ListTopicsTool>(&topics);
+        assert_eq!(
+            topics.structured_content.as_ref().unwrap()["topics"][0]["name"],
+            "test-topic"
+        );
+
+        let stats = tool_stats(&store);
+        assert_structured_result_matches::<StatsTool>(&stats);
+        assert_eq!(
+            stats.structured_content.as_ref().unwrap()["totalMemories"],
+            1
+        );
+    }
+
+    fn assert_structured_result_matches<T: TypedTool>(result: &ToolResult) {
+        let schema = T::output_schema();
+        let validator = jsonschema::draft202012::options()
+            .should_validate_formats(true)
+            .build(&schema)
+            .unwrap();
+        let output = result
+            .structured_content
+            .as_ref()
+            .expect("typed tool result must include structuredContent");
+
+        if let Err(error) = validator.validate(output) {
+            panic!(
+                "{} output did not match its generated schema: {error}",
+                T::NAME
+            );
+        }
     }
 
     /// Audit regression: `format_memory_output` (icm_memory_recall's text


### PR DESCRIPTION
## Summary

Add direct typed MCP output for the transcript tool family.

## Motivation

All five transcript tools encode machine data inside MCP text. Modern clients must decode JSON-RPC and then parse another string, while generic structured wrappers duplicate large transcript payloads.

## Changes

- define transcript DTOs, typed tool markers, conversions, and schema ownership in the dedicated `output/transcript.rs` domain module
- derive precise output schemas for start-session, record, search, show, and stats from those Rust types
- return direct typed values with stable session and message IDs
- map sessions, messages, hits, and statistics to explicit camelCase fields
- replace tuple-based statistics with named count objects
- use concise modern text without duplicating transcript bodies
- preserve the exact legacy JSON text

## Compatibility and safety

MCP `2024-11-05` receives the existing text and no structured fields. Only negotiated modern clients receive typed values. Schemas are closed at every described object boundary.

## Validation

```bash
cargo test -p icm-mcp --locked --offline transcript_
cargo test -p icm-mcp --locked --offline
cargo clippy -p icm-mcp --all-targets --locked --offline -- -D warnings
cargo fmt --all -- --check
```

Focused tests chain session creation, message recording, search, replay, and statistics. They validate the real emitted values against the generated schemas and verify stable IDs, nested values, named counts, closed schemas, timestamp compatibility, and exact legacy output preservation.

The evaluation measured a 31.3% reduction in estimated wire tokens for modern transcript statistics.