### PR TITLE
fix: honor disabled extraction in PostToolUse hook

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2232,6 +2232,9 @@ fn main() -> Result<()> {
             let result = match command {
                 HookCommands::Pre => cmd_hook_pre(),
                 HookCommands::Post { every } => {
+                    if !cfg.extraction.enabled {
+                        return Ok(());
+                    }
                     // CLI flag wins over config; absent flag falls back to config.
                     let extract_every = every.unwrap_or(cfg.extraction.extract_every);
                     #[cfg(feature = "embeddings")]


### PR DESCRIPTION
Adds the missing `hook post` guard so `[extraction] enabled = false` stops PostToolUse extraction and prevents new worker-generated Claude sessions.

Validated with formatting, build, and enabled/disabled queue smoke tests.

Fixes #424.
