### PR TITLE
fix: honor disabled extraction in PostToolUse hook

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2232,6 +2232,9 @@ fn main() -> Result<()> {
             let result = match command {
                 HookCommands::Pre => cmd_hook_pre(),
                 HookCommands::Post { every } => {
+                    if !cfg.extraction.enabled {
+                        return Ok(());
+                    }
                     // CLI flag wins over config; absent flag falls back to config.
                     let extract_every = every.unwrap_or(cfg.extraction.extract_every);
                     #[cfg(feature = "embeddings")]

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2232,9 +2232,6 @@ fn main() -> Result<()> {
             let result = match command {
                 HookCommands::Pre => cmd_hook_pre(),
                 HookCommands::Post { every } => {
-                    if !cfg.extraction.enabled {
-                        return Ok(());
-                    }
                     // CLI flag wins over config; absent flag falls back to config.
                     let extract_every = every.unwrap_or(cfg.extraction.extract_every);
                     #[cfg(feature = "embeddings")]
@@ -2245,6 +2242,7 @@ fn main() -> Result<()> {
                         &store,
                         emb_ref,
                         &cfg.memory,
+                        cfg.extraction.enabled,
                         extract_every,
                         cfg.extraction.store_raw,
                         &cfg.extraction.summarizer,
@@ -3408,6 +3406,7 @@ fn cmd_hook_post(
     store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
+    extraction_enabled: bool,
     extract_every: usize,
     store_raw: bool,
     extraction_summarizer: &crate::config::SummarizerConfig,
@@ -3463,6 +3462,13 @@ fn cmd_hook_post(
                 Some(tool_name),
             );
         }
+    }
+
+    // `[extraction].enabled = false` (issue #424) stops here — archive
+    // and code-areas capture above are independent features and must
+    // keep running regardless of this flag.
+    if !extraction_enabled {
+        return Ok(());
     }
 
     // Track tool calls in SQLite (atomic, persists across reboots)

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2266,10 +2266,8 @@ fn main() -> Result<()> {
                         &store,
                         emb_ref,
                         &cfg.memory,
-                        cfg.extraction.enabled,
                         extract_every,
-                        cfg.extraction.store_raw,
-                        &cfg.extraction.summarizer,
+                        &cfg.extraction,
                         &cfg.archive,
                     )
                 }
@@ -3430,10 +3428,8 @@ fn cmd_hook_post(
     store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
-    extraction_enabled: bool,
     extract_every: usize,
-    store_raw: bool,
-    extraction_summarizer: &crate::config::SummarizerConfig,
+    extraction_cfg: &crate::config::ExtractionConfig,
     archive_cfg: &crate::config::ArchiveConfig,
 ) -> Result<()> {
     let Some(input) = read_stdin_utf8_lossy() else {
@@ -3491,7 +3487,7 @@ fn cmd_hook_post(
     // `[extraction].enabled = false` (issue #424) stops here — archive
     // and code-areas capture above are independent features and must
     // keep running regardless of this flag.
-    if !extraction_enabled {
+    if !extraction_cfg.enabled {
         return Ok(());
     }
 
@@ -3525,7 +3521,7 @@ fn cmd_hook_post(
     // embedder. The worker (`icm extract-pending` / SessionEnd fork) will
     // dequeue and run the configured LLM CLI. ~50ms / fire vs ~3.7s
     // for the inline fastembed path below.
-    if extraction_summarizer.provider != "none" {
+    if extraction_cfg.summarizer.provider != "none" {
         // Cap to 8 KB to keep the queue reasonable. LLM extraction works
         // fine on the most recent slice; very long outputs are rare and
         // their tail is what matters most for auto-context anyway.
@@ -3534,7 +3530,7 @@ fn cmd_hook_post(
             Ok(_) => {
                 eprintln!(
                     "[icm] enqueued raw output for async LLM extraction (provider={})",
-                    extraction_summarizer.provider,
+                    extraction_cfg.summarizer.provider,
                 );
             }
             Err(e) => {
@@ -3556,7 +3552,7 @@ fn cmd_hook_post(
         store,
         capped_inline,
         &project,
-        store_raw,
+        extraction_cfg.store_raw,
         icm_core::Importance::Medium,
         embedder,
     ) {


### PR DESCRIPTION
Adds the missing `hook post` guard so `[extraction] enabled = false` stops PostToolUse extraction and prevents new worker-generated Claude sessions.

Validated with formatting, build, and enabled/disabled queue smoke tests.

Fixes #424.
