### PR TITLE
feat(init): install OpenCode skills natively with YAML frontmatter

### DIFF
--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -5071,6 +5071,43 @@ Do this BEFORE responding to the user. Not optional.
         } else {
             println!("[skill] {:<16} skipped (not detected)", "Pi");
         }
+
+        // OpenCode: https://opencode.ai/docs/skills/
+        // OpenCode skills require YAML frontmatter with name and description.
+        let opencode_skills_base = PathBuf::from(&home).join(".config/opencode/skills");
+        if force || detect_tool("OpenCode", &home, &vscode_data) {
+            let mut install = |name: &str, prompt: &str| -> Result<()> {
+                let skill_dir = opencode_skills_base.join(format!("icm-{name}"));
+                let skill_path = skill_dir.join("SKILL.md");
+                if let Ok(e) = install_manifest::InstallManifest::entry_from_disk(
+                    &skill_path,
+                    "OpenCode skill",
+                    install_manifest::EntryKind::OwnedFile,
+                ) {
+                    manifest.record(e);
+                }
+                let content = format!(
+                    "\
+---
+name: icm-{name}
+description: ICM persistent memory — /{name}
+---
+
+{prompt}"
+                );
+                install_skill(
+                    &skill_dir,
+                    "SKILL.md",
+                    &content,
+                    &format!("OpenCode /icm-{name}"),
+                )
+            };
+            install("recall", icm_recall_prompt)?;
+            install("remember", icm_remember_prompt)?;
+            install("remember-session", icm_remember_session_prompt)?;
+        } else {
+            println!("[skill] {:<16} skipped (not detected)", "OpenCode");
+        }
     }
 
     // --- Hook mode: install hooks for each detected tool ---

--- a/crates/icm-cli/src/uninstall/locations.rs
+++ b/crates/icm-cli/src/uninstall/locations.rs
@@ -381,6 +381,28 @@ pub(crate) fn build_locations(d: &DirContext) -> Vec<LocationSpec> {
         kind: K::OwnedFile,
         purge_data_only: false,
     });
+    let opencode_skills: &[(&str, &str)] = &[
+        (
+            "OpenCode /icm-recall",
+            ".config/opencode/skills/icm-recall/SKILL.md",
+        ),
+        (
+            "OpenCode /icm-remember",
+            ".config/opencode/skills/icm-remember/SKILL.md",
+        ),
+        (
+            "OpenCode /icm-remember-session",
+            ".config/opencode/skills/icm-remember-session/SKILL.md",
+        ),
+    ];
+    for (label, rel) in opencode_skills {
+        specs.push(LocationSpec {
+            label,
+            path: d.home.join(rel),
+            kind: K::OwnedFile,
+            purge_data_only: false,
+        });
+    }
 
     // --- Amp (dotted servers key + skills) ---
     specs.push(LocationSpec {
@@ -550,6 +572,9 @@ mod tests {
             "Zed MCP",
             "OpenCode MCP",
             "OpenCode plugin",
+            "OpenCode /icm-recall",
+            "OpenCode /icm-remember",
+            "OpenCode /icm-remember-session",
             "Amp MCP",
             "Amp /icm-recall",
             "Amp /icm-remember",


### PR DESCRIPTION
OpenCode skills require YAML frontmatter with name/description fields: https://opencode.ai/docs/skills/#write-frontmatter .

This adds native skill generation so `icm init` installs them directly.