### PR TITLE
fix(store): use as_chunks instead of chunks_exact for clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.54"
+version = "0.10.61"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/icm-store/src/store.rs
+++ b/crates/icm-store/src/store.rs
@@ -1027,8 +1027,10 @@ fn blob_to_embedding(blob: &[u8]) -> Vec<f32> {
             "embedding blob size not divisible by 4, truncating"
         );
     }
-    blob.chunks_exact(4)
-        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+    blob.as_chunks::<4>()
+        .0
+        .iter()
+        .map(|c| f32::from_le_bytes(*c))
         .collect()
 }
 


### PR DESCRIPTION
## Summary

`cargo clippy --workspace --all-targets -- -D warnings` was failing on `develop` (and consequently on every open PR's CI, e.g. #315) due to a new clippy lint (`chunks_exact_to_as_chunks`) flagging pre-existing code in `blob_to_embedding` (`crates/icm-store/src/store.rs`), unrelated to those PRs' own diffs.

Applies clippy's own suggested fix: `chunks_exact(4)` -> `as_chunks::<4>().0.iter()`.

Also refreshes a stale `Cargo.lock` version entry for `icm-cli` (0.10.54 -> 0.10.61) that a local build corrected — `Cargo.toml` was already at 0.10.61 since the develop/main sync merge.

## Verification

```
cargo clippy -p icm-store --all-targets -- -D warnings   # was failing, now clean
cargo clippy --workspace --all-targets -- -D warnings    # clean
cargo test -p icm-store                                   # 217 passed
```