### PR TITLE
ci(next-release): use pull_request_target so fork PRs update the changelog

### DIFF
--- a/.github/workflows/next-release.yml
+++ b/.github/workflows/next-release.yml
@@ -1,13 +1,22 @@
 name: Update Next Release PR
 
 on:
-  pull_request:
+  # pull_request_target (not pull_request): GitHub withholds repo secrets
+  # from `pull_request` runs whenever the PR's head is a fork — which is
+  # every external contributor's PR. That silently broke this workflow's
+  # GitHub App token mint (empty client-id) on every fork PR merge since
+  # this workflow was added, going unnoticed because same-repo branches
+  # (bundled bug-hunt work) kept succeeding and dominated the changelog.
+  # Safe here: this job never checks out fork code (no `actions/checkout`
+  # step), and untrusted PR title/body only ever flow through `env:` into
+  # quoted shell variables (never `eval`'d or template-interpolated into
+  # the script), so there's no code-execution path for a malicious PR to
+  # reach the minted token. Mirrors the same workflow on rtk-ai/rtk.
+  pull_request_target:
     types: [closed]
     branches: [develop]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   update-next-release:
@@ -16,11 +25,13 @@ jobs:
     steps:
       # The default workflow token cannot open PRs in this org; mint a
       # short-lived token from the configured GitHub App instead.
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         id: app-token
         with:
-          app-id: ${{ secrets.APP_CLIENT_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-pull-requests: write
 
       - name: Update Next Release PR
         env:


### PR DESCRIPTION
## Summary

`.github/workflows/next-release.yml` used `pull_request: types: [closed]`. GitHub withholds repository secrets from `pull_request`-triggered runs whenever the PR's head is a fork — which is every external contributor's PR. That silently broke the GitHub App token mint (`create-github-app-token` gets an empty `client-id`) on every fork PR merge since this workflow was added in May, going unnoticed because same-repo bug-hunt branches kept succeeding and dominated the "Next Release" PR's changelog.

6 of the 7 PRs merged into `develop` today (#315, #320, #427, #429, #430, #431) came from external contributors, so all 6 silently failed to add their entry to PR #407's body.

## Fix

Switch to `pull_request_target`, matching the already-proven config on `rtk-ai/rtk` (identical script). Safe here specifically because:
- This job never runs `actions/checkout` — no fork code is ever executed.
- The untrusted PR title/body only flow through `env:` into quoted shell variables (`$PR_TITLE`, `$PR_BODY`), never `eval`'d or template-interpolated into the script body — no code-execution path reaches the minted token.

Also bumps `create-github-app-token` to the current v3.2.0 (SHA `bcd2ba49218906704ab6c1aa796996da409d3eb1`, verified against the upstream `v3.2.0` release tag) with its `client-id`/`permission-*` input style, matching `rtk-ai/rtk`.

## Verification
- YAML syntax validated
- SHA pin verified against `actions/create-github-app-token`'s real release tag
- Confirmed via full run history (130 runs) that every past failure of this workflow correlates with a fork-originated PR, and every success correlates with a same-repo branch — pattern fully explains the failures without any other config change