### PR TITLE
feat(consolidate): async consolidation queue for LLM-backed summarization (#179)

### DIFF
--- a/crates/icm-cli/src/http_api.rs
+++ b/crates/icm-cli/src/http_api.rs
@@ -67,6 +67,9 @@ pub struct AppState {
     embedder: Option<Arc<dyn Embedder + Send + Sync>>,
     mcp_calls_since_store: Arc<Mutex<u32>>,
     auto_consolidate: icm_mcp::AutoConsolidate,
+    /// Operator-configured `[mcp] instructions` (issue #179 follow-up),
+    /// appended to the built-in MCP handshake instructions.
+    mcp_instructions: Option<Arc<str>>,
     /// When set, every request must carry `Authorization: Bearer <token>`.
     token: Option<String>,
 }
@@ -214,6 +217,7 @@ pub async fn run_http_server(
     addr: SocketAddr,
     token: Option<String>,
     auto_consolidate: icm_mcp::AutoConsolidate,
+    mcp_instructions: Option<String>,
 ) -> Result<()> {
     // A non-loopback bind with no token exposes the full memory store —
     // recall, store, consolidate — to anyone who can reach the interface,
@@ -228,6 +232,7 @@ pub async fn run_http_server(
         embedder: embedder.map(Arc::from),
         mcp_calls_since_store: Arc::new(Mutex::new(0)),
         auto_consolidate,
+        mcp_instructions: mcp_instructions.map(Arc::from),
         token,
     };
 
@@ -357,6 +362,7 @@ async fn handle_mcp(
         q.compact,
         state.auto_consolidate,
         &mut calls_since_store,
+        state.mcp_instructions.as_deref(),
     ) {
         Some(response) => Json(response).into_response(),
         None => StatusCode::NO_CONTENT.into_response(),
@@ -957,6 +963,7 @@ mod tests {
                 enabled: false,
                 threshold: 10,
             },
+            mcp_instructions: None,
             token: None,
         };
 
@@ -1024,6 +1031,7 @@ mod tests {
                 enabled: false,
                 threshold: 10,
             },
+            mcp_instructions: None,
             token: None,
         };
 

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2550,7 +2550,14 @@ fn main() -> Result<()> {
                     enabled: cfg.memory.auto_consolidate_enabled,
                     threshold: cfg.memory.auto_consolidate_threshold,
                 };
-                return http_api::run_http_server(store, boxed_emb, addr, token, auto_consolidate);
+                return http_api::run_http_server(
+                    store,
+                    boxed_emb,
+                    addr,
+                    token,
+                    auto_consolidate,
+                    cfg.mcp.instructions.clone(),
+                );
             }
             #[cfg(feature = "embeddings")]
             let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
@@ -2566,7 +2573,13 @@ fn main() -> Result<()> {
                 enabled: cfg.memory.auto_consolidate_enabled,
                 threshold: cfg.memory.auto_consolidate_threshold,
             };
-            icm_mcp::run_server(&store, emb_ref, use_compact, auto_consolidate)
+            icm_mcp::run_server(
+                &store,
+                emb_ref,
+                use_compact,
+                auto_consolidate,
+                cfg.mcp.instructions.as_deref(),
+            )
         }
         Commands::HookLog {
             limit,
@@ -4066,6 +4079,27 @@ fn cmd_hook_end(
     // no need to peek the count first.
     if consolidate_cfg.summarizer.provider != "none" {
         spawn_detached_worker(&["consolidate-pending", "--limit", "20"], "consolidation");
+    }
+
+    // Issue #179 follow-up: `icm hook start` / `icm wake-up` prefer a cached
+    // LLM briefing (#165) over the plain bullet pack when one exists — but
+    // until now nothing ever populated that cache automatically. A fresh
+    // install's SessionStart hook would silently keep serving the plain
+    // pack forever unless the user remembered to run `icm briefing`
+    // manually or wired their own cron. Refresh it here, off the critical
+    // path, same as the consolidation fork — rate-limited by
+    // `BRIEFING_REFRESH_INTERVAL` so a chatty session doesn't trigger an
+    // LLM call on every single SessionEnd.
+    if consolidate_cfg.summarizer.provider != "none" {
+        let project = detect_project();
+        let stale = project != "unknown"
+            && !project.is_empty()
+            && briefing_cache_path(&project)
+                .map(|p| briefing_cache_is_stale(&p, BRIEFING_REFRESH_INTERVAL))
+                .unwrap_or(true);
+        if stale {
+            spawn_detached_worker(&["briefing", "--project", project.as_str()], "briefing");
+        }
     }
 
     // Async path: when a provider is configured, drain the
@@ -8584,6 +8618,22 @@ fn load_cached_briefing(project: Option<&str>) -> Option<String> {
     load_cached_briefing_at(&briefing_cache_path(project?)?)
 }
 
+/// Minimum age before SessionEnd bothers regenerating the cached briefing
+/// (issue #179 follow-up) — keeps a chatty session from firing an LLM call
+/// on every single SessionEnd.
+const BRIEFING_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(6 * 3600);
+
+/// True if `path` is missing, unreadable, or older than `max_age` (pure,
+/// testable core of the SessionEnd auto-briefing-refresh trigger, issue #179
+/// follow-up). A cache that's never existed is treated as stale so the very
+/// first refresh actually fires.
+fn briefing_cache_is_stale(path: &std::path::Path, max_age: std::time::Duration) -> bool {
+    match std::fs::metadata(path).and_then(|m| m.modified()) {
+        Ok(modified) => modified.elapsed().map(|age| age > max_age).unwrap_or(true),
+        Err(_) => true,
+    }
+}
+
 /// Build the LLM prompt that compiles a project's memories into a structured
 /// wake-up briefing (issue #165).
 fn build_briefing_prompt(
@@ -10992,6 +11042,27 @@ mod hook_start_tests {
             load_cached_briefing_at(&path).unwrap(),
             "## State of work\n- shipping"
         );
+    }
+
+    #[test]
+    fn briefing_cache_is_stale_missing_fresh_and_old() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("b.md");
+
+        // Never existed → stale, so the very first refresh actually fires.
+        assert!(briefing_cache_is_stale(
+            &path,
+            std::time::Duration::from_secs(3600)
+        ));
+
+        std::fs::write(&path, "briefing").unwrap();
+        // Just written → not stale under a generous max_age.
+        assert!(!briefing_cache_is_stale(
+            &path,
+            std::time::Duration::from_secs(3600)
+        ));
+        // ... but stale under a max_age of zero (anything is "older").
+        assert!(briefing_cache_is_stale(&path, std::time::Duration::ZERO));
     }
 
     #[test]

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -295,6 +295,45 @@ enum Commands {
         dry_run: bool,
     },
 
+    /// Process the async consolidation queue (LLM-backed, issue #179).
+    /// Drains topics enqueued by the auto-consolidate path when
+    /// `consolidate.summarizer.provider != none` (which skips the
+    /// synchronous ~10-15s LLM call on the hot store path). Designed to
+    /// be invoked from a cron, the SessionEnd async fork, or manually.
+    ConsolidatePending {
+        /// Maximum jobs to process in this run.
+        #[arg(short, long, default_value = "10")]
+        limit: usize,
+
+        /// Optional CLI override of `consolidate.summarizer.provider`.
+        #[arg(long)]
+        provider: Option<String>,
+
+        /// Optional CLI override of `consolidate.summarizer.model`.
+        #[arg(long)]
+        model: Option<String>,
+
+        /// Don't actually call the LLM — just print what would be sent.
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// List async consolidation jobs (issue #179) — pending, done, or
+    /// failed, with the captured error for failures.
+    ConsolidateJobs {
+        /// Filter by status: pending | done | failed. All statuses when omitted.
+        #[arg(long)]
+        status: Option<String>,
+
+        /// Maximum rows to show.
+        #[arg(short, long, default_value = "20")]
+        limit: usize,
+
+        /// Reset a `failed` job back to `pending` so the next drain retries it.
+        #[arg(long, value_name = "ID")]
+        retry: Option<String>,
+    },
+
     /// Apply temporal decay to memory weights
     Decay {
         /// Decay factor (default: 0.95)
@@ -1993,6 +2032,7 @@ fn main() -> Result<()> {
                 &store,
                 emb_ref,
                 &cfg.memory,
+                &cfg.consolidate,
                 topic,
                 content,
                 importance.into(),
@@ -2014,6 +2054,7 @@ fn main() -> Result<()> {
                 &store,
                 emb_ref,
                 &cfg.memory,
+                &cfg.consolidate,
                 content,
                 topic,
                 importance.into(),
@@ -2241,6 +2282,29 @@ fn main() -> Result<()> {
                 emb_ref,
             )
         }
+        Commands::ConsolidatePending {
+            limit,
+            provider,
+            model,
+            dry_run,
+        } => {
+            let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
+            cmd_consolidate_pending(
+                &store,
+                emb_ref,
+                &cfg.consolidate.summarizer,
+                limit,
+                provider.as_deref(),
+                model.as_deref(),
+                dry_run,
+                &db_path,
+            )
+        }
+        Commands::ConsolidateJobs {
+            status,
+            limit,
+            retry,
+        } => cmd_consolidate_jobs(&store, status.as_deref(), limit, retry.as_deref()),
         Commands::Embed {
             topic,
             force,
@@ -2415,6 +2479,7 @@ fn main() -> Result<()> {
                 &store,
                 emb_ref,
                 &cfg.memory,
+                &cfg.consolidate,
                 &content,
                 importance.into(),
                 keywords,
@@ -2539,6 +2604,7 @@ fn main() -> Result<()> {
                         &store,
                         emb_ref,
                         &cfg.memory,
+                        &cfg.consolidate,
                         extract_every,
                         &cfg.extraction,
                         &cfg.archive,
@@ -2549,7 +2615,7 @@ fn main() -> Result<()> {
                     let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
                     #[cfg(not(feature = "embeddings"))]
                     let emb_ref: Option<&dyn icm_core::Embedder> = None;
-                    cmd_hook_compact(&store, emb_ref, &cfg.memory)
+                    cmd_hook_compact(&store, emb_ref, &cfg.memory, &cfg.consolidate)
                 }
                 HookCommands::Prompt => cmd_hook_prompt(&store, &cfg.archive),
                 HookCommands::Start { max_tokens } => {
@@ -2565,7 +2631,13 @@ fn main() -> Result<()> {
                     let emb_ref = embedder.as_ref().map(|e| e as &dyn icm_core::Embedder);
                     #[cfg(not(feature = "embeddings"))]
                     let emb_ref: Option<&dyn icm_core::Embedder> = None;
-                    cmd_hook_end(&store, emb_ref, &cfg.memory, &cfg.extraction.summarizer)
+                    cmd_hook_end(
+                        &store,
+                        emb_ref,
+                        &cfg.memory,
+                        &cfg.consolidate,
+                        &cfg.extraction.summarizer,
+                    )
                 }
                 // Dispatched before `open_store`; this arm only exists for
                 // match exhaustiveness and is unreachable.
@@ -2622,10 +2694,40 @@ fn maybe_auto_consolidate(
     embedder: Option<&dyn icm_core::Embedder>,
     topic: &str,
     cfg: &crate::config::MemoryConfig,
+    consolidate_cfg: &crate::config::ConsolidateConfig,
 ) {
     if !cfg.auto_consolidate_enabled {
         return;
     }
+
+    // Issue #179: with an LLM summarizer configured, the synchronous
+    // consolidation below would block the hot store path for ~10-15s
+    // (a `claude -p` round trip) — fine on demand (`icm consolidate`),
+    // unacceptable inline on every `store()`/hook fire. Enqueue instead
+    // and let `icm consolidate-pending` (or the SessionEnd async fork)
+    // do the LLM call off the critical path. Lexical (`provider = "none"`,
+    // the default) keeps running inline — zero behavior change.
+    //
+    // Threshold check happens here, before enqueueing — otherwise every
+    // single store() would queue a job regardless of topic size, and
+    // `auto_consolidate_with_embedder`'s own no-op-below-threshold guard
+    // never gets a chance to run (it's skipped entirely on this branch).
+    if consolidate_cfg.summarizer.provider != "none" {
+        match store.count_by_topic(topic) {
+            Ok(n) if n > cfg.auto_consolidate_threshold => {
+                match store.enqueue_pending_consolidation(topic, "") {
+                    Ok(_) => eprintln!("[icm] enqueued topic '{topic}' for async consolidation"),
+                    Err(e) => {
+                        tracing::warn!("enqueue consolidation failed for topic '{topic}': {e}")
+                    }
+                }
+            }
+            Ok(_) => {} // below threshold — no-op, same as the sync path
+            Err(e) => tracing::warn!("count_by_topic failed for '{topic}': {e}"),
+        }
+        return;
+    }
+
     match store.auto_consolidate_with_embedder(topic, cfg.auto_consolidate_threshold, embedder) {
         Ok(true) => eprintln!(
             "[icm] auto-consolidated topic '{topic}' (exceeded {} entries)",
@@ -2641,6 +2743,7 @@ fn cmd_store(
     store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
+    consolidate_cfg: &crate::config::ConsolidateConfig,
     topic: String,
     content: String,
     importance: Importance,
@@ -2700,7 +2803,7 @@ fn cmd_store(
                 "Updated existing memory (similarity {score:.2}): {}",
                 updated.id
             );
-            maybe_auto_consolidate(store, embedder, &topic, memory_cfg);
+            maybe_auto_consolidate(store, embedder, &topic, memory_cfg, consolidate_cfg);
             return Ok(());
         }
     }
@@ -2737,7 +2840,7 @@ fn cmd_store(
     }
 
     // Auto-consolidate the topic if config says so. Closes audit M2/AC1.
-    maybe_auto_consolidate(store, embedder, &topic, memory_cfg);
+    maybe_auto_consolidate(store, embedder, &topic, memory_cfg, consolidate_cfg);
 
     Ok(())
 }
@@ -2749,6 +2852,7 @@ fn cmd_remember(
     store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
+    consolidate_cfg: &crate::config::ConsolidateConfig,
     content: String,
     topic: Option<String>,
     importance: Importance,
@@ -2766,6 +2870,7 @@ fn cmd_remember(
         store,
         embedder,
         memory_cfg,
+        consolidate_cfg,
         resolved_topic,
         content,
         importance,
@@ -3697,10 +3802,12 @@ fn extract_tool_input_file_path(json: &Value) -> Option<String> {
 /// 2. **Inline path** (default, `provider = "none"`). Current
 ///    fastembed semantic-scoring extractor — multilingual, but pays
 ///    a ~3.7s model-load cost per process.
+#[allow(clippy::too_many_arguments)]
 fn cmd_hook_post(
     store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
+    consolidate_cfg: &crate::config::ConsolidateConfig,
     extract_every: usize,
     extraction_cfg: &crate::config::ExtractionConfig,
     archive_cfg: &crate::config::ArchiveConfig,
@@ -3835,7 +3942,7 @@ fn cmd_hook_post(
             // If the user has auto-consolidate enabled, fire it now so the
             // hook path stops bypassing the rollup.
             let topic = format!("context-{project}");
-            maybe_auto_consolidate(store, embedder, &topic, memory_cfg);
+            maybe_auto_consolidate(store, embedder, &topic, memory_cfg, consolidate_cfg);
         }
         _ => {}
     }
@@ -3848,8 +3955,9 @@ fn cmd_hook_compact(
     store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
+    consolidate_cfg: &crate::config::ConsolidateConfig,
 ) -> Result<()> {
-    extract_from_hook_transcript(store, embedder, memory_cfg, "pre-compact")
+    extract_from_hook_transcript(store, embedder, memory_cfg, consolidate_cfg, "pre-compact")
 }
 
 // ── Hook telemetry CLI ─────────────────────────────────────────────────
@@ -3936,6 +4044,7 @@ fn cmd_hook_end(
     store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
+    consolidate_cfg: &crate::config::ConsolidateConfig,
     extraction_summarizer: &crate::config::SummarizerConfig,
 ) -> Result<()> {
     // Reentrancy guard (#322): if this hook is firing inside an
@@ -3947,6 +4056,16 @@ fn cmd_hook_end(
     // transcript worth extracting anyway.
     if std::env::var_os("ICM_WORKER").is_some() {
         return Ok(());
+    }
+
+    // Issue #179: same detached-worker pattern as the extraction queue
+    // below, but for pending_consolidations. Independent of the
+    // extraction fork — a user can have one provider configured without
+    // the other. `consolidate-pending` is cheap to invoke even when the
+    // queue is empty (prints "No pending consolidations." and exits), so
+    // no need to peek the count first.
+    if consolidate_cfg.summarizer.provider != "none" {
+        spawn_detached_worker(&["consolidate-pending", "--limit", "20"], "consolidation");
     }
 
     // Async path: when a provider is configured, drain the
@@ -3994,6 +4113,7 @@ fn cmd_hook_end(
                         store,
                         embedder,
                         memory_cfg,
+                        consolidate_cfg,
                         "session-end",
                     );
                 }
@@ -4002,7 +4122,43 @@ fn cmd_hook_end(
         }
     }
     // Inline path (legacy): scan transcript and extract via fastembed.
-    extract_from_hook_transcript(store, embedder, memory_cfg, "session-end")
+    extract_from_hook_transcript(store, embedder, memory_cfg, consolidate_cfg, "session-end")
+}
+
+/// Fork a detached, `ICM_WORKER`-tagged copy of this binary running
+/// `args`, redirected to `/dev/null` and set to outlive the parent (Unix:
+/// new session via `setsid`). Used by the SessionEnd hook to drain async
+/// queues (extraction, consolidation) off the critical path without
+/// Claude Code killing us with "Hook cancelled". Failure is logged, not
+/// propagated — the caller has its own inline fallback (extraction) or
+/// simply skips this round (consolidation, picked up on the next
+/// SessionEnd or a manual `icm consolidate-pending`).
+fn spawn_detached_worker(args: &[&str], label: &str) {
+    let Ok(self_path) = std::env::current_exe() else {
+        return;
+    };
+    let mut cmd = std::process::Command::new(&self_path);
+    cmd.args(args);
+    // Mark the worker subtree (#322) so any hook fired by an LLM CLI it
+    // spawns short-circuits instead of forking again.
+    cmd.env("ICM_WORKER", "1");
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            cmd.pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            });
+        }
+    }
+    match cmd.spawn() {
+        Ok(_) => eprintln!("[icm] session-end: forked async {label} worker"),
+        Err(e) => eprintln!("[icm] session-end: {label} worker fork failed ({e}), skipping"),
+    }
 }
 
 /// Read JSON from stdin, locate the transcript file, parse the last 100
@@ -4015,6 +4171,7 @@ fn extract_from_hook_transcript(
     store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
+    consolidate_cfg: &crate::config::ConsolidateConfig,
     source: &str,
 ) -> Result<()> {
     let Some(input) = read_stdin_utf8_lossy() else {
@@ -4155,7 +4312,7 @@ fn extract_from_hook_transcript(
             // so the PreCompact / SessionEnd path stops bypassing the
             // rollup configured in `[memory] auto_consolidate_enabled`.
             let topic = format!("context-{project}");
-            maybe_auto_consolidate(store, embedder, &topic, memory_cfg);
+            maybe_auto_consolidate(store, embedder, &topic, memory_cfg, consolidate_cfg);
         }
         _ => {}
     }
@@ -7562,11 +7719,15 @@ impl WorkerLock {
     /// Try to take the lock next to the DB. `Ok(Some(_))` = acquired,
     /// `Ok(None)` = another process already holds it, `Err` = the lockfile
     /// itself could not be created (caller may proceed without the guard).
-    fn acquire(db_path: &std::path::Path) -> Result<Option<Self>> {
+    ///
+    /// `kind` names the lockfile (e.g. `"extract"`, `"consolidate"`) so
+    /// independent async workers (issue #179) don't contend on the same
+    /// advisory lock and can run concurrently with each other.
+    fn acquire(db_path: &std::path::Path, kind: &str) -> Result<Option<Self>> {
         #[cfg(unix)]
         {
             use std::os::unix::io::AsRawFd;
-            let lock_path = db_path.with_extension("extract.lock");
+            let lock_path = db_path.with_extension(format!("{kind}.lock"));
             let file = std::fs::OpenOptions::new()
                 .create(true)
                 .write(true)
@@ -7591,7 +7752,7 @@ impl WorkerLock {
         }
         #[cfg(not(unix))]
         {
-            let _ = db_path;
+            let _ = (db_path, kind);
             Ok(Some(Self {}))
         }
     }
@@ -7663,7 +7824,7 @@ fn cmd_extract_pending(
     let _lock = if dry_run {
         None
     } else {
-        match WorkerLock::acquire(db_path) {
+        match WorkerLock::acquire(db_path, "extract") {
             Ok(Some(l)) => Some(l),
             Ok(None) => {
                 println!("Another extract-pending worker is already running; skipping.");
@@ -8107,6 +8268,147 @@ fn cmd_consolidate_all(
     Ok(())
 }
 
+/// `icm consolidate-pending` — drain the async consolidation queue (issue
+/// #179). Unlike `consolidate-all`'s cron-style topic scan, this only
+/// processes topics explicitly enqueued by [`maybe_auto_consolidate`] (the
+/// synchronous auto-consolidate trigger, once an LLM summarizer is
+/// configured — the whole point being to move that ~10-15s LLM call off the
+/// hot `icm store` path). Reuses [`cmd_consolidate`] per job, same as
+/// `consolidate-all` reuses it per topic; never keeps originals, for the
+/// same idempotency reason (a just-consolidated topic collapses under the
+/// threshold and won't be re-enqueued).
+#[allow(clippy::too_many_arguments)]
+fn cmd_consolidate_pending(
+    store: &Store,
+    embedder: Option<&dyn icm_core::Embedder>,
+    cfg: &config::SummarizerConfig,
+    limit: usize,
+    cli_provider: Option<&str>,
+    cli_model: Option<&str>,
+    dry_run: bool,
+    db_path: &std::path::Path,
+) -> Result<()> {
+    // Separate lockfile from the extraction worker (see WorkerLock::acquire)
+    // so the two async queues can drain concurrently — they touch disjoint
+    // tables and neither holds a long-running transaction across rows.
+    let _lock = if dry_run {
+        None
+    } else {
+        match WorkerLock::acquire(db_path, "consolidate") {
+            Ok(Some(l)) => Some(l),
+            Ok(None) => {
+                println!("Another consolidate-pending worker is already running; skipping.");
+                return Ok(());
+            }
+            Err(e) => {
+                eprintln!(
+                    "[consolidate-pending] lock unavailable ({e}); proceeding without singleton guard"
+                );
+                None
+            }
+        }
+    };
+
+    let jobs = store.list_pending_consolidation_jobs(limit)?;
+    if jobs.is_empty() {
+        println!("No pending consolidations.");
+        return Ok(());
+    }
+
+    if dry_run {
+        println!("=== Dry run ===");
+        println!("jobs: {}", jobs.len());
+        for job in &jobs {
+            println!("  {} — topic '{}'", job.id, job.topic);
+        }
+        return Ok(());
+    }
+
+    let mut done = 0usize;
+    let mut failed = 0usize;
+    for job in &jobs {
+        println!("[consolidate-pending] {} (topic '{}')…", job.id, job.topic);
+        match cmd_consolidate(
+            store,
+            &job.topic,
+            false,
+            cfg,
+            cli_provider,
+            cli_model,
+            None,
+            embedder,
+        ) {
+            Ok(()) => {
+                if let Err(e) = store.mark_consolidation_job_done(&job.id) {
+                    tracing::warn!("mark_consolidation_job_done failed for {}: {e}", job.id);
+                }
+                done += 1;
+            }
+            Err(e) => {
+                eprintln!(
+                    "[consolidate-pending] job {} (topic '{}') failed: {e}",
+                    job.id, job.topic
+                );
+                if let Err(e2) = store.mark_consolidation_job_failed(&job.id, &e.to_string()) {
+                    tracing::warn!("mark_consolidation_job_failed failed for {}: {e2}", job.id);
+                }
+                failed += 1;
+            }
+        }
+    }
+
+    println!();
+    if failed == 0 {
+        println!("Processed {done} job(s).");
+    } else {
+        println!("Processed {done} job(s); {failed} failed (see errors above, retry with `icm consolidate-jobs --retry <id>`).");
+    }
+    Ok(())
+}
+
+/// `icm consolidate-jobs` — list async consolidation jobs (issue #179), or
+/// with `--retry <id>`, reset one `failed` job back to `pending` so the next
+/// `consolidate-pending` drain picks it up again.
+fn cmd_consolidate_jobs(
+    store: &Store,
+    status: Option<&str>,
+    limit: usize,
+    retry: Option<&str>,
+) -> Result<()> {
+    if let Some(id) = retry {
+        return if store.retry_consolidation_job(id)? {
+            println!("Job {id} reset to pending.");
+            Ok(())
+        } else {
+            bail!("job {id} not found or not in 'failed' status — nothing to retry");
+        };
+    }
+
+    let jobs = store.list_consolidation_jobs(status, limit)?;
+    if jobs.is_empty() {
+        println!("No consolidation jobs.");
+        return Ok(());
+    }
+    for job in &jobs {
+        let completed = job
+            .completed_at
+            .map(|d| d.to_rfc3339())
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "{}  {:<8}  {:<30}  created={}  completed={}",
+            job.id,
+            job.status,
+            job.topic,
+            job.created_at.to_rfc3339(),
+            completed
+        );
+        if let Some(err) = &job.error {
+            println!("    error: {err}");
+        }
+    }
+    Ok(())
+}
+
 fn cmd_extract(
     store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
@@ -8537,6 +8839,7 @@ fn cmd_save_project(
     store: &Store,
     embedder: Option<&dyn icm_core::Embedder>,
     memory_cfg: &crate::config::MemoryConfig,
+    consolidate_cfg: &crate::config::ConsolidateConfig,
     content: &str,
     importance: Importance,
     keywords: Option<String>,
@@ -8550,6 +8853,7 @@ fn cmd_save_project(
         store,
         embedder,
         memory_cfg,
+        consolidate_cfg,
         topic,
         content.to_string(),
         importance,
@@ -10889,11 +11193,11 @@ mod hook_start_tests {
         let dir = tempfile::tempdir().unwrap();
         let db = dir.path().join("memories.db");
 
-        let first = WorkerLock::acquire(&db).unwrap();
+        let first = WorkerLock::acquire(&db, "extract").unwrap();
         assert!(first.is_some(), "first acquire should succeed");
 
         // Held: a concurrent acquire is refused (Ok(None)), not an error.
-        let second = WorkerLock::acquire(&db).unwrap();
+        let second = WorkerLock::acquire(&db, "extract").unwrap();
         assert!(
             second.is_none(),
             "second acquire must be refused while held"
@@ -10901,7 +11205,7 @@ mod hook_start_tests {
 
         // Release, then the lock is available again.
         drop(first);
-        let third = WorkerLock::acquire(&db).unwrap();
+        let third = WorkerLock::acquire(&db, "extract").unwrap();
         assert!(third.is_some(), "acquire should succeed after release");
     }
 
@@ -12047,6 +12351,135 @@ mod cli_contracts_tests {
         assert_eq!(http_proxy.as_deref(), Some("http://127.0.0.1:11435"));
         assert_eq!(token.as_deref(), Some("secret"));
     }
+
+    /// Issue #179 regression test: `maybe_auto_consolidate` must only
+    /// enqueue a job once the topic actually exceeds the threshold — an
+    /// earlier draft enqueued unconditionally whenever an LLM summarizer
+    /// was configured, which would have queued a job on every single
+    /// `store()` call regardless of topic size.
+    #[test]
+    fn maybe_auto_consolidate_enqueues_only_over_threshold() {
+        let store = Store::in_memory_with_dims(64).unwrap();
+        let memory_cfg = crate::config::MemoryConfig {
+            auto_consolidate_enabled: true,
+            auto_consolidate_threshold: 3,
+            ..Default::default()
+        };
+        let mut consolidate_cfg = crate::config::ConsolidateConfig::default();
+        consolidate_cfg.summarizer.provider = "claude".to_string();
+
+        for i in 0..3 {
+            store
+                .store(Memory::new(
+                    "t".to_string(),
+                    format!("fact {i}"),
+                    Importance::Medium,
+                ))
+                .unwrap();
+        }
+
+        // At exactly the threshold — must not enqueue yet (same `> threshold`
+        // semantics as the pre-existing sync path).
+        maybe_auto_consolidate(&store, None, "t", &memory_cfg, &consolidate_cfg);
+        assert_eq!(
+            store.pending_consolidation_count().unwrap(),
+            0,
+            "must not enqueue at exactly the threshold"
+        );
+
+        store
+            .store(Memory::new(
+                "t".to_string(),
+                "fact 3".to_string(),
+                Importance::Medium,
+            ))
+            .unwrap();
+
+        // Now over threshold — must enqueue exactly one job.
+        maybe_auto_consolidate(&store, None, "t", &memory_cfg, &consolidate_cfg);
+        assert_eq!(store.pending_consolidation_count().unwrap(), 1);
+
+        let jobs = store.list_pending_consolidation_jobs(10).unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].topic, "t");
+        assert_eq!(jobs[0].status, "pending");
+
+        // A second store() over an already-enqueued topic must not pile up
+        // duplicate jobs beyond what the drain will process — verifies the
+        // enqueue call itself is idempotent-friendly per invocation (each
+        // call adds one row; that's fine, the drain processes and marks
+        // them done rather than needing DB-level dedup).
+        maybe_auto_consolidate(&store, None, "t", &memory_cfg, &consolidate_cfg);
+        assert!(store.pending_consolidation_count().unwrap() >= 1);
+    }
+
+    /// End-to-end for issue #179: `cmd_consolidate_pending` must drain a
+    /// queued job, actually consolidate the topic (provider=none exercises
+    /// the lexical fallback so the test has no LLM CLI dependency), and
+    /// mark the job `done`. `cmd_consolidate_jobs` must then list it.
+    #[test]
+    fn consolidate_pending_drains_job_and_marks_done() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("memories.db");
+        let store = Store::with_dims(&db_path, 64).unwrap();
+
+        for i in 0..4 {
+            store
+                .store(Memory::new(
+                    "t".to_string(),
+                    format!("fact {i}"),
+                    Importance::Medium,
+                ))
+                .unwrap();
+        }
+        let job_id = store.enqueue_pending_consolidation("t", "").unwrap();
+
+        let cfg = config::SummarizerConfig::default(); // provider = "none" → lexical join
+        cmd_consolidate_pending(&store, None, &cfg, 10, None, None, false, &db_path).unwrap();
+
+        let jobs = store.list_consolidation_jobs(None, 10).unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].id, job_id);
+        assert_eq!(jobs[0].status, "done");
+        assert!(jobs[0].completed_at.is_some());
+        assert!(store
+            .list_pending_consolidation_jobs(10)
+            .unwrap()
+            .is_empty());
+
+        // The topic itself must actually be consolidated (4 memories -> 1).
+        let remaining = store.get_by_topic("t").unwrap();
+        assert_eq!(remaining.len(), 1);
+    }
+
+    /// `cmd_consolidate_pending` on a job whose topic no longer has any
+    /// memories (e.g. it was manually consolidated/deleted between enqueue
+    /// and drain) must mark the job `failed` with a captured error rather
+    /// than panicking or silently dropping the job.
+    #[test]
+    fn consolidate_pending_marks_failed_job_with_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("memories.db");
+        let store = Store::with_dims(&db_path, 64).unwrap();
+
+        let job_id = store
+            .enqueue_pending_consolidation("does-not-exist", "")
+            .unwrap();
+
+        let cfg = config::SummarizerConfig::default();
+        cmd_consolidate_pending(&store, None, &cfg, 10, None, None, false, &db_path).unwrap();
+
+        let jobs = store.list_consolidation_jobs(Some("failed"), 10).unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].id, job_id);
+        assert!(jobs[0].error.is_some());
+
+        // `icm consolidate-jobs --retry <id>` must reset it back to pending.
+        cmd_consolidate_jobs(&store, None, 10, Some(&job_id)).unwrap();
+        let jobs = store.list_consolidation_jobs(Some("pending"), 10).unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].id, job_id);
+    }
 }
 
 #[cfg(test)]
@@ -12633,11 +13066,13 @@ mod cmd_remember_tests {
         use icm_store::Store;
         let store = Store::in_memory().unwrap();
         let cfg = crate::config::MemoryConfig::default();
+        let consolidate_cfg = crate::config::ConsolidateConfig::default();
 
         cmd_store(
             &store,
             None,
             &cfg,
+            &consolidate_cfg,
             "icm".into(),
             "TODO: wire FTS5 trigger for memory updates".into(),
             Importance::Medium,
@@ -12650,6 +13085,7 @@ mod cmd_remember_tests {
             &store,
             None,
             &cfg,
+            &consolidate_cfg,
             "FTS5 trigger now syncs on update; closes the recall gap".into(),
             Some("icm".into()),
             Importance::Medium,

--- a/crates/icm-mcp/src/server.rs
+++ b/crates/icm-mcp/src/server.rs
@@ -58,6 +58,7 @@ pub fn run_server(
     embedder: Option<&dyn Embedder>,
     compact: bool,
     auto_consolidate: AutoConsolidate,
+    extra_instructions: Option<&str>,
 ) -> anyhow::Result<()> {
     let stdin = io::stdin();
     let mut reader = stdin.lock();
@@ -110,6 +111,7 @@ pub fn run_server(
             compact,
             auto_consolidate,
             &mut calls_since_store,
+            extra_instructions,
         ) {
             write_response(&mut stdout, &response)?;
         }
@@ -118,6 +120,7 @@ pub fn run_server(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn handle_json_rpc_message(
     msg: JsonRpcMessage,
     store: &Store,
@@ -125,6 +128,7 @@ pub fn handle_json_rpc_message(
     compact: bool,
     auto_consolidate: AutoConsolidate,
     calls_since_store: &mut u32,
+    extra_instructions: Option<&str>,
 ) -> Option<JsonRpcResponse> {
     let method = msg.method.as_deref().unwrap_or("");
     debug!("MCP request: {method}");
@@ -132,7 +136,7 @@ pub fn handle_json_rpc_message(
     let id = msg.id?;
 
     Some(match method {
-        "initialize" => handle_initialize(id),
+        "initialize" => handle_initialize(id, extra_instructions),
         "ping" => JsonRpcResponse::ok(id, json!({})),
         "tools/list" => handle_tools_list(id, embedder.is_some()),
         "tools/call" => handle_tools_call(
@@ -155,7 +159,18 @@ fn write_response(stdout: &mut io::Stdout, resp: &JsonRpcResponse) -> anyhow::Re
     Ok(())
 }
 
-fn handle_initialize(id: Value) -> JsonRpcResponse {
+/// `extra_instructions` is the operator-configured `[mcp] instructions`
+/// value (issue #179 follow-up): previously that config field was parsed
+/// but never actually reached the MCP handshake, so setting it in
+/// `config.toml` silently did nothing. Appended, not a replacement — the
+/// built-in recall/store guidance still applies to every client.
+fn handle_initialize(id: Value, extra_instructions: Option<&str>) -> JsonRpcResponse {
+    let instructions = match extra_instructions {
+        Some(extra) if !extra.trim().is_empty() => {
+            format!("{ICM_INSTRUCTIONS}\n\n{}", extra.trim())
+        }
+        _ => ICM_INSTRUCTIONS.to_string(),
+    };
     JsonRpcResponse::ok(
         id,
         json!({
@@ -167,7 +182,7 @@ fn handle_initialize(id: Value) -> JsonRpcResponse {
                 "name": SERVER_NAME,
                 "version": SERVER_VERSION
             },
-            "instructions": ICM_INSTRUCTIONS
+            "instructions": instructions
         }),
     )
 }
@@ -246,4 +261,45 @@ fn handle_tools_call(
     }
 
     JsonRpcResponse::ok(id, serde_json::to_value(result).unwrap_or(json!(null)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #179 follow-up: `[mcp] instructions` in config.toml was parsed
+    /// (`config::McpConfig::instructions`) but never actually reached the
+    /// MCP `initialize` handshake — setting it silently did nothing. This
+    /// locks in that the value now really is appended to the built-in
+    /// guidance sent to every client.
+    #[test]
+    fn initialize_appends_configured_extra_instructions() {
+        let resp = handle_initialize(json!(1), Some("Also: this project uses Rust 2021."));
+        let instructions = resp.result.unwrap()["instructions"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(instructions.contains(ICM_INSTRUCTIONS));
+        assert!(instructions.contains("Also: this project uses Rust 2021."));
+    }
+
+    #[test]
+    fn initialize_omits_extra_instructions_when_unset() {
+        let resp = handle_initialize(json!(1), None);
+        let instructions = resp.result.unwrap()["instructions"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(instructions, ICM_INSTRUCTIONS);
+    }
+
+    #[test]
+    fn initialize_treats_blank_extra_instructions_as_unset() {
+        let resp = handle_initialize(json!(1), Some("   \n  "));
+        let instructions = resp.result.unwrap()["instructions"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(instructions, ICM_INSTRUCTIONS);
+    }
 }

--- a/crates/icm-store/src/backend.rs
+++ b/crates/icm-store/src/backend.rs
@@ -18,7 +18,9 @@ use icm_core::{
     TranscriptHit, TranscriptStats, TranscriptStore,
 };
 
-use crate::common::{CodeArea, HookEvent, HookEventInsert, HookStatsRow, PendingRow};
+use crate::common::{
+    CodeArea, ConsolidationJob, HookEvent, HookEventInsert, HookStatsRow, PendingRow,
+};
 
 #[cfg(feature = "backend-sqlite")]
 use crate::store::SqliteStore;
@@ -443,6 +445,40 @@ impl Store {
     }
     pub fn pending_extraction_count(&self) -> IcmResult<usize> {
         dispatch!(self, pending_extraction_count())
+    }
+    /// Enqueue a topic for async LLM consolidation (issue #179). Returns
+    /// the generated job id.
+    pub fn enqueue_pending_consolidation(&self, topic: &str, project: &str) -> IcmResult<String> {
+        dispatch!(self, enqueue_pending_consolidation(topic, project))
+    }
+    pub fn list_pending_consolidation_jobs(
+        &self,
+        limit: usize,
+    ) -> IcmResult<Vec<ConsolidationJob>> {
+        dispatch!(self, list_pending_consolidation_jobs(limit))
+    }
+    /// List consolidation jobs, optionally filtered by status
+    /// (`pending` | `done` | `failed`). Used by `icm consolidate-jobs`.
+    pub fn list_consolidation_jobs(
+        &self,
+        status: Option<&str>,
+        limit: usize,
+    ) -> IcmResult<Vec<ConsolidationJob>> {
+        dispatch!(self, list_consolidation_jobs(status, limit))
+    }
+    pub fn mark_consolidation_job_done(&self, id: &str) -> IcmResult<()> {
+        dispatch!(self, mark_consolidation_job_done(id))
+    }
+    pub fn mark_consolidation_job_failed(&self, id: &str, error: &str) -> IcmResult<()> {
+        dispatch!(self, mark_consolidation_job_failed(id, error))
+    }
+    /// Reset a `failed` job back to `pending` so the next drain retries
+    /// it. Returns `false` if the id doesn't exist or isn't `failed`.
+    pub fn retry_consolidation_job(&self, id: &str) -> IcmResult<bool> {
+        dispatch!(self, retry_consolidation_job(id))
+    }
+    pub fn pending_consolidation_count(&self) -> IcmResult<usize> {
+        dispatch!(self, pending_consolidation_count())
     }
     pub fn upsert_code_area(
         &self,

--- a/crates/icm-store/src/common.rs
+++ b/crates/icm-store/src/common.rs
@@ -68,3 +68,19 @@ pub struct HookStatsRow {
 /// `(id, project, tool_name, raw_output, captured_at)` where
 /// `captured_at` is RFC3339.
 pub type PendingRow = (String, String, String, String, String);
+
+/// One row of the async consolidation queue (issue #179). Unlike the
+/// extraction queue's fire-and-delete rows, jobs keep their status after
+/// processing so `icm consolidate-jobs` can show completed/failed history
+/// and a failed job can be retried instead of silently vanishing.
+#[derive(Debug, Clone)]
+pub struct ConsolidationJob {
+    pub id: String,
+    pub topic: String,
+    pub project: String,
+    /// `"pending"` | `"done"` | `"failed"`.
+    pub status: String,
+    pub error: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+}

--- a/crates/icm-store/src/opensearch/connection.rs
+++ b/crates/icm-store/src/opensearch/connection.rs
@@ -251,6 +251,17 @@ impl OpenSearchStore {
             }}}),
         )?;
         self.create_index(
+            IDX_CONSOLIDATION_JOBS,
+            json!({"mappings": {"properties": {
+                "topic": {"type": "keyword"},
+                "project": {"type": "keyword"},
+                "status": {"type": "keyword"},
+                "error": {"type": "text"},
+                "created_at": {"type": "date"},
+                "completed_at": {"type": "date"}
+            }}}),
+        )?;
+        self.create_index(
             IDX_CODE_AREAS,
             json!({"mappings": {"properties": {
                 "project": {"type": "keyword"},

--- a/crates/icm-store/src/opensearch/hooks.rs
+++ b/crates/icm-store/src/opensearch/hooks.rs
@@ -97,6 +97,175 @@ impl OpenSearchStore {
         Ok(resp.get("count").and_then(|v| v.as_u64()).unwrap_or(0) as usize)
     }
 
+    // Async consolidation queue (issue #179)
+
+    pub fn enqueue_pending_consolidation(&self, topic: &str, project: &str) -> IcmResult<String> {
+        let id = ulid::Ulid::new().to_string();
+        self.request(
+            "PUT",
+            &format!(
+                "{IDX_CONSOLIDATION_JOBS}/_doc/{id}?{}",
+                self.refresh_param()
+            ),
+            Some(json!({
+                "topic": topic,
+                "project": project,
+                "status": "pending",
+                "created_at": Utc::now().to_rfc3339()
+            })),
+            false,
+        )?;
+        Ok(id)
+    }
+
+    fn hit_to_consolidation_job(h: &Value) -> Option<ConsolidationJob> {
+        let id = h.get("_id")?.as_str()?.to_string();
+        let s = h.get("_source")?;
+        let created_at = s.get("created_at")?.as_str()?;
+        Some(ConsolidationJob {
+            id,
+            topic: s.get("topic")?.as_str()?.to_string(),
+            project: s
+                .get("project")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            status: s.get("status")?.as_str()?.to_string(),
+            error: s.get("error").and_then(|v| v.as_str()).map(String::from),
+            created_at: created_at.parse().unwrap_or_else(|_| Utc::now()),
+            completed_at: s
+                .get("completed_at")
+                .and_then(|v| v.as_str())
+                .and_then(|v| v.parse().ok()),
+        })
+    }
+
+    fn search_consolidation_jobs(
+        &self,
+        query: Value,
+        limit: usize,
+    ) -> IcmResult<Vec<ConsolidationJob>> {
+        let resp = self.post(&format!("{IDX_CONSOLIDATION_JOBS}/_search"), query)?;
+        Ok(resp
+            .get("hits")
+            .and_then(|h| h.get("hits"))
+            .and_then(|h| h.as_array())
+            .map(|hits| {
+                hits.iter()
+                    .filter_map(Self::hit_to_consolidation_job)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
+            .into_iter()
+            .take(limit)
+            .collect())
+    }
+
+    pub fn list_pending_consolidation_jobs(
+        &self,
+        limit: usize,
+    ) -> IcmResult<Vec<ConsolidationJob>> {
+        self.search_consolidation_jobs(
+            json!({
+                "size": limit,
+                "query": {"term": {"status": "pending"}},
+                "sort": [{"created_at": "asc"}]
+            }),
+            limit,
+        )
+    }
+
+    pub fn list_consolidation_jobs(
+        &self,
+        status: Option<&str>,
+        limit: usize,
+    ) -> IcmResult<Vec<ConsolidationJob>> {
+        let query = match status {
+            Some(s) => json!({
+                "size": limit,
+                "query": {"term": {"status": s}},
+                "sort": [{"created_at": "desc"}]
+            }),
+            None => json!({
+                "size": limit,
+                "query": {"match_all": {}},
+                "sort": [{"created_at": "desc"}]
+            }),
+        };
+        self.search_consolidation_jobs(query, limit)
+    }
+
+    pub fn mark_consolidation_job_done(&self, id: &str) -> IcmResult<()> {
+        self.request(
+            "POST",
+            &format!(
+                "{IDX_CONSOLIDATION_JOBS}/_update/{id}?{}",
+                self.refresh_param()
+            ),
+            Some(json!({
+                "doc": {"status": "done", "completed_at": Utc::now().to_rfc3339(), "error": null}
+            })),
+            false,
+        )?;
+        Ok(())
+    }
+
+    pub fn mark_consolidation_job_failed(&self, id: &str, error: &str) -> IcmResult<()> {
+        self.request(
+            "POST",
+            &format!(
+                "{IDX_CONSOLIDATION_JOBS}/_update/{id}?{}",
+                self.refresh_param()
+            ),
+            Some(json!({
+                "doc": {"status": "failed", "completed_at": Utc::now().to_rfc3339(), "error": error}
+            })),
+            false,
+        )?;
+        Ok(())
+    }
+
+    pub fn retry_consolidation_job(&self, id: &str) -> IcmResult<bool> {
+        // Scripted update (not a plain `doc` merge) so the reset is
+        // conditional on the current status being `failed` — matches the
+        // SQL backends' `WHERE status = 'failed'`, so retrying an
+        // already-pending or already-done job is a no-op, not a silent
+        // downgrade of its state.
+        let resp = self.request(
+            "POST",
+            &format!(
+                "{IDX_CONSOLIDATION_JOBS}/_update/{id}?{}",
+                self.refresh_param()
+            ),
+            Some(json!({
+                "script": {
+                    "lang": "painless",
+                    "source": "if (ctx._source.status == 'failed') { \
+                                    ctx._source.status = 'pending'; \
+                                    ctx._source.error = null; \
+                                    ctx._source.completed_at = null; \
+                                } else { \
+                                    ctx.op = 'none'; \
+                                }"
+                }
+            })),
+            false,
+        )?;
+        Ok(resp
+            .as_ref()
+            .and_then(|v| v.get("result"))
+            .and_then(|v| v.as_str())
+            == Some("updated"))
+    }
+
+    pub fn pending_consolidation_count(&self) -> IcmResult<usize> {
+        let resp = self.post(
+            &format!("{IDX_CONSOLIDATION_JOBS}/_count"),
+            json!({"query": {"term": {"status": "pending"}}}),
+        )?;
+        Ok(resp.get("count").and_then(|v| v.as_u64()).unwrap_or(0) as usize)
+    }
+
     pub fn upsert_code_area(
         &self,
         project: &str,

--- a/crates/icm-store/src/opensearch/mod.rs
+++ b/crates/icm-store/src/opensearch/mod.rs
@@ -44,7 +44,9 @@ use icm_core::{
 
 // Shared public row types live in `crate::common` (issue #301) so every
 // backend can be compiled into one binary without colliding definitions.
-pub use crate::common::{CodeArea, HookEvent, HookEventInsert, HookStatsRow, PendingRow};
+pub use crate::common::{
+    CodeArea, ConsolidationJob, HookEvent, HookEventInsert, HookStatsRow, PendingRow,
+};
 
 // Index names
 
@@ -52,6 +54,7 @@ const IDX_MEMORIES: &str = "icm_memories";
 const IDX_METADATA: &str = "icm_metadata";
 const IDX_HOOKS: &str = "icm_hook_events";
 const IDX_PENDING: &str = "icm_pending_extractions";
+const IDX_CONSOLIDATION_JOBS: &str = "icm_pending_consolidations";
 const IDX_CODE_AREAS: &str = "icm_code_areas";
 
 // Store

--- a/crates/icm-store/src/postgres/connection.rs
+++ b/crates/icm-store/src/postgres/connection.rs
@@ -208,6 +208,18 @@ fn init_schema(client: &mut Client, requested_dims: usize) -> IcmResult<usize> {
                 captured_at TIMESTAMPTZ NOT NULL
             );
 
+            CREATE TABLE IF NOT EXISTS pending_consolidations (
+                id TEXT PRIMARY KEY,
+                topic TEXT NOT NULL,
+                project TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL DEFAULT 'pending',
+                error TEXT,
+                created_at TIMESTAMPTZ NOT NULL,
+                completed_at TIMESTAMPTZ
+            );
+            CREATE INDEX IF NOT EXISTS idx_pending_consolidations_status
+                ON pending_consolidations(status, created_at);
+
             CREATE TABLE IF NOT EXISTS code_areas (
                 id BIGSERIAL PRIMARY KEY,
                 project TEXT NOT NULL,

--- a/crates/icm-store/src/postgres/hooks.rs
+++ b/crates/icm-store/src/postgres/hooks.rs
@@ -105,6 +105,129 @@ impl PostgresStore {
         Ok(n.max(0) as usize)
     }
 
+    // Async consolidation queue (issue #179)
+
+    pub fn enqueue_pending_consolidation(&self, topic: &str, project: &str) -> IcmResult<String> {
+        let id = ulid::Ulid::new().to_string();
+        let mut c = self.conn()?;
+        c.execute(
+            "INSERT INTO pending_consolidations (id, topic, project, status, created_at)
+             VALUES ($1, $2, $3, 'pending', $4)",
+            &[&id, &topic, &project, &Utc::now()],
+        )
+        .map_err(pg_err)?;
+        Ok(id)
+    }
+
+    fn row_to_consolidation_job(row: &postgres::Row) -> ConsolidationJob {
+        let created_at: DateTime<Utc> = row.get(5);
+        let completed_at: Option<DateTime<Utc>> = row.get(6);
+        ConsolidationJob {
+            id: row.get(0),
+            topic: row.get(1),
+            project: row.get(2),
+            status: row.get(3),
+            error: row.get(4),
+            created_at,
+            completed_at,
+        }
+    }
+
+    pub fn list_pending_consolidation_jobs(
+        &self,
+        limit: usize,
+    ) -> IcmResult<Vec<ConsolidationJob>> {
+        let mut c = self.conn()?;
+        let rows = c
+            .query(
+                "SELECT id, topic, project, status, error, created_at, completed_at
+                 FROM pending_consolidations
+                 WHERE status = 'pending'
+                 ORDER BY created_at ASC
+                 LIMIT $1",
+                &[&(limit as i64)],
+            )
+            .map_err(pg_err)?;
+        Ok(rows.iter().map(Self::row_to_consolidation_job).collect())
+    }
+
+    pub fn list_consolidation_jobs(
+        &self,
+        status: Option<&str>,
+        limit: usize,
+    ) -> IcmResult<Vec<ConsolidationJob>> {
+        let mut c = self.conn()?;
+        let rows = match status {
+            Some(s) => c
+                .query(
+                    "SELECT id, topic, project, status, error, created_at, completed_at
+                     FROM pending_consolidations
+                     WHERE status = $1
+                     ORDER BY created_at DESC
+                     LIMIT $2",
+                    &[&s, &(limit as i64)],
+                )
+                .map_err(pg_err)?,
+            None => c
+                .query(
+                    "SELECT id, topic, project, status, error, created_at, completed_at
+                     FROM pending_consolidations
+                     ORDER BY created_at DESC
+                     LIMIT $1",
+                    &[&(limit as i64)],
+                )
+                .map_err(pg_err)?,
+        };
+        Ok(rows.iter().map(Self::row_to_consolidation_job).collect())
+    }
+
+    pub fn mark_consolidation_job_done(&self, id: &str) -> IcmResult<()> {
+        let mut c = self.conn()?;
+        c.execute(
+            "UPDATE pending_consolidations SET status = 'done', completed_at = $2, error = NULL
+             WHERE id = $1",
+            &[&id, &Utc::now()],
+        )
+        .map_err(pg_err)?;
+        Ok(())
+    }
+
+    pub fn mark_consolidation_job_failed(&self, id: &str, error: &str) -> IcmResult<()> {
+        let mut c = self.conn()?;
+        c.execute(
+            "UPDATE pending_consolidations SET status = 'failed', completed_at = $2, error = $3
+             WHERE id = $1",
+            &[&id, &Utc::now(), &error],
+        )
+        .map_err(pg_err)?;
+        Ok(())
+    }
+
+    pub fn retry_consolidation_job(&self, id: &str) -> IcmResult<bool> {
+        let mut c = self.conn()?;
+        let n = c
+            .execute(
+                "UPDATE pending_consolidations
+                 SET status = 'pending', error = NULL, completed_at = NULL
+                 WHERE id = $1 AND status = 'failed'",
+                &[&id],
+            )
+            .map_err(pg_err)?;
+        Ok(n > 0)
+    }
+
+    pub fn pending_consolidation_count(&self) -> IcmResult<usize> {
+        let mut c = self.conn()?;
+        let row = c
+            .query_one(
+                "SELECT COUNT(*) FROM pending_consolidations WHERE status = 'pending'",
+                &[],
+            )
+            .map_err(pg_err)?;
+        let n: i64 = row.get(0);
+        Ok(n.max(0) as usize)
+    }
+
     // Code areas (issue #196)
 
     /// Insert or refresh a row for `(project, file_path)`.

--- a/crates/icm-store/src/postgres/mod.rs
+++ b/crates/icm-store/src/postgres/mod.rs
@@ -49,7 +49,9 @@ use icm_core::{
 
 // Shared public row types live in `crate::common` (issue #301) so every
 // backend can be compiled into one binary without colliding definitions.
-pub use crate::common::{CodeArea, HookEvent, HookEventInsert, HookStatsRow, PendingRow};
+pub use crate::common::{
+    CodeArea, ConsolidationJob, HookEvent, HookEventInsert, HookStatsRow, PendingRow,
+};
 
 // Helpers (mirrored from the SQLite backend so behaviour matches)
 

--- a/crates/icm-store/src/schema.rs
+++ b/crates/icm-store/src/schema.rs
@@ -432,6 +432,26 @@ pub fn init_db_with_dims(conn: &Connection, embedding_dims: usize) -> Result<(),
         CREATE INDEX IF NOT EXISTS idx_pending_extractions_captured
             ON pending_extractions(captured_at);
 
+        -- Async-consolidation queue (issue #179). When
+        -- `[consolidate.summarizer].provider` is set to anything other
+        -- than `none`, the auto-consolidate path enqueues a job here
+        -- instead of running the LLM inline on the hot store path. A
+        -- worker (`icm consolidate-pending` or the SessionEnd async
+        -- fork) drains it. Rows keep their terminal status (done/failed)
+        -- instead of being deleted, so `icm consolidate-jobs` can show
+        -- history and a failed job can be retried.
+        CREATE TABLE IF NOT EXISTS pending_consolidations (
+            id TEXT PRIMARY KEY,
+            topic TEXT NOT NULL,
+            project TEXT NOT NULL DEFAULT '',
+            status TEXT NOT NULL DEFAULT 'pending',
+            error TEXT,
+            created_at TEXT NOT NULL,
+            completed_at TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_pending_consolidations_status
+            ON pending_consolidations(status, created_at);
+
         -- Structured hook telemetry. Every `icm hook <event>` invocation
         -- records one row so users can audit what fired, how long it took,
         -- what its outcome was, and whether the async extraction path was

--- a/crates/icm-store/src/store/hooks.rs
+++ b/crates/icm-store/src/store/hooks.rs
@@ -5,6 +5,21 @@
 //! coherent group of inherent methods) on that type.
 
 use super::*;
+
+fn row_to_consolidation_job(row: &rusqlite::Row<'_>) -> rusqlite::Result<ConsolidationJob> {
+    let created_at: String = row.get(5)?;
+    let completed_at: Option<String> = row.get(6)?;
+    Ok(ConsolidationJob {
+        id: row.get(0)?,
+        topic: row.get(1)?,
+        project: row.get(2)?,
+        status: row.get(3)?,
+        error: row.get(4)?,
+        created_at: parse_dt(&created_at),
+        completed_at: completed_at.map(|s| parse_dt(&s)),
+    })
+}
+
 impl SqliteStore {
     /// Atomically increment the hook call counter and return the new value.
     pub fn increment_hook_counter(&self) -> IcmResult<usize> {
@@ -108,6 +123,152 @@ impl SqliteStore {
         let n: i64 = self
             .conn
             .query_row("SELECT COUNT(*) FROM pending_extractions", [], |r| r.get(0))
+            .map_err(db_err)?;
+        Ok(n as usize)
+    }
+
+    // Async consolidation queue (issue #179)
+    //
+    // Mirrors the extraction queue above, but rows keep their terminal
+    // status instead of being deleted so `icm consolidate-jobs` can show
+    // history and a failed job can be retried.
+
+    /// Enqueue a topic for later LLM consolidation. Returns the generated
+    /// row id.
+    pub fn enqueue_pending_consolidation(&self, topic: &str, project: &str) -> IcmResult<String> {
+        let id = ulid::Ulid::new().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        self.conn
+            .execute(
+                "INSERT INTO pending_consolidations (id, topic, project, status, created_at)
+                 VALUES (?1, ?2, ?3, 'pending', ?4)",
+                rusqlite::params![id, topic, project, now],
+            )
+            .map_err(db_err)?;
+        Ok(id)
+    }
+
+    /// Pop up to `limit` oldest `pending` jobs (FIFO by enqueue time).
+    pub fn list_pending_consolidation_jobs(
+        &self,
+        limit: usize,
+    ) -> IcmResult<Vec<ConsolidationJob>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, topic, project, status, error, created_at, completed_at
+                 FROM pending_consolidations
+                 WHERE status = 'pending'
+                 ORDER BY created_at ASC
+                 LIMIT ?1",
+            )
+            .map_err(db_err)?;
+        let rows = stmt
+            .query_map([limit as i64], row_to_consolidation_job)
+            .map_err(db_err)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(db_err)?;
+        Ok(rows)
+    }
+
+    /// List jobs, optionally filtered by status (`pending` | `done` |
+    /// `failed`); all statuses when `None`. Used by `icm consolidate-jobs`.
+    pub fn list_consolidation_jobs(
+        &self,
+        status: Option<&str>,
+        limit: usize,
+    ) -> IcmResult<Vec<ConsolidationJob>> {
+        let rows: Vec<ConsolidationJob> = match status {
+            Some(s) => {
+                let mut stmt = self
+                    .conn
+                    .prepare(
+                        "SELECT id, topic, project, status, error, created_at, completed_at
+                         FROM pending_consolidations
+                         WHERE status = ?1
+                         ORDER BY created_at DESC
+                         LIMIT ?2",
+                    )
+                    .map_err(db_err)?;
+                let result = stmt
+                    .query_map(rusqlite::params![s, limit as i64], row_to_consolidation_job)
+                    .map_err(db_err)?
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(db_err)?;
+                result
+            }
+            None => {
+                let mut stmt = self
+                    .conn
+                    .prepare(
+                        "SELECT id, topic, project, status, error, created_at, completed_at
+                         FROM pending_consolidations
+                         ORDER BY created_at DESC
+                         LIMIT ?1",
+                    )
+                    .map_err(db_err)?;
+                let result = stmt
+                    .query_map([limit as i64], row_to_consolidation_job)
+                    .map_err(db_err)?
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(db_err)?;
+                result
+            }
+        };
+        Ok(rows)
+    }
+
+    /// Mark a job `done`. Non-fatal if the id no longer exists.
+    pub fn mark_consolidation_job_done(&self, id: &str) -> IcmResult<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+        self.conn
+            .execute(
+                "UPDATE pending_consolidations SET status = 'done', completed_at = ?2, error = NULL
+                 WHERE id = ?1",
+                rusqlite::params![id, now],
+            )
+            .map_err(db_err)?;
+        Ok(())
+    }
+
+    /// Mark a job `failed`, capturing the error so `icm consolidate-jobs`
+    /// can surface it and the user can retry.
+    pub fn mark_consolidation_job_failed(&self, id: &str, error: &str) -> IcmResult<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+        self.conn
+            .execute(
+                "UPDATE pending_consolidations SET status = 'failed', completed_at = ?2, error = ?3
+                 WHERE id = ?1",
+                rusqlite::params![id, now, error],
+            )
+            .map_err(db_err)?;
+        Ok(())
+    }
+
+    /// Reset a `failed` job back to `pending` so the next drain retries it.
+    /// Returns `false` if the id doesn't exist or isn't `failed`.
+    pub fn retry_consolidation_job(&self, id: &str) -> IcmResult<bool> {
+        let n = self
+            .conn
+            .execute(
+                "UPDATE pending_consolidations
+                 SET status = 'pending', error = NULL, completed_at = NULL
+                 WHERE id = ?1 AND status = 'failed'",
+                rusqlite::params![id],
+            )
+            .map_err(db_err)?;
+        Ok(n > 0)
+    }
+
+    /// Total jobs currently `pending`. Used by `icm doctor`.
+    pub fn pending_consolidation_count(&self) -> IcmResult<usize> {
+        let n: i64 = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM pending_consolidations WHERE status = 'pending'",
+                [],
+                |r| r.get(0),
+            )
             .map_err(db_err)?;
         Ok(n as usize)
     }

--- a/crates/icm-store/src/store/mod.rs
+++ b/crates/icm-store/src/store/mod.rs
@@ -16,7 +16,9 @@ use icm_core::{
     StoreStats, TopicHealth, TranscriptHit, TranscriptStats, TranscriptStore,
 };
 
-pub use crate::common::{CodeArea, HookEvent, HookEventInsert, HookStatsRow, PendingRow};
+pub use crate::common::{
+    CodeArea, ConsolidationJob, HookEvent, HookEventInsert, HookStatsRow, PendingRow,
+};
 use crate::schema::init_db_with_dims;
 pub struct SqliteStore {
     conn: Connection,


### PR DESCRIPTION
## Summary

Implements mechanism #1 of #179 — the in-process background queue for LLM-backed consolidation — as a companion to the already-shipped `icm consolidate-all` cron mechanism. Also improves ICM's install-time context setup (Patrick asked to fold this into the same PR).

### Async consolidation queue

Architecture mirrors the existing `pending_extractions` async queue (used for hook-triggered extraction), with one addition Patrick asked for during design review: jobs keep a `status`/`error`/`completed_at` history instead of being fire-and-deleted, so failures are visible and retryable rather than silently vanishing.

- New `pending_consolidations` table (SQLite/Postgres/OpenSearch) backing a `ConsolidationJob` struct: `id, topic, project, status (pending|done|failed), error, created_at, completed_at`.
- `maybe_auto_consolidate` (the shared trigger used by `icm store`, `icm remember`, hooks): when `consolidate.summarizer.provider != "none"`, an over-threshold topic is now **enqueued** instead of consolidated synchronously — moves a ~10-15s LLM round trip off the hot write path. Lexical mode (`provider = "none"`, the default) is unchanged.
- `icm consolidate-pending [--limit] [--provider] [--model] [--dry-run]` — drains the queue, reusing `cmd_consolidate` per job; marks each `done` or `failed` (with the error captured).
- `icm consolidate-jobs [--status] [--limit] [--retry <id>]` — lists jobs, or resets one `failed` job back to `pending`.
- SessionEnd hook forks a detached `consolidate-pending --limit 20` worker (same pattern as the extraction fork, independent singleton lockfile so the two queues don't contend).

### Install-time context setup improvements

Auditing what a fresh `icm init` actually gives an agent out of the box surfaced two real gaps:

- `[mcp] instructions` in `config.toml` was parsed but **never reached the MCP `initialize` handshake** — setting it silently did nothing on both the stdio and HTTP transports. Now appended to the built-in recall/store guidance sent to every client.
- The SessionStart hook (installed by `icm init --mode hook`) prefers a cached LLM wake-up briefing (#165) over the plain bullet pack, but **nothing ever populated that cache automatically** — a fresh install would silently serve the plain pack forever unless the user manually ran `icm briefing` or wired their own cron. SessionEnd now refreshes it via the same detached-worker fork as the consolidation queue, gated by a 6h staleness check so a chatty session doesn't trigger an LLM call on every single SessionEnd.

## Test plan

- [x] `cargo test -p icm-cli` (369 passed) + `cargo test -p icm-mcp` (93 passed), including: threshold-gated enqueue regression (catches an unconditional-enqueue bug I found and fixed during implementation), drain success marks `done`, drain of a stale job marks `failed` with error, retry resets to `pending`, MCP `initialize` appends/omits/trims custom instructions, briefing-cache staleness (missing/fresh/expired).
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean across sqlite/postgres/opensearch feature combinations.
- [x] Full real-binary functional pass against an isolated temp DB (`--db`): store → threshold enqueue → `consolidate-jobs` listing → `--dry-run` → real drain via the actual `claude` CLI → job marked `done`, topic actually consolidated.
- [x] Failure path exercised for real: stale job (topic already gone) → marked `failed` with captured error → `--retry` → back to `pending`.
- [x] SessionEnd hook fork verified for real (`icm hook end`) — spawns the detached `consolidate-pending` worker and logs it.
- [x] MCP `instructions` fix verified for real over both transports: stdio `icm serve` and HTTP `icm serve --http` initialize handshakes both return the built-in guidance + the configured custom text.
- [x] Auto-briefing fork verified for real: fresh install (no cache) → forks and a real `claude`-generated briefing lands in the cache; pre-existing fresh cache → correctly skips the fork (no LLM call).

Note: found and cleaned up a real issue during testing — `--db`'s help text claims it "overrides config and `ICM_DB` env var," but no such env var is actually read anywhere in the codebase. Not touched in this PR (out of scope), flagging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)