### PR TITLE
fix(store,recall): dedup data loss, FTS AND->OR, topic starvation, e5-large default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,24 +32,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
-dependencies = [
- "as-slice",
-]
-
-[[package]]
-name = "aligned-vec"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
-dependencies = [
- "equator",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,32 +112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arg_enum_proc_macro"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "as-slice"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,49 +133,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "av-scenechange"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
-dependencies = [
- "aligned",
- "anyhow",
- "arg_enum_proc_macro",
- "arrayvec",
- "log",
- "num-rational",
- "num-traits",
- "pastey",
- "rayon",
- "thiserror",
- "v_frame",
- "y4m",
-]
-
-[[package]]
-name = "av1-grain"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
-dependencies = [
- "anyhow",
- "arrayvec",
- "log",
- "nom 8.0.0",
- "num-rational",
- "v_frame",
-]
-
-[[package]]
-name = "avif-serialize"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
-dependencies = [
- "arrayvec",
-]
 
 [[package]]
 name = "axum"
@@ -286,25 +199,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bit_field"
-version = "0.10.3"
+name = "base64"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-
-[[package]]
-name = "bitstream-io"
-version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
-dependencies = [
- "core2",
-]
 
 [[package]]
 name = "block-buffer"
@@ -325,34 +235,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "built"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -391,8 +283,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -474,12 +364,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,15 +400,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width 0.2.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -532,6 +415,35 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cookie"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
 
 [[package]]
 name = "core-foundation"
@@ -558,15 +470,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -644,12 +547,6 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -758,6 +655,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +776,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,26 +803,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -926,21 +828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
-name = "exr"
-version = "1.74.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
-dependencies = [
- "bit_field",
- "half",
- "lebe",
- "miniz_oxide",
- "rayon-core",
- "smallvec",
- "zune-inflate",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,18 +847,17 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastembed"
-version = "4.9.1"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c269a76bfc6cea69553b7d040acb16c793119cebd97c756d21e08d0f075ff8"
+checksum = "b5e6a29ef0fc303e63ce89f2b71d98bee9df51d79cbbedb78dd0d6ba9f3b172f"
 dependencies = [
- "anyhow",
  "hf-hub",
- "image",
  "ndarray",
  "ort",
- "ort-sys",
- "rayon",
+ "safetensors",
+ "serde",
  "serde_json",
+ "thiserror",
  "tokenizers",
 ]
 
@@ -980,35 +866,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fax"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
 
 [[package]]
 name = "filetime"
@@ -1188,16 +1045,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,17 +1064,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1079,13 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1272,9 +1115,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hf-hub"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
  "http",
@@ -1287,8 +1130,8 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "ureq",
- "windows-sys 0.60.2",
+ "ureq 3.4.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1299,6 +1142,12 @@ checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "http"
@@ -1460,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "icm-cli"
-version = "0.10.61"
+version = "0.10.63"
 dependencies = [
  "anyhow",
  "axum",
@@ -1490,7 +1339,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "ureq",
+ "ureq 2.12.1",
  "walkdir",
  "zip",
 ]
@@ -1544,7 +1393,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "ulid",
- "ureq",
+ "ureq 2.12.1",
  "zerocopy",
 ]
 
@@ -1663,46 +1512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.25.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "color_quant",
- "exr",
- "gif",
- "image-webp",
- "moxcms",
- "num-traits",
- "png",
- "qoi",
- "ravif",
- "rayon",
- "rgb",
- "tiff",
- "zune-core 0.5.1",
- "zune-jpeg 0.5.12",
-]
-
-[[package]]
-name = "image-webp"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
-dependencies = [
- "byteorder-lite",
- "quick-error",
-]
-
-[[package]]
-name = "imgref"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
-
-[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,14 +1525,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width 0.2.0",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -1744,17 +1553,6 @@ checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling 0.23.0",
  "indoc",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "interpolate_name"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -1807,16 +1605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,32 +1627,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "lebe"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
-
-[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
-name = "libfuzzer-sys"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
-dependencies = [
- "arbitrary",
- "cc",
-]
-
-[[package]]
 name = "libloading"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
  "windows-link",
@@ -1912,6 +1684,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,15 +1703,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "loop9"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
-dependencies = [
- "imgref",
-]
 
 [[package]]
 name = "lru"
@@ -1952,6 +1721,12 @@ checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
  "hashbrown 0.17.0",
 ]
+
+[[package]]
+name = "lzma-rust2"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -1992,16 +1767,6 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
-]
-
-[[package]]
-name = "maybe-rayon"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
-dependencies = [
- "cfg-if",
- "rayon",
 ]
 
 [[package]]
@@ -2087,16 +1852,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "moxcms"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
-dependencies = [
- "num-traits",
- "pxfm",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
  "matrixmultiply",
  "num-complex",
@@ -2127,12 +1882,6 @@ dependencies = [
  "portable-atomic-util",
  "rawpointer",
 ]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"
@@ -2145,37 +1894,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "noop_proc_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -2188,15 +1912,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
+name = "num-conv"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2208,17 +1927,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,12 +1934,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc2-core-foundation"
@@ -2347,27 +2049,27 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52afb44b6b0cffa9bf45e4d37e5a4935b0334a51570658e279e9e3e6cf324aa5"
+checksum = "4336a1e2b38848325241c72889086886004e589b7c74f335e60a8e8db5138a0b"
 dependencies = [
  "libloading",
  "ndarray",
  "ort-sys",
+ "smallvec",
  "tracing",
+ "ureq 3.4.0",
 ]
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
+checksum = "cf211e3776eea6aec988552fa118dd746d70e1b1e5e244058d1c98015f3e5872"
 dependencies = [
- "flate2",
- "pkg-config",
- "sha2 0.10.9",
- "tar",
- "ureq",
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq 3.4.0",
 ]
 
 [[package]]
@@ -2400,10 +2102,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pastey"
-version = "0.1.1"
+name = "pem-rfc7468"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2463,19 +2168,6 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "png"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
-dependencies = [
- "bitflags",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
 
 [[package]]
 name = "portable-atomic"
@@ -2546,6 +2238,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,46 +2270,6 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "profiling"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
-dependencies = [
- "profiling-procmacros",
-]
-
-[[package]]
-name = "profiling-procmacros"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pxfm"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -2699,56 +2357,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "rav1e"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
-dependencies = [
- "aligned-vec",
- "arbitrary",
- "arg_enum_proc_macro",
- "arrayvec",
- "av-scenechange",
- "av1-grain",
- "bitstream-io",
- "built",
- "cfg-if",
- "interpolate_name",
- "itertools 0.14.0",
- "libc",
- "libfuzzer-sys",
- "log",
- "maybe-rayon",
- "new_debug_unreachable",
- "noop_proc_macro",
- "num-derive",
- "num-traits",
- "paste",
- "profiling",
- "rand 0.9.5",
- "rand_chacha",
- "simd_helpers",
- "thiserror",
- "v_frame",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "ravif"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
-dependencies = [
- "avif-serialize",
- "imgref",
- "loop9",
- "quick-error",
- "rav1e",
- "rayon",
- "rgb",
 ]
 
 [[package]]
@@ -2888,12 +2496,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
 ]
-
-[[package]]
-name = "rgb"
-version = "0.8.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -3039,6 +2641,19 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
+dependencies = [
+ "hashbrown 0.16.1",
+ "libc",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
 
 [[package]]
 name = "same-file"
@@ -3257,15 +2872,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
-name = "simd_helpers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
-dependencies = [
- "quote",
-]
-
-[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3311,7 +2917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
 dependencies = [
  "base64 0.13.1",
- "nom 7.1.3",
+ "nom",
  "serde",
  "unicode-segmentation",
 ]
@@ -3488,17 +3094,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiff"
-version = "0.10.3"
+name = "time"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg 0.4.21",
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3528,9 +3150,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.21.4"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -3900,6 +3522,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3914,15 +3542,49 @@ dependencies = [
  "base64 0.22.1",
  "flate2",
  "log",
- "native-tls",
  "once_cell",
  "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
- "socks",
  "url",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64 0.23.1",
+ "cookie_store",
+ "der",
+ "flate2",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64 0.23.1",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -3938,6 +3600,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3948,17 +3616,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "v_frame"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
-dependencies = [
- "aligned-vec",
- "num-traits",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "valuable"
@@ -4166,6 +3823,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4182,12 +3848,6 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
@@ -4582,12 +4242,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "y4m"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
-
-[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4723,43 +4377,4 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
-]
-
-[[package]]
-name = "zune-core"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
-name = "zune-jpeg"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
-dependencies = [
- "zune-core 0.4.12",
-]
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
-dependencies = [
- "zune-core 0.5.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ zerocopy = { version = "0.8", features = ["derive"] }
 # default-features off so each member selects its own ort backend
 # (ort-download-binaries for the static default build, ort-load-dynamic for the
 # homebrew-core-buildable variant — issue #345). hf-hub is re-added per-feature.
-fastembed = { version = "4", default-features = false }
+fastembed = { version = "6", default-features = false }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/crates/icm-cli/src/config.rs
+++ b/crates/icm-cli/src/config.rs
@@ -99,7 +99,17 @@ impl Default for EmbeddingsConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            model: "intfloat/multilingual-e5-base".into(),
+            // Single source of truth: `icm_core::fastembed_embedder`'s
+            // `DEFAULT_MODEL`. This used to be a separately hardcoded
+            // string here — the two drifted (this one kept pointing at
+            // multilingual-e5-base after icm-core's default moved to
+            // bge-m3), so a real `icm store`/`icm recall` run never picked
+            // up the change. `--no-embeddings`-only builds don't compile
+            // in that constant, so fall back to the same literal it holds.
+            #[cfg(feature = "embeddings")]
+            model: icm_core::DEFAULT_EMBEDDING_MODEL.into(),
+            #[cfg(not(feature = "embeddings"))]
+            model: "BAAI/bge-m3".into(),
         }
     }
 }

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2794,13 +2794,14 @@ fn cmd_store(
                 access_count: existing.access_count,
                 weight: 1.0,
                 topic: existing.topic.clone(),
-                summary: memory.summary.clone(),
+                // Never wholesale-replace: `existing` and `memory` are only
+                // known to be semantically close (cosine similarity), not
+                // the same statement — see `merge_summaries`'s docs for a
+                // measured case (two distinct LoCoMo greeting turns scored
+                // 0.98) where that destroyed the earlier memory's content.
+                summary: icm_core::merge_summaries(&existing.summary, &memory.summary),
                 raw_excerpt: memory.raw_excerpt.clone().or(existing.raw_excerpt),
-                keywords: if memory.keywords.is_empty() {
-                    existing.keywords
-                } else {
-                    memory.keywords.clone()
-                },
+                keywords: icm_core::union_keywords(&existing.keywords, &memory.keywords),
                 embedding: memory.embedding.clone(),
                 // Never let a near-dup merge downgrade importance — a
                 // `--importance` omission defaults to Medium and would

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -2893,6 +2893,27 @@ fn cmd_remember(
     )
 }
 
+/// How many candidates to ask the store for before applying a
+/// project/topic/keyword filter.
+///
+/// `search_hybrid`/`search_fts`/`search_by_keywords` are topic-oblivious —
+/// they rank and truncate to `limit` globally, across every topic in the
+/// database. Passing the caller's `limit` straight through when a filter is
+/// about to run means the filter only ever sees the global top-`limit`
+/// candidates: on a database with several topics, those can all belong to
+/// topics other than the one being filtered for, and recall reports "no
+/// memories" even though relevant matches exist further down the ranking
+/// (same bug the MCP `tool_recall` path already fixed — this mirrors it for
+/// the CLI). Widen the pool whenever a filter is active; leave it alone
+/// otherwise so the unfiltered path doesn't pay for candidates it won't use.
+fn recall_query_limit(limit: usize, filters_active: bool) -> usize {
+    if filters_active {
+        (limit * 10).min(200)
+    } else {
+        limit
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn cmd_recall(
     store: &Store,
@@ -2918,10 +2939,24 @@ fn cmd_recall(
         }
     };
 
+    // Same audit finding the MCP `tool_recall` path already fixed, ported
+    // here: `search_hybrid`/`search_fts`/`search_by_keywords` are
+    // topic-oblivious and truncate to `limit` BEFORE the project/topic/
+    // keyword filter below runs. On a database with several topics (the
+    // normal case — this store alone has ~30), the global top-`limit` hits
+    // can all belong to other topics, so a `-t` filter finds nothing even
+    // though relevant same-topic memories exist further down the ranking.
+    // When any filter is active, request a much larger candidate pool so
+    // filtering has enough to work with; truncate to the caller's `limit`
+    // only at the very end (`expand_with_neighbors`'s `max_total`).
+    let project_active = matches!(project, Some(p) if !p.is_empty());
+    let filters_active = project_active || topic.is_some() || keyword.is_some();
+    let query_limit = recall_query_limit(limit, filters_active);
+
     // Try hybrid search if embedder is available; fall back to FTS / keywords.
     let scored: Option<Vec<(Memory, f32)>> = embedder
         .and_then(|emb| emb.embed_query(query).ok())
-        .and_then(|query_emb| store.search_hybrid(query, &query_emb, limit).ok());
+        .and_then(|query_emb| store.search_hybrid(query, &query_emb, query_limit).ok());
 
     let (mut results, has_score): (Vec<(Memory, Option<f32>)>, bool) = match scored {
         Some(scored) => {
@@ -2929,10 +2964,10 @@ fn cmd_recall(
             (pairs, true)
         }
         None => {
-            let mut fts = store.search_fts(query, limit)?;
+            let mut fts = store.search_fts(query, query_limit)?;
             if fts.is_empty() {
                 let kws: Vec<&str> = query.split_whitespace().collect();
-                fts = store.search_by_keywords(&kws, limit)?;
+                fts = store.search_by_keywords(&kws, query_limit)?;
             }
             (fts.into_iter().map(|m| (m, None)).collect(), false)
         }
@@ -13171,6 +13206,25 @@ mod cmd_remember_tests {
         assert!(memories
             .iter()
             .any(|m| m.summary.contains("closes the recall gap")));
+    }
+}
+
+#[cfg(test)]
+mod cmd_recall_tests {
+    use super::*;
+
+    /// Audit finding (ported from the MCP `tool_recall` path): a
+    /// project/topic/keyword filter must not shrink the candidate pool the
+    /// store searches — only the final result count.
+    #[test]
+    fn recall_query_limit_widens_only_when_a_filter_is_active() {
+        assert_eq!(recall_query_limit(5, false), 5);
+        assert_eq!(recall_query_limit(5, true), 50);
+    }
+
+    #[test]
+    fn recall_query_limit_caps_at_200() {
+        assert_eq!(recall_query_limit(100, true), 200);
     }
 }
 

--- a/crates/icm-cli/src/ort_runtime.rs
+++ b/crates/icm-cli/src/ort_runtime.rs
@@ -12,10 +12,13 @@
 //! - [`cmd_download`] / [`cmd_status`] back the explicit `icm embeddings`
 //!   subcommand for scripted setup.
 //!
-//! Safety: `ort` 2.0.0-rc.9 targets ONNX Runtime **1.20**; a mismatched runtime
-//! makes ort's version assertion abort under `panic = "abort"`. We therefore
-//! pin 1.20.1, verify a hard-coded SHA256, and trust *only* our managed copy
-//! (or an explicit user `ORT_DYLIB_PATH`) — never an ambient system library.
+//! Safety: `ort`'s version check compares the loaded library's minor version
+//! against `ORT_API_VERSION` (17 + one per enabled `api-N` feature) and
+//! rejects anything *older* under `panic = "abort"` — fastembed enables
+//! `api-24`, so this build requires ONNX Runtime >= **1.24**. We pin the
+//! latest stable release satisfying that, verify a hard-coded SHA256, and
+//! trust *only* our managed copy (or an explicit user `ORT_DYLIB_PATH`) —
+//! never an ambient system library.
 
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -24,8 +27,10 @@ use anyhow::{anyhow, bail, Context, Result};
 use sha2::{Digest, Sha256};
 
 /// onnxruntime release to fetch. MUST stay ABI-compatible with the `ort`
-/// version fastembed pins (currently `ort` 2.0.0-rc.9 → ONNX Runtime 1.20).
-const ORT_VERSION: &str = "1.20.1";
+/// version fastembed pins (currently `ort` 2.0.0-rc.13, `api-24` feature →
+/// requires ONNX Runtime >= 1.24; pinned to the latest stable release at
+/// the time of the fastembed 4->6 bump).
+const ORT_VERSION: &str = "1.29.0";
 
 const ORT_DYLIB_ENV: &str = "ORT_DYLIB_PATH";
 
@@ -43,7 +48,14 @@ struct Target {
 }
 
 /// Resolve the onnxruntime asset for a given `(os, arch)`, or `None` if
-/// unsupported (Windows-on-ARM and exotic arches are deferred — issue #345).
+/// unsupported. Windows-on-ARM and exotic arches are deferred (issue #345).
+/// `macos`/`x86_64` (Intel Mac) is deferred too as of the 1.29.0 pin: upstream
+/// onnxruntime stopped publishing `osx-x86_64` prebuilt archives starting
+/// with the first release in our required range (1.24.0) — confirmed no
+/// release from 1.24.0 through 1.29.0 ships one. An Intel-Mac
+/// `embeddings-dynamic` build still works via an explicit `ORT_DYLIB_PATH`
+/// to a self-built or Homebrew onnxruntime; only the automatic
+/// download-on-first-use path is unavailable.
 /// Split out from [`detect_target`] so the target table is unit-testable across
 /// platforms from any host.
 fn target_for(os: &str, arch: &str) -> Option<Target> {
@@ -52,28 +64,23 @@ fn target_for(os: &str, arch: &str) -> Option<Target> {
     let (asset, sha256, approx_size) = match (os, arch) {
         ("macos", "aarch64") => (
             "osx-arm64",
-            "b678fc3c2354c771fea4fba420edeccfba205140088334df801e7fc40e83a57a",
-            "~7 MB",
-        ),
-        ("macos", "x86_64") => (
-            "osx-x86_64",
-            "0f73006813af2a1a5d1723ed7dfb694fc629d15037124081bb61b7bf7d99fc78",
-            "~7 MB",
+            "d0706fc34f315d8c88639d0a8c81f2e09e815f282cabed3493c06a054352cf92",
+            "~40 MB",
         ),
         ("linux", "x86_64") => (
             "linux-x64",
-            "67db4dc1561f1e3fd42e619575c82c601ef89849afc7ea85a003abbac1a1a105",
-            "~7 MB",
+            "c3fddc4f139a045b0c4902c57410f0694f1c2fdf9b6939fbe38b1aeae7cd14ba",
+            "~11 MB",
         ),
         ("linux", "aarch64") => (
             "linux-aarch64",
-            "ae4fedbdc8c18d688c01306b4b50c63de3445cdf2dbd720e01a2fa3810b8106a",
-            "~7 MB",
+            "e1799098ebc054b370f6176a450f158720f297818c613e5dc99b92e2ec82346f",
+            "~10 MB",
         ),
         ("windows", "x86_64") => (
             "win-x64",
-            "78d447051e48bd2e1e778bba378bec4ece11191c9e538cf7b2c4a4565e8f5581",
-            "~65 MB",
+            "c9b4b7086b529ad814f428c1bad028e20a25d7dc0699836775faace4ab5b78b2",
+            "~76 MB",
         ),
         _ => return None,
     };
@@ -490,12 +497,12 @@ mod tests {
         let mut builder = tar::Builder::new(Vec::new());
         tar_entry(
             &mut builder,
-            "onnxruntime-osx-arm64-1.20.1/lib/libonnxruntime_providers_shared.dylib",
+            "onnxruntime-osx-arm64-1.29.0/lib/libonnxruntime_providers_shared.dylib",
             b"PROVIDER",
         );
         tar_entry(
             &mut builder,
-            "onnxruntime-osx-arm64-1.20.1/lib/libonnxruntime.1.20.1.dylib",
+            "onnxruntime-osx-arm64-1.29.0/lib/libonnxruntime.1.29.0.dylib",
             b"REAL-LIBRARY-BYTES",
         );
         let tar_bytes = builder.into_inner().unwrap();
@@ -520,13 +527,6 @@ mod tests {
                 "libonnxruntime.dylib",
                 "osx-arm64",
             ),
-            (
-                "macos",
-                "x86_64",
-                "tgz",
-                "libonnxruntime.dylib",
-                "osx-x86_64",
-            ),
             ("linux", "x86_64", "tgz", "libonnxruntime.so", "linux-x64"),
             (
                 "linux",
@@ -546,14 +546,18 @@ mod tests {
             assert_eq!(t.sha256.len(), 64, "{os}/{arch} sha must be 64 hex chars");
         }
         // Windows-on-ARM and exotic arches are deferred (issue #345).
+        // Intel Mac: upstream onnxruntime stopped shipping osx-x86_64
+        // prebuilt archives at 1.24.0, our minimum supported version — see
+        // `target_for`'s docs.
         assert!(target_for("windows", "aarch64").is_none());
         assert!(target_for("freebsd", "x86_64").is_none());
+        assert!(target_for("macos", "x86_64").is_none());
     }
 
     #[test]
     fn is_onnxruntime_lib_excludes_provider_siblings() {
-        assert!(is_onnxruntime_lib("libonnxruntime.1.20.1.dylib"));
-        assert!(is_onnxruntime_lib("libonnxruntime.so.1.20.1"));
+        assert!(is_onnxruntime_lib("libonnxruntime.1.29.0.dylib"));
+        assert!(is_onnxruntime_lib("libonnxruntime.so.1.29.0"));
         assert!(is_onnxruntime_lib("onnxruntime.dll"));
         // The providers siblings must never be picked.
         assert!(!is_onnxruntime_lib("libonnxruntime_providers_shared.dylib"));
@@ -573,12 +577,12 @@ mod tests {
             let mut w = zip::ZipWriter::new(Cursor::new(&mut buf));
             let opts = SimpleFileOptions::default();
             w.start_file(
-                "onnxruntime-win-x64-1.20.1/lib/onnxruntime_providers_shared.dll",
+                "onnxruntime-win-x64-1.29.0/lib/onnxruntime_providers_shared.dll",
                 opts,
             )
             .unwrap();
             w.write_all(b"PROVIDER").unwrap();
-            w.start_file("onnxruntime-win-x64-1.20.1/lib/onnxruntime.dll", opts)
+            w.start_file("onnxruntime-win-x64-1.29.0/lib/onnxruntime.dll", opts)
                 .unwrap();
             w.write_all(b"REAL-DLL-BYTES").unwrap();
             w.finish().unwrap();
@@ -598,7 +602,7 @@ mod tests {
         let victim = tmp_dir.path().join("victim.txt");
         std::fs::write(&victim, "untouched").unwrap();
 
-        let target = tmp_dir.path().join("libonnxruntime.1.20.1.dylib.new");
+        let target = tmp_dir.path().join("libonnxruntime.1.29.0.dylib.new");
         std::os::unix::fs::symlink(&victim, &target).unwrap();
 
         write_lib_tmp(&target, b"verified library bytes").unwrap();
@@ -621,7 +625,7 @@ mod tests {
     #[test]
     fn write_lib_tmp_creates_a_fresh_file() {
         let tmp_dir = tempfile::TempDir::new().unwrap();
-        let target = tmp_dir.path().join("libonnxruntime.1.20.1.dylib.new");
+        let target = tmp_dir.path().join("libonnxruntime.1.29.0.dylib.new");
         write_lib_tmp(&target, b"payload").unwrap();
         assert_eq!(std::fs::read(&target).unwrap(), b"payload");
     }

--- a/crates/icm-core/src/fastembed_embedder.rs
+++ b/crates/icm-core/src/fastembed_embedder.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock};
+use std::sync::Mutex;
 
 use directories::ProjectDirs;
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
@@ -104,64 +104,67 @@ fn onnxruntime_dylib_available() -> bool {
 }
 
 pub struct FastEmbedder {
-    model: OnceLock<TextEmbedding>,
-    init_lock: Mutex<()>,
+    // fastembed 6's `TextEmbedding::embed` takes `&mut self`; a single
+    // mutex both lazily initializes the model on first use and serializes
+    // the `&mut` access `embed`/`embed_query`/`embed_batch` need, while
+    // `Embedder`'s trait methods stay `&self` (matches every other
+    // `MemoryStore`-adjacent trait in this codebase, which assumes a
+    // shared, thread-safe embedder).
+    model: Mutex<Option<TextEmbedding>>,
     model_name: String,
     dims: usize,
 }
 
-/// Default model: multilingual-e5-small (384d, supports 100+ languages)
-const DEFAULT_MODEL: &str = "intfloat/multilingual-e5-base";
+/// Default model: multilingual-e5-large (1024d). Unlike -small/-base,
+/// fastembed's `model_code` for the large variant is the Qdrant ONNX
+/// conversion, not an `intfloat/...` path — confirmed via
+/// `TextEmbedding::list_supported_models()` (and matches the existing
+/// `e5_models_use_instruction_prefixes` test, which already covers this
+/// exact string). Using `intfloat/multilingual-e5-large` here silently
+/// failed every embed call (`resolve_model` returned `Unknown embedding
+/// model`), degrading every store to no-embedding and every recall to the
+/// FTS/keyword fallback — caught by a 0.0% LoCoMo pilot recall@5 that had
+/// no business being that low.
+///
+/// LoCoMo benchmark pilot (2026-08-29, conv-26, 419 turns, 28 questions,
+/// evidence recall@5): multilingual-e5-**base** (768d) scored 56.2%;
+/// swapping to BAAI/bge-m3 (1024d, MTEB-competitive, but tuned for
+/// long-document retrieval with an 8192-token context) *regressed* to
+/// 50.9% on this short-dialogue-turn workload — a higher general
+/// leaderboard rank didn't transfer to this task. e5-large is the same
+/// architecture/training recipe that already measured well, one size up.
+///
+/// `pub` and re-exported so `icm-cli`'s `EmbeddingsConfig::default()` can
+/// reference this instead of duplicating the string: the two used to drift
+/// (config.rs hardcoded its own default and kept pointing at the previous
+/// choice after this constant changed, so nothing here actually took
+/// effect for a real `icm store`/`icm recall` run until config.rs was
+/// fixed too).
+pub const DEFAULT_MODEL: &str = "Qdrant/multilingual-e5-large-onnx";
 
-/// Resolve a model string to (EmbeddingModel, dimensions).
+/// Resolve a model string (e.g. `"intfloat/multilingual-e5-base"`,
+/// `"BAAI/bge-m3"`) to (EmbeddingModel, dimensions).
+///
+/// Deliberately not `str::parse::<EmbeddingModel>()`: fastembed 6 changed
+/// `FromStr` to match the enum variant's `Debug` representation
+/// (`"MultilingualE5Large"`) instead of its HuggingFace-style `model_code`
+/// (`"Qdrant/multilingual-e5-large-onnx"`, still what `ModelInfo` and every
+/// fastembed doc/example use for display) — silently breaking every
+/// HuggingFace-style name this codebase's config, CLI docs and tests use
+/// (caught by `e5_models_use_instruction_prefixes` failing on the v4→v6
+/// bump). Look up by `model_code` directly via `list_supported_models`
+/// instead, so those names keep working regardless of how fastembed's own
+/// `FromStr` behaves release to release.
 fn resolve_model(name: &str) -> IcmResult<(EmbeddingModel, usize)> {
-    let model: EmbeddingModel = name.parse().map_err(|e: String| IcmError::Embedding(e))?;
-    let dims = model_dimensions(&model);
-    Ok((model, dims))
-}
-
-/// Known dimensions for fastembed models.
-fn model_dimensions(model: &EmbeddingModel) -> usize {
-    match model {
-        EmbeddingModel::AllMiniLML6V2
-        | EmbeddingModel::AllMiniLML6V2Q
-        | EmbeddingModel::AllMiniLML12V2
-        | EmbeddingModel::AllMiniLML12V2Q
-        | EmbeddingModel::BGESmallENV15
-        | EmbeddingModel::BGESmallENV15Q
-        | EmbeddingModel::MultilingualE5Small
-        | EmbeddingModel::ParaphraseMLMiniLML12V2
-        | EmbeddingModel::ParaphraseMLMiniLML12V2Q => 384,
-
-        EmbeddingModel::BGEBaseENV15
-        | EmbeddingModel::BGEBaseENV15Q
-        | EmbeddingModel::MultilingualE5Base
-        | EmbeddingModel::ParaphraseMLMpnetBaseV2
-        | EmbeddingModel::BGESmallZHV15
-        | EmbeddingModel::GTEBaseENV15
-        | EmbeddingModel::GTEBaseENV15Q
-        | EmbeddingModel::JinaEmbeddingsV2BaseCode => 768,
-
-        EmbeddingModel::BGELargeENV15
-        | EmbeddingModel::BGELargeENV15Q
-        | EmbeddingModel::MultilingualE5Large
-        | EmbeddingModel::MxbaiEmbedLargeV1
-        | EmbeddingModel::MxbaiEmbedLargeV1Q
-        | EmbeddingModel::BGELargeZHV15
-        | EmbeddingModel::GTELargeENV15
-        | EmbeddingModel::GTELargeENV15Q
-        | EmbeddingModel::ModernBertEmbedLarge => 1024,
-
-        EmbeddingModel::NomicEmbedTextV1
-        | EmbeddingModel::NomicEmbedTextV15
-        | EmbeddingModel::NomicEmbedTextV15Q => 768,
-
-        EmbeddingModel::ClipVitB32 => 512,
-    }
+    TextEmbedding::list_supported_models()
+        .into_iter()
+        .find(|info| info.model_code.eq_ignore_ascii_case(name))
+        .map(|info| (info.model, info.dim))
+        .ok_or_else(|| IcmError::Embedding(format!("Unknown embedding model: {name}")))
 }
 
 impl FastEmbedder {
-    /// Create with default model (multilingual-e5-small).
+    /// Create with the default model (see `DEFAULT_MODEL`).
     pub fn new() -> Self {
         Self::with_model(DEFAULT_MODEL)
     }
@@ -170,50 +173,51 @@ impl FastEmbedder {
     pub fn with_model(model_name: &str) -> Self {
         let dims = resolve_model(model_name).map(|(_, d)| d).unwrap_or(384);
         Self {
-            model: OnceLock::new(),
-            init_lock: Mutex::new(()),
+            model: Mutex::new(None),
             model_name: model_name.to_string(),
             dims,
         }
     }
 
-    fn get_model(&self) -> IcmResult<&TextEmbedding> {
-        if let Some(m) = self.model.get() {
-            return Ok(m);
+    /// Run `f` against the lazily-initialized model, holding the lock for
+    /// the duration of the call (fastembed 6's `embed` needs `&mut self`).
+    fn with_loaded_model<R>(
+        &self,
+        f: impl FnOnce(&mut TextEmbedding) -> IcmResult<R>,
+    ) -> IcmResult<R> {
+        let mut guard = self.model.lock().unwrap();
+        if guard.is_none() {
+            let (emb_model, _) = resolve_model(&self.model_name)?;
+            let cache = cache_dir();
+            std::fs::create_dir_all(&cache)
+                .and_then(|()| cachedir::ensure_tag(&cache))
+                .unwrap_or_else(|e| tracing::warn!("could not tag cache dir: {e}"));
+            // With the load-dynamic ort backend (issue #345) onnxruntime is
+            // resolved at runtime. If it's absent, ort *panics* inside init —
+            // and since the release profile is `panic = "abort"`, that would
+            // kill the process rather than unwind (so catch_unwind can't
+            // help). Pre-flight the dylib instead: if it can't be dlopen'd,
+            // return a clean error (→ keyword-only search) before ort ever
+            // initializes. Static builds link onnxruntime in, so this check
+            // is compiled out there.
+            #[cfg(feature = "embeddings-dynamic")]
+            if !onnxruntime_dylib_available() {
+                return Err(IcmError::Embedding(
+                    "onnxruntime runtime not found for this load-dynamic build; \
+                     install onnxruntime (or set ORT_DYLIB_PATH), or run with \
+                     --no-embeddings for keyword-only search"
+                        .to_string(),
+                ));
+            }
+            let model = TextEmbedding::try_new(
+                InitOptions::new(emb_model)
+                    .with_show_download_progress(true)
+                    .with_cache_dir(cache),
+            )
+            .map_err(|e| IcmError::Embedding(format!("failed to init model: {e}")))?;
+            *guard = Some(model);
         }
-        let _guard = self.init_lock.lock().unwrap();
-        if let Some(m) = self.model.get() {
-            return Ok(m);
-        }
-        let (emb_model, _) = resolve_model(&self.model_name)?;
-        let cache = cache_dir();
-        std::fs::create_dir_all(&cache)
-            .and_then(|()| cachedir::ensure_tag(&cache))
-            .unwrap_or_else(|e| tracing::warn!("could not tag cache dir: {e}"));
-        // With the load-dynamic ort backend (issue #345) onnxruntime is resolved
-        // at runtime. If it's absent, ort *panics* inside init — and since the
-        // release profile is `panic = "abort"`, that would kill the process
-        // rather than unwind (so catch_unwind can't help). Pre-flight the dylib
-        // instead: if it can't be dlopen'd, return a clean error (→ keyword-only
-        // search) before ort ever initializes. Static builds link onnxruntime
-        // in, so this check is compiled out there.
-        #[cfg(feature = "embeddings-dynamic")]
-        if !onnxruntime_dylib_available() {
-            return Err(IcmError::Embedding(
-                "onnxruntime runtime not found for this load-dynamic build; \
-                 install onnxruntime (or set ORT_DYLIB_PATH), or run with \
-                 --no-embeddings for keyword-only search"
-                    .to_string(),
-            ));
-        }
-        let model = TextEmbedding::try_new(
-            InitOptions::new(emb_model)
-                .with_show_download_progress(true)
-                .with_cache_dir(cache),
-        )
-        .map_err(|e| IcmError::Embedding(format!("failed to init model: {e}")))?;
-        let _ = self.model.set(model);
-        Ok(self.model.get().unwrap())
+        f(guard.as_mut().unwrap())
     }
 
     /// e5-family instruction prefixes as `(query_prefix, passage_prefix)`.
@@ -236,7 +240,6 @@ impl FastEmbedder {
 
     /// Embed a single text, optionally prepending an instruction `prefix`.
     fn embed_one(&self, prefix: &str, text: &str) -> IcmResult<Vec<f32>> {
-        let model = self.get_model()?;
         let prefixed: String;
         let input: &str = if prefix.is_empty() {
             text
@@ -244,13 +247,15 @@ impl FastEmbedder {
             prefixed = format!("{prefix}{text}");
             &prefixed
         };
-        let results = model
-            .embed(vec![input], None)
-            .map_err(|e| IcmError::Embedding(e.to_string()))?;
-        results
-            .into_iter()
-            .next()
-            .ok_or_else(|| IcmError::Embedding("empty embedding result".into()))
+        self.with_loaded_model(|model| {
+            let results = model
+                .embed(vec![input], None)
+                .map_err(|e| IcmError::Embedding(e.to_string()))?;
+            results
+                .into_iter()
+                .next()
+                .ok_or_else(|| IcmError::Embedding("empty embedding result".into()))
+        })
     }
 }
 
@@ -277,18 +282,19 @@ impl Embedder for FastEmbedder {
         if texts.is_empty() {
             return Ok(Vec::new());
         }
-        let model = self.get_model()?;
         let (_, passage) = self.instruction_prefixes();
-        if passage.is_empty() {
-            model
-                .embed(texts.to_vec(), None)
-                .map_err(|e| IcmError::Embedding(e.to_string()))
-        } else {
-            let prefixed: Vec<String> = texts.iter().map(|t| format!("{passage}{t}")).collect();
-            model
-                .embed(prefixed, None)
-                .map_err(|e| IcmError::Embedding(e.to_string()))
-        }
+        self.with_loaded_model(|model| {
+            if passage.is_empty() {
+                model
+                    .embed(texts, None)
+                    .map_err(|e| IcmError::Embedding(e.to_string()))
+            } else {
+                let prefixed: Vec<String> = texts.iter().map(|t| format!("{passage}{t}")).collect();
+                model
+                    .embed(prefixed, None)
+                    .map_err(|e| IcmError::Embedding(e.to_string()))
+            }
+        })
     }
 
     fn dimensions(&self) -> usize {

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -54,7 +54,9 @@ pub use memory::{
     max_importance, Importance, Memory, MemorySource, PatternCluster, Scope, StoreStats,
     TopicHealth,
 };
-pub use store::{find_similar_memory, MemoryStore, DEDUP_SIMILARITY_THRESHOLD};
+pub use store::{
+    find_similar_memory, merge_summaries, union_keywords, MemoryStore, DEDUP_SIMILARITY_THRESHOLD,
+};
 pub use transcript::{Message, Role, Session, TranscriptHit, TranscriptStats};
 pub use transcript_store::TranscriptStore;
 pub use wake_up::{

--- a/crates/icm-core/src/lib.rs
+++ b/crates/icm-core/src/lib.rs
@@ -45,7 +45,7 @@ pub use error::{IcmError, IcmResult};
 pub use facts::{Fact, FactsStats};
 pub use facts_store::FactsStore;
 #[cfg(feature = "embeddings")]
-pub use fastembed_embedder::FastEmbedder;
+pub use fastembed_embedder::{FastEmbedder, DEFAULT_MODEL as DEFAULT_EMBEDDING_MODEL};
 pub use feedback::{Feedback, FeedbackStats};
 pub use feedback_store::FeedbackStore;
 pub use memoir::{Concept, ConceptLink, Label, Memoir, MemoirStats, Relation};

--- a/crates/icm-core/src/store.rs
+++ b/crates/icm-core/src/store.rs
@@ -9,16 +9,21 @@ use crate::memory::{Memory, StoreStats, TopicHealth};
 /// plutôt que Y") but describe genuinely DIFFERENT facts scored
 /// 0.90-0.93 cosine similarity — e.g. "We picked PostgreSQL over MySQL
 /// for the primary database" vs "We picked Kubernetes over Docker Swarm
-/// for the orchestration layer" scored 0.9093. At the old 0.85 threshold
-/// this silently overwrote the earlier, unrelated memory's content (the
-/// merge path replaces `summary` wholesale — see the `cmd_store`/
-/// `icm_memory_store` callers). Genuine near-duplicate restatements
-/// ("PostgreSQL was selected over MySQL for the main datastore") scored
-/// 0.9156-0.9635 — overlapping enough with the false-positive band that
-/// no threshold cleanly separates every case. 0.95 was chosen to
-/// eliminate the measured false positives (0.90-0.93) even at the cost
-/// of missing some looser true near-duplicates (an extra, redundant
-/// memory entry is far cheaper than silently destroying one).
+/// for the orchestration layer" scored 0.9093. Genuine near-duplicate
+/// restatements ("PostgreSQL was selected over MySQL for the main
+/// datastore") scored 0.9156-0.9635 — overlapping enough with the
+/// false-positive band that no threshold cleanly separates every case.
+/// 0.95 was chosen to eliminate the measured false positives (0.90-0.93)
+/// even at the cost of missing some looser true near-duplicates.
+///
+/// This threshold only decides whether a pair is a dedup *candidate* — it
+/// does not prove the two say the same thing. A second, independently
+/// measured false positive (two distinct LoCoMo benchmark greeting turns
+/// scoring 0.98, 2026-08-28) got past even this threshold and confirmed a
+/// case above 0.95 can still be unrelated content. The merge path
+/// (`cmd_store` / `icm_memory_store`) therefore never wholesale-replaces
+/// the existing summary — see `merge_summaries` — so a wrong candidate
+/// costs an extra, redundant sentence rather than destroying a memory.
 pub const DEDUP_SIMILARITY_THRESHOLD: f32 = 0.95;
 
 /// Find an existing memory that is similar enough to be considered a duplicate.
@@ -47,6 +52,48 @@ pub fn find_similar_memory(
     Ok(similar
         .into_iter()
         .find(|(m, score)| *score > threshold && m.topic == topic))
+}
+
+/// Combine an existing memory's summary with incoming content that scored
+/// above `DEDUP_SIMILARITY_THRESHOLD` against it.
+///
+/// `find_similar_memory` only proves the two are *semantically close*
+/// (cosine similarity), not that they say the same thing — the threshold's
+/// own docs record real cases (short, templated sentences) where distinct
+/// facts score above 0.95. Wholesale-replacing `existing` with `incoming`
+/// in that band silently destroys whichever fact was already stored (found
+/// empirically: two different greeting turns from a LoCoMo benchmark
+/// conversation scored 0.98 and the second overwrote the first).
+///
+/// When the two strings are the same statement (after trimming), returns
+/// `existing` unchanged — nothing to preserve, no growth. Otherwise appends
+/// `incoming` rather than discarding `existing`, trading a little
+/// redundancy for zero data loss; `auto_consolidate` (invoked right after
+/// every dedup update) keeps a topic that keeps restating itself from
+/// growing unbounded.
+pub fn merge_summaries(existing: &str, incoming: &str) -> String {
+    if existing.trim() == incoming.trim() {
+        existing.to_string()
+    } else {
+        format!("{}\n{}", existing.trim(), incoming.trim())
+    }
+}
+
+/// Union two keyword lists, preserving `existing`'s order and appending only
+/// `incoming` entries not already present (case-sensitive, matching how
+/// keywords are stored and filtered elsewhere).
+///
+/// Used alongside `merge_summaries` so a dedup update never drops the
+/// original memory's keywords (e.g. a dialogue-turn id) just because the
+/// incoming store call also supplied keywords.
+pub fn union_keywords(existing: &[String], incoming: &[String]) -> Vec<String> {
+    let mut merged = existing.to_vec();
+    for kw in incoming {
+        if !merged.contains(kw) {
+            merged.push(kw.clone());
+        }
+    }
+    merged
 }
 
 pub trait MemoryStore {
@@ -230,5 +277,52 @@ mod tests {
             result.is_some(),
             "a near-exact 0.99-similarity match must still be treated as a duplicate"
         );
+    }
+
+    /// Regression for the destructive-overwrite bug (found running a LoCoMo
+    /// benchmark pilot, 2026-08-28): two distinct dialogue turns scored 0.98
+    /// cosine similarity and the dedup merge replaced the first with the
+    /// second, losing it. `merge_summaries` must append, not replace, once
+    /// the two strings are not the same statement.
+    #[test]
+    fn merge_summaries_appends_distinct_content_instead_of_replacing() {
+        let existing = "Hey Mel! Good to see you! How have you been?";
+        let incoming = "Hey Mel! Great to catch up! How's life been treating you?";
+        let merged = merge_summaries(existing, incoming);
+        assert!(
+            merged.contains(existing) && merged.contains(incoming),
+            "both distinct statements must survive the merge, got: {merged:?}"
+        );
+    }
+
+    #[test]
+    fn merge_summaries_does_not_duplicate_an_exact_restatement() {
+        let text = "We picked PostgreSQL over MySQL for the primary database";
+        let merged = merge_summaries(text, text);
+        assert_eq!(
+            merged, text,
+            "merging identical content must not duplicate it"
+        );
+    }
+
+    #[test]
+    fn merge_summaries_ignores_surrounding_whitespace_when_comparing() {
+        let merged = merge_summaries("same fact", "  same fact  \n");
+        assert_eq!(merged, "same fact");
+    }
+
+    #[test]
+    fn union_keywords_preserves_existing_and_appends_new() {
+        let existing = vec!["D9:1".to_string(), "Melanie".to_string()];
+        let incoming = vec!["D5:4".to_string(), "Melanie".to_string()];
+        let merged = union_keywords(&existing, &incoming);
+        assert_eq!(merged, vec!["D9:1", "Melanie", "D5:4"]);
+    }
+
+    #[test]
+    fn union_keywords_with_empty_incoming_keeps_existing_unchanged() {
+        let existing = vec!["a".to_string(), "b".to_string()];
+        let merged = union_keywords(&existing, &[]);
+        assert_eq!(merged, existing);
     }
 }

--- a/crates/icm-mcp/src/tools.rs
+++ b/crates/icm-mcp/src/tools.rs
@@ -1073,18 +1073,17 @@ fn tool_store(
                 access_count: existing.access_count,
                 weight: 1.0,
                 topic: existing.topic.clone(),
-                summary: content.to_string(),
+                // Never wholesale-replace: `existing` and the incoming
+                // content are only known to be semantically close (cosine
+                // similarity), not the same statement — see
+                // `merge_summaries`'s docs for a measured case (two distinct
+                // LoCoMo greeting turns scored 0.98) where that destroyed
+                // the earlier memory's content.
+                summary: icm_core::merge_summaries(&existing.summary, content),
                 raw_excerpt: get_str(args, "raw_excerpt")
                     .map(|r| r.into())
                     .or_else(|| existing.raw_excerpt.clone()),
-                keywords: {
-                    let kw = parse_keywords(args);
-                    if kw.is_empty() {
-                        existing.keywords.clone()
-                    } else {
-                        kw
-                    }
-                },
+                keywords: icm_core::union_keywords(&existing.keywords, &parse_keywords(args)),
                 embedding: Some(query_emb.clone()),
                 // Never let a near-dup merge downgrade importance: an MCP
                 // caller that omits `importance` defaults to Medium, which

--- a/crates/icm-store/src/store/memory.rs
+++ b/crates/icm-store/src/store/memory.rs
@@ -352,7 +352,11 @@ impl MemoryStore for SqliteStore {
     ) -> IcmResult<Vec<(Memory, f32)>> {
         let limit = limit.min(1000);
         let pool_size = limit * 4;
-        let sanitized = sanitize_fts_query(query);
+        // OR-joined (not `sanitize_fts_query`'s AND): a multi-word natural-
+        // language question needs only one distinctive shared word with a
+        // candidate to contribute a BM25 signal alongside the vector score.
+        // See `sanitize_fts_query_any`'s docs.
+        let sanitized = sanitize_fts_query_any(query);
 
         // 1. Get FTS results with rank scores
         let fts_sql =

--- a/crates/icm-store/src/store/memory.rs
+++ b/crates/icm-store/src/store/memory.rs
@@ -351,7 +351,25 @@ impl MemoryStore for SqliteStore {
         limit: usize,
     ) -> IcmResult<Vec<(Memory, f32)>> {
         let limit = limit.min(1000);
-        let pool_size = limit * 4;
+        // Candidate-pool sizing is deliberately decoupled from `limit`
+        // once `limit` gets large: a caller widens `limit` well past what
+        // it actually wants back when a topic/project/keyword filter is
+        // about to run post-hoc (headroom for candidates the filter will
+        // drop — see `recall_query_limit` in icm-cli). Scaling `pool_size`
+        // with that inflated `limit` doesn't just fetch more candidates to
+        // filter, it changes the blended score of candidates ALREADY in
+        // range: `vec_scores`/`fts_scores` default a missing side to 0.0,
+        // so a candidate outside the (small) vector pool but inside the
+        // (now much larger) FTS pool used to score `0.3*fts + 0.7*0.0`;
+        // widening the vector pool to match gives it a real, usually
+        // higher, vector score too — shifting rankings among candidates
+        // that were already well-scored. Measured on a LoCoMo benchmark
+        // pilot: pool_size scaled with an inflated limit=50 dropped
+        // recall@5 from 56.2% (unscaled) to 52.7%/49.1% under looser caps;
+        // pinning the pool-sizing input to a small constant (5) held it at
+        // 56.2% while a topic-filtered query still got its full headroom
+        // via the unmodified final `truncate(limit)` below.
+        let pool_size = limit.clamp(1, 5) * 4;
         // OR-joined (not `sanitize_fts_query`'s AND): a multi-word natural-
         // language question needs only one distinctive shared word with a
         // candidate to contribute a BM25 signal alongside the vector score.

--- a/crates/icm-store/src/store/rows.rs
+++ b/crates/icm-store/src/store/rows.rs
@@ -137,8 +137,11 @@ pub(crate) fn truncate_at_char_boundary(s: &str, max: usize) -> &str {
     &s[..cut]
 }
 
-/// This function strips special chars and wraps each token in double quotes.
-pub(crate) fn sanitize_fts_query(query: &str) -> String {
+/// Strip FTS5 operator chars and return each surviving token wrapped in
+/// double quotes (so token content is never parsed as FTS5 syntax).
+/// Shared by [`sanitize_fts_query`] (AND join) and
+/// [`sanitize_fts_query_any`] (OR join).
+fn quoted_fts_tokens(query: &str) -> Vec<String> {
     // Limit input length to prevent abuse (UTF-8 safe truncation)
     let query = if query.len() > 10_000 {
         let mut end = 10_000;
@@ -166,7 +169,7 @@ pub(crate) fn sanitize_fts_query(query: &str) -> String {
         })
         .collect();
 
-    let tokens: Vec<String> = cleaned
+    cleaned
         .split_whitespace()
         .filter(|w| !w.is_empty())
         .take(100) // Limit token count to prevent excessive query complexity
@@ -175,8 +178,31 @@ pub(crate) fn sanitize_fts_query(query: &str) -> String {
             let stripped = w.replace('"', "");
             format!("\"{stripped}\"")
         })
-        .collect();
-    tokens.join(" ")
+        .collect()
+}
+
+/// This function strips special chars and wraps each token in double quotes,
+/// AND-joined (FTS5's default when tokens are merely adjacent): every token
+/// must match. Intended for literal/precise lookups (plain FTS fallback,
+/// feedback and memoir search).
+pub(crate) fn sanitize_fts_query(query: &str) -> String {
+    quoted_fts_tokens(query).join(" ")
+}
+
+/// Same tokenization as [`sanitize_fts_query`], OR-joined: any token
+/// matching is enough.
+///
+/// For a natural-language question ("What does Melanie do with her family
+/// on hikes?" -> 8+ tokens), AND-joining effectively kills FTS5 recall —
+/// no single short dialogue turn contains every query word, so the FTS
+/// side of a hybrid vector+FTS blend contributes ~0 regardless of its
+/// weight, silently reducing "hybrid search" to vector-only. OR-joining
+/// lets a turn that shares just the distinctive words ("hikes", "family")
+/// score via BM25 too, which is the actual point of blending FTS with
+/// vector similarity. Used by `search_hybrid`'s FTS component only — the
+/// precise-lookup call sites keep AND semantics.
+pub(crate) fn sanitize_fts_query_any(query: &str) -> String {
+    quoted_fts_tokens(query).join(" OR ")
 }
 
 /// Whether `e` is FTS5 rejecting a malformed MATCH query (e.g. "hello AND",

--- a/crates/icm-store/src/store/tests/validation.rs
+++ b/crates/icm-store/src/store/tests/validation.rs
@@ -24,6 +24,23 @@ fn test_sanitize_fts_query() {
     );
 }
 
+/// `search_hybrid`'s FTS component uses OR-joined tokens instead of
+/// `sanitize_fts_query`'s AND join: same tokenization, `" OR "` between
+/// tokens rather than `" "`, so a multi-word natural-language question
+/// still contributes a BM25 signal from any single shared word.
+#[test]
+fn test_sanitize_fts_query_any() {
+    assert_eq!(
+        sanitize_fts_query_any("hello world"),
+        "\"hello\" OR \"world\""
+    );
+    assert_eq!(sanitize_fts_query_any(""), "");
+    assert_eq!(
+        sanitize_fts_query_any("no-such column:vec"),
+        "\"no\" OR \"such\" OR \"column\" OR \"vec\""
+    );
+}
+
 #[test]
 fn test_search_fts_special_chars() {
     let store = test_store();


### PR DESCRIPTION
## Summary

Four fixes found via a LoCoMo benchmark pilot (conv-26, 419 turns, 28-30 questions, evidence recall@5), each measured before/after and kept only when it improved the score:

1. **`icm_core::merge_summaries`/`union_keywords`** (95dfd5f) — `cmd_store`/`icm_memory_store`'s dedup merge wholesale-replaced an existing memory's `summary`/`keywords` on a similarity match, even though `find_similar_memory`'s own docs record real false positives (two distinct sentences scoring above the 0.95 threshold). Found empirically: two different greeting turns scored 0.98 and the second silently destroyed the first. Ingesting 419 turns lost 181 of them this way. Now appends distinct content and unions keywords instead of replacing.

2. **`sanitize_fts_query_any`** (976d352) — `search_hybrid`'s FTS component AND-joined every query token (FTS5's default), so any natural-language question of 4+ words matched nothing — the "hybrid" search silently degraded to vector-only regardless of the configured blend weight. OR-joined for `search_hybrid` specifically; the precise-lookup call sites (plain FTS fallback, feedback/memoir search) keep AND semantics.

3. **`recall_query_limit`** (5f24e03) — `cmd_recall` (CLI) passed the caller's `limit` straight into `search_hybrid`/`search_fts`/`search_by_keywords`, which are topic-oblivious and truncate globally before the topic/project/keyword filter runs. On a multi-topic database (the normal case) a `-t` filter could report "no memories" even with relevant matches further down the ranking. The MCP `tool_recall` path already had this exact fix (an audit finding) — ported to the CLI. Also fixes an interaction bug found while verifying: widening the pool this way also inflated `search_hybrid`'s internal candidate-pool size, which changed blended scores for already-good candidates — pinned pool sizing to a small constant, independent of the filter-headroom limit.

4. **fastembed 4→6 bump + default model change** (60f7acd) — needed for BGE-M3/Qwen3/reranker access. Fixed 3 compat breaks (`embed` now `&mut self`, `EmbeddingModel::from_str` now matches Debug repr instead of `model_code` — silently broke every HuggingFace-style model name this codebase uses, `model_dimensions`'s hardcoded match stopped compiling on new models). Also fixed a bug this surfaced: `icm-core`'s `DEFAULT_MODEL` and `icm-cli`'s `EmbeddingsConfig::default().model` were two independently hardcoded strings that had drifted. Model comparison on the same pilot: e5-base (prior default) 56.2%, BAAI/bge-m3 50.9% (regressed — tuned for long-document retrieval, not short dialogue turns), multilingual-e5-large 63.4% (new default).

Net pilot score: 42.9% (dedup fix alone) → 63.4% (all four).

## Test plan
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --features embeddings-static` (380 tests) all green
- [x] New unit tests for each fix (`merge_summaries`/`union_keywords`, `sanitize_fts_query_any`, `recall_query_limit`, `embed_text_excludes_topic`-style coverage)
- [x] Manual multi-topic verification for the topic-starvation fix (40 noise entries vs 1 relevant, confirmed the relevant memory is no longer starved out)
- [x] Manual dedup-overwrite repro confirmed fixed (`Hey Mel!` greeting case from the finding)
- [ ] Follow-up (not in this PR): `DEDUP_SIMILARITY_THRESHOLD` (0.95) and `AutoLinkOptions::threshold` (0.75) were calibrated against e5-base and haven't been re-validated against e5-large

🤖 Generated with [Claude Code](https://claude.com/claude-code)