### PR TITLE
feat(store): hierarchical database path resolution with per-project support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ it end-to-end: facts seeded through ICM are recalled with 100% accuracy
 by Claude Code, Gemini CLI, Copilot CLI, Cursor Agent, and Aider —
 **98% cross-agent efficiency** on the standard test.
 
-If you want isolation (per-project, per-tool, etc.) pass `--db <path>`
-or set `ICM_DB_PATH`; each path is an independent corpus.
+If you want isolation (per-project, per-tool, etc.) pass `--db <path>`,
+set `ICM_DB`, or use `icm init --per-project` to create a project-local
+database under `.icm/`; each path is an independent corpus.
 
 ## Install
 
@@ -136,9 +137,17 @@ The download supports macOS (arm64/x86_64), Linux (x86_64/aarch64), and Windows 
 ## Setup
 
 ```bash
-# Auto-detect and configure all supported tools
+# Auto-detect and configure all supported tools (global database)
 icm init
+
+# Per-project database (stores memories in .icm/memories.db)
+icm init --per-project
 ```
+
+`--per-project` creates a project-local `.icm/config.toml` at the git
+root, so all `icm` commands run from within the project automatically
+use an isolated database. Combine with global `icm init` — global
+settings (tools, hooks) are unaffected; only the database is scoped.
 
 Configures **18 tools** in one command ([full integration guide](docs/integrations.md)):
 
@@ -475,11 +484,24 @@ Changing the model automatically re-creates the vector index (existing embedding
 
 Single SQLite file. No external services, no network dependency.
 
+Default (global) database location:
+
 ```
 ~/Library/Application Support/dev.icm.icm/memories.db                    # macOS
 ~/.local/share/dev.icm.icm/memories.db                                   # Linux
 C:\Users\<user>\AppData\Local\icm\icm\data\memories.db                   # Windows
 ```
+
+Per-project database (created by `icm init --per-project`):
+
+```
+<project-root>/.icm/memories.db
+```
+
+ICM auto-detects a project-local `.icm/config.toml` from the current
+working directory. A relative `[store].path` is resolved against the
+git root, so all `icm` commands within the project tree use the
+scoped database without needing `--db` on every invocation.
 
 ### Configuration
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -5,11 +5,22 @@
 #   Linux:   ~/.config/icm/config.toml
 #   Windows: C:\Users\<user>\AppData\Roaming\icm\icm\config\config.toml
 # Or override with: ICM_CONFIG=/path/to/config.toml
+#
+# Database path resolution (highest priority first):
+#   1. --db CLI flag
+#   2. ICM_DB environment variable
+#   3. [store].path in this config file
+#   4. <project-root>/.icm/config.toml [store].path (auto-detected via git root)
+#   5. <project-root>/.icm/memories.db (auto-detected via git root)
+#   6. Platform default data directory (see src/main.rs default_db_path)
 
 [store]
 # SQLite database path (default: platform data dir).
 # Uncomment to use a custom location:
 # path = "/custom/path/to/memories.db"
+#
+# For per-project databases, set ICM_DB or create a .icm/config.toml
+# at your project root via `icm init --per-project`.
 
 [store.backup]
 # Automatic preventive backups using the SQLite Online Backup API.

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -1859,6 +1859,72 @@ fn resolve_embedding_dims(
     }
 }
 
+#[cfg(feature = "embeddings")]
+fn init_embedder(model: &str) -> Option<icm_core::FastEmbedder> {
+    Some(icm_core::FastEmbedder::with_model(model))
+}
+
+/// Placeholder embedder for builds without the `embeddings` feature.
+///
+/// It is never instantiated (`init_embedder` always returns `None` and the
+/// runtime guards on `embeddings_enabled`), but giving the no-embeddings
+/// build a concrete `Embedder` type lets the many
+/// `embedder.as_ref().map(|e| e as &dyn Embedder)` call sites compile
+/// without per-site `#[cfg]` gates.
+#[cfg(not(feature = "embeddings"))]
+struct DisabledEmbedder;
+
+#[cfg(not(feature = "embeddings"))]
+impl icm_core::Embedder for DisabledEmbedder {
+    fn embed(&self, _text: &str) -> icm_core::IcmResult<Vec<f32>> {
+        Err(icm_core::IcmError::Embedding(
+            "this build was compiled without the `embeddings` feature".into(),
+        ))
+    }
+    fn embed_batch(&self, _texts: &[&str]) -> icm_core::IcmResult<Vec<Vec<f32>>> {
+        Err(icm_core::IcmError::Embedding(
+            "this build was compiled without the `embeddings` feature".into(),
+        ))
+    }
+    fn dimensions(&self) -> usize {
+        icm_core::DEFAULT_EMBEDDING_DIMS
+    }
+}
+
+#[cfg(not(feature = "embeddings"))]
+fn init_embedder(_model: &str) -> Option<DisabledEmbedder> {
+    None
+}
+
+/// `icm embeddings status|download` — manage the semantic-search runtime.
+/// Behavior depends on how this binary was built (issue #345).
+fn cmd_embeddings(action: &EmbeddingsAction) -> Result<()> {
+    match action {
+        EmbeddingsAction::Status => {
+            #[cfg(feature = "embeddings-dynamic")]
+            ort_runtime::cmd_status();
+            #[cfg(all(feature = "embeddings", not(feature = "embeddings-dynamic")))]
+            println!(
+                "onnxruntime is statically linked into this build — semantic search is \
+                 always available."
+            );
+            #[cfg(not(feature = "embeddings"))]
+            println!("This build was compiled without embeddings (keyword-only search).");
+        }
+        EmbeddingsAction::Download => {
+            #[cfg(feature = "embeddings-dynamic")]
+            {
+                ort_runtime::cmd_download()?;
+            }
+            #[cfg(all(feature = "embeddings", not(feature = "embeddings-dynamic")))]
+            println!("Nothing to download: onnxruntime is statically linked into this build.");
+            #[cfg(not(feature = "embeddings"))]
+            println!("This build was compiled without embeddings; nothing to download.");
+        }
+    }
+    Ok(())
+}
+
 fn main() -> Result<()> {
     // Reset SIGPIPE to default so piped commands (e.g. `icm export | head`)
     // don't panic on broken pipe.
@@ -5947,20 +6013,19 @@ description: ICM persistent memory — /{name}
     //   <git-root>/.icm/config.toml  with  [store] path = ".icm/memories.db"
     // On subsequent invocations, the resolver will pick this up.
     if per_project {
-        let project_root = detect_project_root()
-            .or_else(|| std::env::current_dir().ok());
+        let project_root = detect_project_root().or_else(|| std::env::current_dir().ok());
         if let Some(root) = project_root {
             let icm_dir = root.join(".icm");
             if !icm_dir.is_dir() {
                 std::fs::create_dir_all(&icm_dir)
                     .with_context(|| format!("creating {}", icm_dir.display()))?;
                 let project_cfg = icm_dir.join("config.toml");
-                std::fs::write(
-                    &project_cfg,
-                    "[store]\npath = \".icm/memories.db\"\n",
-                )
-                .with_context(|| format!("writing {}", project_cfg.display()))?;
-                println!("[project] created project-local .icm/ at {}", root.display());
+                std::fs::write(&project_cfg, "[store]\npath = \".icm/memories.db\"\n")
+                    .with_context(|| format!("writing {}", project_cfg.display()))?;
+                println!(
+                    "[project] created project-local .icm/ at {}",
+                    root.display()
+                );
             } else {
                 println!("[project] .icm/ already exists at {}", root.display());
             }
@@ -7739,7 +7804,10 @@ fn cmd_config(cli_db: Option<PathBuf>, cfg: &config::Config) -> Result<()> {
     let project_root = detect_project_root();
     let resolved = resolve_db_path(cli_db, cfg);
     println!("  resolved = {}", resolved.display());
-    println!("  path (config) = {}", cfg.store.path.as_deref().unwrap_or("(not set)"));
+    println!(
+        "  path (config) = {}",
+        cfg.store.path.as_deref().unwrap_or("(not set)")
+    );
     if let Some(ref env) = env_db {
         println!("  ICM_DB (env)  = {env}");
     } else {
@@ -11894,6 +11962,154 @@ mod read_only_requested_tests {
     fn no_flag_no_env_means_writable() {
         with_env(None, || {
             assert!(!read_only_requested(false));
+        });
+    }
+}
+
+#[cfg(test)]
+mod resolve_db_path_tests {
+    use super::*;
+
+    /// `resolve_db_path` reads `$ICM_DB` and shells out to `git rev-parse`
+    /// against the process cwd — both process-global state — so every test
+    /// here holds this lock and restores cwd/env before releasing it.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_isolated_cwd<F: FnOnce(&std::path::Path)>(body: F) {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let prev_cwd = std::env::current_dir().unwrap();
+        let prev_icm_db = std::env::var("ICM_DB").ok();
+        std::env::remove_var("ICM_DB");
+
+        let dir = tempfile::tempdir().unwrap();
+        // macOS: /tmp (and TMPDIR) is a symlink into /private/tmp — the
+        // `git rev-parse --show-toplevel` that `detect_project_root` shells
+        // out to always returns the canonicalized path, so comparing
+        // against the raw tempdir path here would spuriously fail on a
+        // string mismatch (`/var/folders/...` vs `/private/var/folders/...`)
+        // that has nothing to do with `resolve_db_path`'s actual behavior.
+        let canonical = dir.path().canonicalize().unwrap();
+        std::env::set_current_dir(&canonical).unwrap();
+        body(&canonical);
+
+        std::env::set_current_dir(prev_cwd).unwrap();
+        match prev_icm_db {
+            Some(v) => std::env::set_var("ICM_DB", v),
+            None => std::env::remove_var("ICM_DB"),
+        }
+    }
+
+    #[test]
+    fn cli_flag_wins_over_everything() {
+        with_isolated_cwd(|_| {
+            std::env::set_var("ICM_DB", "/should/not/win");
+            let cfg = config::Config::default();
+            let resolved = resolve_db_path(Some(PathBuf::from("/explicit/flag.db")), &cfg);
+            assert_eq!(resolved, PathBuf::from("/explicit/flag.db"));
+        });
+    }
+
+    #[test]
+    fn env_var_wins_when_no_flag() {
+        with_isolated_cwd(|_| {
+            std::env::set_var("ICM_DB", "/from/env.db");
+            let cfg = config::Config::default();
+            let resolved = resolve_db_path(None, &cfg);
+            assert_eq!(resolved, PathBuf::from("/from/env.db"));
+        });
+    }
+
+    #[test]
+    fn config_path_wins_over_project_local_and_default() {
+        with_isolated_cwd(|dir| {
+            // Even inside a git repo with a project-local .icm/memories.db,
+            // an explicit config [store].path must win (level 3 > 4/5).
+            std::process::Command::new("git")
+                .arg("init")
+                .arg("-q")
+                .current_dir(dir)
+                .status()
+                .unwrap();
+            std::fs::create_dir_all(dir.join(".icm")).unwrap();
+            std::fs::write(dir.join(".icm").join("memories.db"), "").unwrap();
+
+            let mut cfg = config::Config::default();
+            cfg.store.path = Some("/from/config.db".to_string());
+            let resolved = resolve_db_path(None, &cfg);
+            assert_eq!(resolved, PathBuf::from("/from/config.db"));
+        });
+    }
+
+    #[test]
+    fn project_local_config_toml_wins_over_bare_memories_db() {
+        with_isolated_cwd(|dir| {
+            std::process::Command::new("git")
+                .arg("init")
+                .arg("-q")
+                .current_dir(dir)
+                .status()
+                .unwrap();
+            let icm_dir = dir.join(".icm");
+            std::fs::create_dir_all(&icm_dir).unwrap();
+            // Both a config.toml (level 4) and a bare memories.db (level 5)
+            // exist — the config.toml's path must win.
+            std::fs::write(icm_dir.join("memories.db"), "").unwrap();
+            std::fs::write(
+                icm_dir.join("config.toml"),
+                "[store]\npath = \"custom-name.db\"\n",
+            )
+            .unwrap();
+
+            let cfg = config::Config::default();
+            let resolved = resolve_db_path(None, &cfg);
+            assert_eq!(resolved, dir.join("custom-name.db"));
+        });
+    }
+
+    #[test]
+    fn project_local_memories_db_used_when_no_config_toml() {
+        with_isolated_cwd(|dir| {
+            std::process::Command::new("git")
+                .arg("init")
+                .arg("-q")
+                .current_dir(dir)
+                .status()
+                .unwrap();
+            let icm_dir = dir.join(".icm");
+            std::fs::create_dir_all(&icm_dir).unwrap();
+            std::fs::write(icm_dir.join("memories.db"), "").unwrap();
+
+            let cfg = config::Config::default();
+            let resolved = resolve_db_path(None, &cfg);
+            assert_eq!(resolved, icm_dir.join("memories.db"));
+        });
+    }
+
+    #[test]
+    fn falls_back_to_default_outside_any_git_repo_without_icm_dir() {
+        with_isolated_cwd(|_| {
+            // No git init here — not a repo, no .icm/ — must fall through
+            // to the platform default rather than panicking or picking up
+            // an unrelated ancestor repo's .icm/ (e.g. this very checkout's).
+            let cfg = config::Config::default();
+            let resolved = resolve_db_path(None, &cfg);
+            assert_eq!(resolved, default_db_path());
+        });
+    }
+
+    #[test]
+    fn git_repo_without_icm_dir_falls_back_to_default() {
+        with_isolated_cwd(|dir| {
+            std::process::Command::new("git")
+                .arg("init")
+                .arg("-q")
+                .current_dir(dir)
+                .status()
+                .unwrap();
+            // A real git repo, but no .icm/ directory created yet.
+            let cfg = config::Config::default();
+            let resolved = resolve_db_path(None, &cfg);
+            assert_eq!(resolved, default_db_path());
         });
     }
 }

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -5944,7 +5944,7 @@ description: ICM persistent memory — /{name}
     // --- Project-local .icm/ setup ---
     // When --per-project is set, create a project-local database config
     // so ICM uses a separate database per project. This creates:
-    //   <git-root>/.icm/config.toml  with  [store] path = "memories.db"
+    //   <git-root>/.icm/config.toml  with  [store] path = ".icm/memories.db"
     // On subsequent invocations, the resolver will pick this up.
     if per_project {
         let project_root = detect_project_root()
@@ -5957,7 +5957,7 @@ description: ICM persistent memory — /{name}
                 let project_cfg = icm_dir.join("config.toml");
                 std::fs::write(
                     &project_cfg,
-                    "[store]\npath = \"memories.db\"\n",
+                    "[store]\npath = \".icm/memories.db\"\n",
                 )
                 .with_context(|| format!("writing {}", project_cfg.display()))?;
                 println!("[project] created project-local .icm/ at {}", root.display());

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -449,7 +449,8 @@ enum Commands {
 
         /// Also write project-level instruction files into the current
         /// directory (`CLAUDE.md`, `AGENTS.md`, `.windsurfrules`,
-        /// `.aider.conventions.md`, `.github/copilot-instructions.md`).
+        /// `.aider.conventions.md`, `.github/copilot-instructions.md`)
+        /// and set up a project-local database under `.icm/`.
         /// Default behavior writes only to global per-tool paths
         /// (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, etc.) so init
         /// doesn't pollute every project tree.
@@ -1557,21 +1558,108 @@ fn default_db_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("memories.db"))
 }
 
-fn open_store(db: Option<PathBuf>, embedding_dims: usize) -> Result<Store> {
-    let path = db.unwrap_or_else(default_db_path);
-    Store::with_dims(&path, embedding_dims).context("failed to open database")
+/// Detect the project root (git repository root) from the current directory.
+fn detect_project_root() -> Option<PathBuf> {
+    std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if path.is_empty() {
+                    None
+                } else {
+                    Some(PathBuf::from(path))
+                }
+            } else {
+                None
+            }
+        })
+}
+
+/// Resolve database path using hierarchical resolution:
+///
+/// 1. `--db` CLI flag (highest priority)
+/// 2. `$ICM_DB` environment variable
+/// 3. Global config `[store].path` from config file
+/// 4. Project-local `.icm/config.toml` `[store].path` at git root
+/// 5. Project-local `.icm/memories.db` at git root (if file exists)
+/// 6. Default platform data directory
+fn resolve_db_path(cli_db: Option<PathBuf>, cfg: &config::Config) -> PathBuf {
+    // 1. --db CLI flag
+    if let Some(db) = cli_db {
+        return db;
+    }
+
+    // 2. $ICM_DB env var
+    if let Ok(env_db) = std::env::var("ICM_DB") {
+        let path = PathBuf::from(env_db);
+        if !path.as_os_str().is_empty() {
+            return path;
+        }
+    }
+
+    // 3. Global config [store].path
+    if let Some(config_path) = &cfg.store.path {
+        let path = PathBuf::from(config_path);
+        if !path.as_os_str().is_empty() {
+            return path;
+        }
+    }
+
+    // 4. Project-local .icm/ directory (at git root)
+    if let Some(project_root) = detect_project_root() {
+        let icm_dir = project_root.join(".icm");
+        if icm_dir.is_dir() {
+            // 4a. .icm/config.toml with [store].path
+            let project_cfg = icm_dir.join("config.toml");
+            if project_cfg.exists() {
+                if let Ok(content) = std::fs::read_to_string(&project_cfg) {
+                    if let Ok(value) = content.parse::<toml::Value>() {
+                        if let Some(path_str) = value
+                            .get("store")
+                            .and_then(|s| s.get("path"))
+                            .and_then(|p| p.as_str())
+                        {
+                            let path = if Path::new(path_str).is_absolute() {
+                                PathBuf::from(path_str)
+                            } else {
+                                project_root.join(path_str)
+                            };
+                            if !path.as_os_str().is_empty() {
+                                return path;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // 4b. .icm/memories.db (if file exists)
+            let project_db = icm_dir.join("memories.db");
+            if project_db.exists() {
+                return project_db;
+            }
+        }
+    }
+
+    // 5. Default platform data dir
+    default_db_path()
+}
+
+fn open_store(db: PathBuf, embedding_dims: usize) -> Result<Store> {
+    Store::with_dims(&db, embedding_dims).context("failed to open database")
 }
 
 /// Open the store and, if `backup_cfg.enabled`, trigger an automatic backup
 /// when the last backup is older than `interval_days`. Backup errors are
 /// logged as warnings — they must not block the normal workflow.
 fn open_store_with_backup(
-    db: Option<PathBuf>,
+    path: PathBuf,
     embedding_dims: usize,
     backup_cfg: &crate::config::BackupConfig,
 ) -> Result<Store> {
-    let path = db.clone().unwrap_or_else(default_db_path);
-    let store = open_store(db, embedding_dims)?;
+    let store = open_store(path.clone(), embedding_dims)?;
 
     if backup_cfg.enabled && path.exists() {
         if backup_cfg.keep_backups == 0 {
@@ -1709,8 +1797,7 @@ fn cmd_backup(db_path: &std::path::Path, output: Option<&std::path::Path>) -> Re
 /// the same way as [`open_store`] and rejects with a helpful message
 /// if the DB doesn't exist yet — read-only mode cannot bootstrap a
 /// fresh DB.
-fn open_store_readonly(db: Option<PathBuf>) -> Result<Store> {
-    let path = db.unwrap_or_else(default_db_path);
+fn open_store_readonly(path: PathBuf) -> Result<Store> {
     Store::open_readonly(&path).with_context(|| {
         format!(
             "failed to open database read-only at {} \
@@ -1746,14 +1833,13 @@ fn read_only_requested(cli_flag: bool) -> bool {
 ///    `DEFAULT_EMBEDDING_DIMS` (fresh install, nothing to lose).
 fn resolve_embedding_dims(
     embedder: Option<&dyn icm_core::Embedder>,
-    cli_db: Option<&PathBuf>,
+    db_path: &Path,
     _cfg: &crate::config::Config,
 ) -> usize {
     if let Some(e) = embedder {
         return e.dimensions();
     }
-    let path = cli_db.cloned().unwrap_or_else(default_db_path);
-    match Store::read_stored_embedding_dims(&path) {
+    match Store::read_stored_embedding_dims(db_path) {
         Ok(Some(dims)) => dims,
         // No DB or no metadata row → fresh install path; default is safe.
         Ok(None) => icm_core::DEFAULT_EMBEDDING_DIMS,
@@ -1765,78 +1851,12 @@ fn resolve_embedding_dims(
             tracing::warn!(
                 "could not peek stored embedding dims at {} ({}); \
                  falling back to DEFAULT_EMBEDDING_DIMS",
-                path.display(),
+                db_path.display(),
                 e,
             );
             icm_core::DEFAULT_EMBEDDING_DIMS
         }
     }
-}
-
-#[cfg(feature = "embeddings")]
-fn init_embedder(model: &str) -> Option<icm_core::FastEmbedder> {
-    Some(icm_core::FastEmbedder::with_model(model))
-}
-
-/// Placeholder embedder for builds without the `embeddings` feature.
-///
-/// It is never instantiated (`init_embedder` always returns `None` and the
-/// runtime guards on `embeddings_enabled`), but giving the no-embeddings
-/// build a concrete `Embedder` type lets the many
-/// `embedder.as_ref().map(|e| e as &dyn Embedder)` call sites compile
-/// without per-site `#[cfg]` gates.
-#[cfg(not(feature = "embeddings"))]
-struct DisabledEmbedder;
-
-#[cfg(not(feature = "embeddings"))]
-impl icm_core::Embedder for DisabledEmbedder {
-    fn embed(&self, _text: &str) -> icm_core::IcmResult<Vec<f32>> {
-        Err(icm_core::IcmError::Embedding(
-            "this build was compiled without the `embeddings` feature".into(),
-        ))
-    }
-    fn embed_batch(&self, _texts: &[&str]) -> icm_core::IcmResult<Vec<Vec<f32>>> {
-        Err(icm_core::IcmError::Embedding(
-            "this build was compiled without the `embeddings` feature".into(),
-        ))
-    }
-    fn dimensions(&self) -> usize {
-        icm_core::DEFAULT_EMBEDDING_DIMS
-    }
-}
-
-#[cfg(not(feature = "embeddings"))]
-fn init_embedder(_model: &str) -> Option<DisabledEmbedder> {
-    None
-}
-
-/// `icm embeddings status|download` — manage the semantic-search runtime.
-/// Behavior depends on how this binary was built (issue #345).
-fn cmd_embeddings(action: &EmbeddingsAction) -> Result<()> {
-    match action {
-        EmbeddingsAction::Status => {
-            #[cfg(feature = "embeddings-dynamic")]
-            ort_runtime::cmd_status();
-            #[cfg(all(feature = "embeddings", not(feature = "embeddings-dynamic")))]
-            println!(
-                "onnxruntime is statically linked into this build — semantic search is \
-                 always available."
-            );
-            #[cfg(not(feature = "embeddings"))]
-            println!("This build was compiled without embeddings (keyword-only search).");
-        }
-        EmbeddingsAction::Download => {
-            #[cfg(feature = "embeddings-dynamic")]
-            {
-                ort_runtime::cmd_download()?;
-            }
-            #[cfg(all(feature = "embeddings", not(feature = "embeddings-dynamic")))]
-            println!("Nothing to download: onnxruntime is statically linked into this build.");
-            #[cfg(not(feature = "embeddings"))]
-            println!("This build was compiled without embeddings; nothing to download.");
-        }
-    }
-    Ok(())
 }
 
 fn main() -> Result<()> {
@@ -1903,11 +1923,6 @@ fn main() -> Result<()> {
     } else {
         None
     };
-    let embedding_dims = resolve_embedding_dims(
-        embedder.as_ref().map(|e| e as &dyn icm_core::Embedder),
-        cli.db.first(),
-        &cfg,
-    );
     // Audit #185 medium: reject `--db A ... --db B` (or with `=`)
     // instead of silently letting the last occurrence win. Clap
     // alone doesn't catch the parent+subcommand split case (the
@@ -1929,11 +1944,19 @@ fn main() -> Result<()> {
         }
     }
     let cli_db: Option<PathBuf> = cli.db.into_iter().next();
-    // `db_path` feeds the extract-pending worker lock (#322) and some
+    // `db_path` centralizes hierarchical resolution (issue #257): --db flag,
+    // $ICM_DB env var, global config, project-local .icm/, then the platform
+    // default. It feeds the extract-pending worker lock (#322), doctor/repair/
+    // backup (which bypass the normal store open below), and some
     // feature-gated commands (e.g. the embeddings-only `embed`); it can be
     // unused in the leanest builds.
     #[allow(unused_variables)]
-    let db_path = cli_db.clone().unwrap_or_else(default_db_path);
+    let db_path = resolve_db_path(cli_db.clone(), &cfg);
+    let embedding_dims = resolve_embedding_dims(
+        embedder.as_ref().map(|e| e as &dyn icm_core::Embedder),
+        &db_path,
+        &cfg,
+    );
 
     // `icm uninstall` must NOT open the SQLite store: a default
     // `open_store` call would recreate the DB directory and WAL/SHM files
@@ -1981,7 +2004,7 @@ fn main() -> Result<()> {
         );
         let mut reader = open_export_reader(from_export)?;
         let dims = peek_export_embedding_dims(&mut reader).unwrap_or(embedding_dims);
-        let store = open_store_with_backup(cli_db.clone(), dims, &cfg.store.backup)?;
+        let store = open_store_with_backup(db_path.clone(), dims, &cfg.store.backup)?;
         return cmd_import_from_export(&store, reader, dry_run);
     }
     if let Commands::Import {
@@ -1992,7 +2015,7 @@ fn main() -> Result<()> {
     {
         let mut reader = open_export_reader(src)?;
         let dims = peek_export_embedding_dims(&mut reader).unwrap_or(embedding_dims);
-        let store = open_store_with_backup(cli_db.clone(), dims, &cfg.store.backup)?;
+        let store = open_store_with_backup(db_path.clone(), dims, &cfg.store.backup)?;
         return cmd_import_from_export(&store, reader, dry_run);
     }
     // `icm hook disable` only edits AI-tool settings files — it needs neither
@@ -2011,9 +2034,9 @@ fn main() -> Result<()> {
     }
 
     let store = if read_only_requested(cli.read_only) {
-        open_store_readonly(cli_db)?
+        open_store_readonly(db_path.clone())?
     } else {
-        open_store_with_backup(cli_db, embedding_dims, &cfg.store.backup)?
+        open_store_with_backup(db_path.clone(), embedding_dims, &cfg.store.backup)?
     };
 
     match command {
@@ -2374,7 +2397,7 @@ fn main() -> Result<()> {
             force,
             per_project,
             with_codex_post_hook,
-        } => cmd_init(mode, force, per_project, with_codex_post_hook),
+        } => cmd_init(mode, force, per_project, with_codex_post_hook, &db_path),
         // Doctor, Repair and Backup are dispatched before `open_store` above;
         // these arms exist only for match exhaustiveness and are unreachable.
         Commands::Doctor => unreachable!("dispatched before open_store"),
@@ -2493,7 +2516,7 @@ fn main() -> Result<()> {
             println!("{result}");
             Ok(())
         }
-        Commands::Config => cmd_config(),
+        Commands::Config => cmd_config(cli_db, &cfg),
         Commands::Upgrade { apply, check } => upgrade::cmd_upgrade(apply, check),
         #[cfg(feature = "bench")]
         Commands::Bench { count } => cmd_bench(count),
@@ -5045,6 +5068,7 @@ fn cmd_init(
     force: bool,
     per_project: bool,
     with_codex_post_hook: bool,
+    db_path: &Path,
 ) -> Result<()> {
     let icm_bin = std::env::current_exe().context("cannot determine icm binary path")?;
     let icm_bin_str = portable_command_path(&icm_bin);
@@ -5917,9 +5941,35 @@ description: ICM persistent memory — /{name}
         manifest.save(&manifest_path)?;
     }
 
+    // --- Project-local .icm/ setup ---
+    // When --per-project is set, create a project-local database config
+    // so ICM uses a separate database per project. This creates:
+    //   <git-root>/.icm/config.toml  with  [store] path = "memories.db"
+    // On subsequent invocations, the resolver will pick this up.
+    if per_project {
+        let project_root = detect_project_root()
+            .or_else(|| std::env::current_dir().ok());
+        if let Some(root) = project_root {
+            let icm_dir = root.join(".icm");
+            if !icm_dir.is_dir() {
+                std::fs::create_dir_all(&icm_dir)
+                    .with_context(|| format!("creating {}", icm_dir.display()))?;
+                let project_cfg = icm_dir.join("config.toml");
+                std::fs::write(
+                    &project_cfg,
+                    "[store]\npath = \"memories.db\"\n",
+                )
+                .with_context(|| format!("writing {}", project_cfg.display()))?;
+                println!("[project] created project-local .icm/ at {}", root.display());
+            } else {
+                println!("[project] .icm/ already exists at {}", root.display());
+            }
+        }
+    }
+
     println!();
     println!("  binary:   {icm_bin_str}");
-    println!("  db:       {}", default_db_path().display());
+    println!("  db:       {}", db_path.display());
     if !manifest.is_empty() {
         println!(
             "  manifest: {} ({} entr{})",
@@ -7681,18 +7731,51 @@ fn inject_opencode_mcp_server(config_path: &Path, name: &str, icm_bin: &str) -> 
     Ok("configured".into())
 }
 
-fn cmd_config() -> Result<()> {
-    let cfg = config::load_config()?;
+fn cmd_config(cli_db: Option<PathBuf>, cfg: &config::Config) -> Result<()> {
     println!("Config: {}", config::show_config_path());
     println!();
     println!("[store]");
-    println!(
-        "  path = {}",
-        cfg.store
-            .path
-            .as_deref()
-            .unwrap_or("(default platform path)")
-    );
+    let env_db = std::env::var("ICM_DB").ok();
+    let project_root = detect_project_root();
+    let resolved = resolve_db_path(cli_db, cfg);
+    println!("  resolved = {}", resolved.display());
+    println!("  path (config) = {}", cfg.store.path.as_deref().unwrap_or("(not set)"));
+    if let Some(ref env) = env_db {
+        println!("  ICM_DB (env)  = {env}");
+    } else {
+        println!("  ICM_DB (env)  = (not set)");
+    }
+    if let Some(root) = &project_root {
+        println!();
+        println!("[project]");
+        println!("  root = {}", root.display());
+        let icm_dir = root.join(".icm");
+        if icm_dir.is_dir() {
+            println!("  .icm/ exists");
+            let project_cfg = icm_dir.join("config.toml");
+            if project_cfg.exists() {
+                if let Ok(content) = std::fs::read_to_string(&project_cfg) {
+                    if let Ok(value) = content.parse::<toml::Value>() {
+                        if let Some(path_str) = value
+                            .get("store")
+                            .and_then(|s| s.get("path"))
+                            .and_then(|p| p.as_str())
+                        {
+                            println!("  .icm/config.toml [store].path = {path_str}");
+                        }
+                    }
+                }
+            }
+            let project_db = icm_dir.join("memories.db");
+            if project_db.exists() {
+                println!("  .icm/memories.db exists");
+            } else {
+                println!("  .icm/memories.db (not found)");
+            }
+        } else {
+            println!("  .icm/ (not found)");
+        }
+    }
     println!();
     println!("[memory]");
     println!("  default_importance = {}", cfg.memory.default_importance);

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -12062,7 +12062,15 @@ mod resolve_db_path_tests {
 
             let cfg = config::Config::default();
             let resolved = resolve_db_path(None, &cfg);
-            assert_eq!(resolved, dir.join("custom-name.db"));
+            // Compare against `detect_project_root()`'s own output rather
+            // than the raw tempdir path: `git rev-parse --show-toplevel`
+            // canonicalizes (symlink resolution on macOS — /var vs
+            // /private/var — and a `\\?\`-prefixed extended path on
+            // Windows), so building the expectation from the same function
+            // under test avoids a platform-specific string mismatch that
+            // has nothing to do with `resolve_db_path`'s actual behavior.
+            let project_root = detect_project_root().unwrap();
+            assert_eq!(resolved, project_root.join("custom-name.db"));
         });
     }
 
@@ -12081,7 +12089,8 @@ mod resolve_db_path_tests {
 
             let cfg = config::Config::default();
             let resolved = resolve_db_path(None, &cfg);
-            assert_eq!(resolved, icm_dir.join("memories.db"));
+            let project_root = detect_project_root().unwrap();
+            assert_eq!(resolved, project_root.join(".icm").join("memories.db"));
         });
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -402,6 +402,66 @@ Pattern-based scoring. Each sentence gets a score from keyword matches:
 
 Sentences below threshold are dropped. Dedup via Jaccard similarity (>0.6 = skip).
 
+## Database Path Resolution
+
+ICM determines the active SQLite database path through a 6-level hierarchical resolution chain. Each level overrides the ones below it:
+
+```
+Priority 1: --db CLI flag (highest)
+Priority 2: ICM_DB environment variable
+Priority 3: Global config [store].path (~/.config/icm/config.toml)
+Priority 4: Project-local .icm/config.toml [store].path (detected via git root)
+Priority 5: Project-local .icm/memories.db (auto-detected at git root, file must exist)
+Priority 6: Default platform data directory (lowest)
+```
+
+### Resolution flow
+
+`resolve_db_path()` is called at startup (before `open_store()`):
+
+```
+resolve_db_path(cli_db, cfg)
+  ├─ cli_db present?            → return it        (level 1)
+  ├─ $ICM_DB set?               → return it        (level 2)
+  ├─ cfg.store.path set?        → return it        (level 3)
+  ├─ detect_project_root() ok?
+  │   ├─ .icm/config.toml has [store].path? → return it (level 4)
+  │   └─ .icm/memories.db exists?           → return it (level 5)
+  └─ default_db_path()          → return it        (level 6)
+```
+
+`detect_project_root()` shells out to `git rev-parse --show-toplevel`. If the current directory is not inside a git repository, levels 4-5 are skipped.
+
+### Per-project database
+
+`icm init --per-project` creates `<git-root>/.icm/config.toml`:
+
+```toml
+[store]
+path = "memories.db"
+```
+
+A relative path is resolved against the git root. On subsequent invocations, the resolver picks up level 4 and uses the project-local database. All `icm` commands within that project tree then use the scoped database without needing `--db` on every call.
+
+Combine with global `icm init` — global settings (tools, hooks) are unaffected; only the database is scoped.
+
+### Config display
+
+`icm config` shows the full resolution chain with source tracing:
+
+```
+[store]
+ resolved = /home/user/project/.icm/memories.db
+ path (config) = memories.db
+ ICM_DB (env) = (not set)
+
+[project]
+ root = /home/user/project
+ .icm/ exists
+ .icm/config.toml [store].path = memories.db
+ .icm/memories.db exists
+```
+
 ## Build
 
 ```bash

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -27,8 +27,25 @@ Re-running the install command upgrades an existing installation in place.
 ### 2. Setup
 
 ```bash
+# Global setup — one database for all projects
 icm init
+
+# Per-project setup — isolated database per project
+icm init --per-project
 ```
+
+`--per-project` creates `.icm/config.toml` at the project's git root. All `icm` commands within that project tree automatically use the project-local database, without needing `--db` on every invocation. The database path is resolved hierarchically:
+
+| Priority | Source | Example |
+|----------|--------|---------|
+| 1 | `--db` CLI flag | `icm --db /tmp/test.db store ...` |
+| 2 | `ICM_DB` env var | `ICM_DB=/tmp/test.db icm recall ...` |
+| 3 | Global config | `~/.config/icm/config.toml [store].path` |
+| 4 | `.icm/config.toml` | `<project>/.icm/config.toml [store].path` |
+| 5 | `.icm/memories.db` | Auto-detected at git root (if file exists) |
+| 6 | Platform default | `~/.local/share/icm/memories.db` |
+
+Run `icm config` to see the active resolution chain with source tracing.
 
 This auto-detects your AI tools and configures the MCP server. Supports 14 tools: Claude Code, Claude Desktop, Cursor, Windsurf, VS Code, Gemini, Zed, Amp, Amazon Q, Cline, Roo Code, Kilo Code, Codex CLI, OpenCode.
 

--- a/plugins/opencode-icm.ts
+++ b/plugins/opencode-icm.ts
@@ -15,8 +15,11 @@
 import type { Plugin } from "@opencode-ai/plugin"
 import { execFileSync, spawn } from "child_process"
 
+// Tools whose output is not worth extracting (file writes, questions, tracking)
+const NOISE_TOOLS = new Set(["Edit", "Write", "Question", "skill", "todowrite", "notify", "notification"])
+
 // Capture tool output every N tool calls...
-const EXTRACT_EVERY = 3
+const EXTRACT_EVERY = 10
 // ...but only drain the extraction queue (the step that loads the
 // fastembed model) once per N enqueues. Issue #239: running a full
 // `icm extract` on every 3rd tool call reloaded the embedding model
@@ -30,13 +33,14 @@ let enqueueCount = 0
 
 /// Enqueue raw text for deferred extraction. `icm extract --enqueue`
 /// only writes a queue row — it never loads the embedding model.
-function icmEnqueue(project: string, input: string): void {
+function icmEnqueue(project: string, input: string, cwd?: string): void {
   try {
     execFileSync("icm", ["extract", "--enqueue", "-p", project], {
       encoding: "utf-8",
       timeout: 10000,
       input,
       stdio: ["pipe", "pipe", "pipe"],
+      cwd,
     })
   } catch {
     // silent — extraction is best-effort
@@ -46,11 +50,12 @@ function icmEnqueue(project: string, input: string): void {
 /// Drain the pending-extraction queue in a detached background process.
 /// Fire-and-forget: the chat turn never waits on it, and the heavy
 /// fastembed model load happens at most once per drain.
-function icmDrainDetached(): void {
+function icmDrainDetached(cwd?: string): void {
   try {
     const child = spawn("icm", ["extract-pending", "--limit", "30"], {
       detached: true,
       stdio: "ignore",
+      cwd,
     })
     child.unref()
   } catch {
@@ -61,12 +66,13 @@ function icmDrainDetached(): void {
 /// Capture stdout of `icm <args>` synchronously. Returns the empty string on
 /// any failure so a missing/old binary or empty memory store can never break
 /// a chat turn.
-function icmCapture(args: string[]): string {
+function icmCapture(args: string[], cwd?: string): string {
   try {
     const out = execFileSync("icm", args, {
       encoding: "utf-8",
       timeout: 10000,
       stdio: ["ignore", "pipe", "pipe"],
+      cwd,
     })
     return String(out).trim()
   } catch {
@@ -98,6 +104,7 @@ export const IcmPlugin: Plugin = async ({ $, directory }) => {
     "tool.execute.after": async (input: any, result: any) => {
       const tool = String(input?.tool ?? "")
       if (!tool || tool.startsWith("icm") || tool.startsWith("mcp__icm__")) return
+      if (NOISE_TOOLS.has(tool)) return
 
       toolCallCount++
       if (toolCallCount < EXTRACT_EVERY) return
@@ -110,11 +117,11 @@ export const IcmPlugin: Plugin = async ({ $, directory }) => {
 
       // Enqueue only (cheap, no model load), then drain once per
       // DRAIN_EVERY enqueues in a detached process — see issue #239.
-      icmEnqueue(project, output.slice(0, 8000))
+      icmEnqueue(project, output.slice(0, 8000), directory)
       enqueueCount++
       if (enqueueCount >= DRAIN_EVERY) {
         enqueueCount = 0
-        icmDrainDetached()
+        icmDrainDetached(directory)
       }
     },
 
@@ -141,9 +148,9 @@ export const IcmPlugin: Plugin = async ({ $, directory }) => {
 
       // Compaction is a natural flush point: enqueue the conversation
       // slice and drain the whole queue once in a detached process.
-      icmEnqueue(project, text)
+      icmEnqueue(project, text, directory)
       enqueueCount = 0
-      icmDrainDetached()
+      icmDrainDetached(directory)
     },
 
     // Layer 2: log on session creation. OpenCode's `session.created` hook
@@ -168,13 +175,13 @@ export const IcmPlugin: Plugin = async ({ $, directory }) => {
       injectedSessions.add(sessionID)
 
       // Wake-up pack: critical/high-importance facts + preferences.
-      const wakeUp = icmCapture(["wake-up", "--project", project])
+      const wakeUp = icmCapture(["wake-up", "--project", project], directory)
       if (wakeUp) {
         output.system.push(wakeUp)
       }
 
       // Project-scoped recall: top-N relevant memories for this project.
-      const ctx = icmCapture(["recall-project", "--limit", "5"])
+      const ctx = icmCapture(["recall-project", "--project", project, "--limit", "5"], directory)
       if (ctx) {
         output.system.push(ctx)
         console.error(


### PR DESCRIPTION
Rebase + finish of #257 (closed as stale after 13 days of no response — same content, cherry-picked onto current `develop` and re-verified). Full credit to @Acharnite / Kiffer for the original design and implementation.

## Summary

Replaces the simple `--db`-or-default path logic with a 6-level hierarchical resolution chain, so users don't need wrapper scripts or hardcoded paths to work across multiple projects — and closes a real, separately-discovered bug along the way: **`ICM_DB` was documented in `--db`'s help text but never actually read anywhere in the code.** This PR makes it real.

### Resolution chain (highest priority first)

| Level | Source | Example |
|-------|--------|---------|
| 1 | `--db` CLI flag | `icm --db /tmp/test.db store ...` |
| 2 | `ICM_DB` env var | `ICM_DB=/tmp/icm.db icm recall ...` |
| 3 | Global config `[store].path` | `~/.config/icm/config.toml` |
| 4 | Project-local `.icm/config.toml` `[store].path` | Git root auto-detection |
| 5 | Project-local `.icm/memories.db` | Auto-detected at git root (if file exists) |
| 6 | Platform default data directory | `~/.local/share/icm/memories.db` |

- `resolve_db_path(cli_db, cfg) → PathBuf` centralizes resolution; `open_store`/`open_store_with_backup`/`open_store_readonly` simplified from `Option<PathBuf>` to a pre-resolved `PathBuf`.
- `icm init --per-project` creates `.icm/config.toml` with `[store] path = ".icm/memories.db"`.
- `icm config` shows the full resolution chain with source tracing.
- Fully backward compatible — `--db` still works identically, the platform default is unchanged.

## What changed since the original #257

- Rebased onto current `develop` (moved a lot since May — dedup fix, embeddings 4→6, onnxruntime pin, the #179 consolidation queue, etc.). The multi-backend `Store` enum (Postgres/OpenSearch, shipped after this PR was opened) is preserved — the original branch predated that work and hardcoded `SqliteStore`.
- Fixed a real inconsistency between the first two original commits: the initial `.icm/config.toml` template wrote `path = "memories.db"` (resolving to `<project-root>/memories.db`, not inside `.icm/`) — the second commit's own fix (`.icm/memories.db`) is the one that survived the rebase.
- Added unit test coverage for `resolve_db_path` (none existed before): each priority level winning over the ones below it, project-local `.icm/config.toml` beating a bare `.icm/memories.db`, and the platform-default fallback both outside any git repo and inside one with no `.icm/` yet.

## Test plan

- [x] `cargo test --workspace` (378 in icm-cli + full workspace, all green) including 7 new `resolve_db_path` tests.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` / `cargo fmt --check` clean.
- [x] Real-binary verification: `ICM_DB` env var now actually works; `--db` still wins over it; a project-local `.icm/memories.db` (git-root auto-detected) is picked up when nothing else is set; `icm init --per-project` creates the config and `icm config` correctly resolves through it afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)