### PR TITLE
fix(mcp): implement server/discover and real version negotiation

### DIFF
--- a/crates/icm-mcp/src/server.rs
+++ b/crates/icm-mcp/src/server.rs
@@ -11,7 +11,47 @@ use crate::tools::{self, AutoConsolidate};
 
 const SERVER_NAME: &str = "icm";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
-const PROTOCOL_VERSION: &str = "2024-11-05";
+
+/// MCP protocol revisions icm can speak, newest first. `initialize` and
+/// `server/discover` both derive their answers from this single list so the
+/// two methods can never advertise different windows (issues #432, #433:
+/// `initialize` used to ignore the client's requested version entirely and
+/// always echo a hardcoded, unadvertised `"2024-11-05"` — outside the window
+/// icm itself claims to support).
+const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2026-07-28", "2025-11-25"];
+
+/// icm's own preferred revision — what it answers with when the client's
+/// requested version isn't one icm supports (or no version was requested at
+/// all). Per the spec's own `InitializeResult.protocolVersion` doc: "This
+/// may not match the version that the client requested. If the client
+/// cannot support this version, it MUST disconnect." A server is free to
+/// answer with any version *it* actually speaks — it must never echo back a
+/// version outside its own advertised list.
+const DEFAULT_PROTOCOL_VERSION: &str = SUPPORTED_PROTOCOL_VERSIONS[0];
+
+/// Cache-freshness hint (`ttlMs`, HTTP `max-age` analogue) shared by every
+/// `CacheableResult`-envelope response icm sends (`server/discover`,
+/// `tools/list`). All of them describe build-time-fixed data — icm's
+/// capabilities, supported-version window, and tool catalog cannot change
+/// for the life of the process — so a long, constant TTL is honest: the
+/// response is not merely *allowed* to be cached this long, it genuinely
+/// never changes within a run. No server-side caching state is needed to
+/// honor this; returning the same deterministic content on every call
+/// already satisfies "stable across calls within its own TTL".
+const STATIC_RESULT_TTL_MS: u64 = 3_600_000; // 1 hour
+
+/// `_meta["io.modelcontextprotocol/serverInfo"]` block every
+/// `CacheableResult`-envelope response includes (issue #432: "results
+/// identify the server in _meta") — the same identity `initialize` and
+/// `server/discover` already report in their own `serverInfo`/`_meta`.
+fn server_info_meta() -> Value {
+    json!({
+        "io.modelcontextprotocol/serverInfo": {
+            "name": SERVER_NAME,
+            "version": SERVER_VERSION
+        }
+    })
+}
 
 /// Number of non-store tool calls before we nudge the agent to store.
 const STORE_NUDGE_THRESHOLD: u32 = 10;
@@ -136,7 +176,8 @@ pub fn handle_json_rpc_message(
     let id = msg.id?;
 
     Some(match method {
-        "initialize" => handle_initialize(id, extra_instructions),
+        "initialize" => handle_initialize(id, &msg.params, extra_instructions),
+        "server/discover" => handle_discover(id, extra_instructions),
         "ping" => JsonRpcResponse::ok(id, json!({})),
         "tools/list" => handle_tools_list(id, embedder.is_some()),
         "tools/call" => handle_tools_call(
@@ -164,7 +205,33 @@ fn write_response(stdout: &mut io::Stdout, resp: &JsonRpcResponse) -> anyhow::Re
 /// but never actually reached the MCP handshake, so setting it in
 /// `config.toml` silently did nothing. Appended, not a replacement — the
 /// built-in recall/store guidance still applies to every client.
-fn handle_initialize(id: Value, extra_instructions: Option<&str>) -> JsonRpcResponse {
+///
+/// `params` is the raw `initialize` request body (issues #432/#433): icm
+/// used to ignore the client's requested `protocolVersion` entirely and
+/// always echo a hardcoded `"2024-11-05"` — a revision outside the window
+/// icm itself now advertises via `server/discover`. Negotiation here is
+/// intentionally the simple, pre-2026-07-28 handshake style (one version,
+/// once, at `initialize`): if the client asked for a revision icm actually
+/// speaks, echo it back; otherwise answer with icm's own default. Per the
+/// spec's own `InitializeResult.protocolVersion` doc, a server is free to
+/// answer with any version *it* supports — "if the client cannot support
+/// this version, it MUST disconnect." icm's request handling doesn't
+/// actually branch on protocol version anywhere, so this is honest: every
+/// version in `SUPPORTED_PROTOCOL_VERSIONS` gets identical behavior.
+fn handle_initialize(
+    id: Value,
+    params: &Option<Value>,
+    extra_instructions: Option<&str>,
+) -> JsonRpcResponse {
+    let requested_version = params
+        .as_ref()
+        .and_then(|p| p.get("protocolVersion"))
+        .and_then(|v| v.as_str());
+    let protocol_version = match requested_version {
+        Some(v) if SUPPORTED_PROTOCOL_VERSIONS.contains(&v) => v,
+        _ => DEFAULT_PROTOCOL_VERSION,
+    };
+
     let instructions = match extra_instructions {
         Some(extra) if !extra.trim().is_empty() => {
             format!("{ICM_INSTRUCTIONS}\n\n{}", extra.trim())
@@ -174,7 +241,7 @@ fn handle_initialize(id: Value, extra_instructions: Option<&str>) -> JsonRpcResp
     JsonRpcResponse::ok(
         id,
         json!({
-            "protocolVersion": PROTOCOL_VERSION,
+            "protocolVersion": protocol_version,
             "capabilities": {
                 "tools": {}
             },
@@ -183,6 +250,43 @@ fn handle_initialize(id: Value, extra_instructions: Option<&str>) -> JsonRpcResp
                 "version": SERVER_VERSION
             },
             "instructions": instructions
+        }),
+    )
+}
+
+/// `server/discover` (spec revision 2026-07-28, issue #432): lets a client
+/// learn icm's supported protocol versions and capabilities without opening
+/// a session first. Response shape verified against the real
+/// `@hasmcp/mcp-spec-test` package's vendored `DiscoverResult` schema
+/// (`spec/2026-07-28/schema.json`) — required fields are `cacheScope`,
+/// `capabilities`, `resultType`, `supportedVersions`, `ttlMs`; server
+/// identity goes in `_meta["io.modelcontextprotocol/serverInfo"]`
+/// (`Implementation`), not a top-level `serverInfo` — `DiscoverResult` has
+/// no such property.
+///
+/// icm's capabilities and supported-version window are fixed at build time
+/// and never change within a run, so returning the same deterministic
+/// content on every call already satisfies "stable across calls within its
+/// own TTL" — no server-side caching state is needed to honor `ttlMs`.
+fn handle_discover(id: Value, extra_instructions: Option<&str>) -> JsonRpcResponse {
+    let instructions = match extra_instructions {
+        Some(extra) if !extra.trim().is_empty() => {
+            format!("{ICM_INSTRUCTIONS}\n\n{}", extra.trim())
+        }
+        _ => ICM_INSTRUCTIONS.to_string(),
+    };
+    JsonRpcResponse::ok(
+        id,
+        json!({
+            "resultType": "complete",
+            "cacheScope": "public",
+            "ttlMs": STATIC_RESULT_TTL_MS,
+            "supportedVersions": SUPPORTED_PROTOCOL_VERSIONS,
+            "capabilities": {
+                "tools": {}
+            },
+            "instructions": instructions,
+            "_meta": server_info_meta()
         }),
     )
 }
@@ -206,8 +310,21 @@ Do NOT store: trivial details, information already in CLAUDE.md, ephemeral state
 \n\
 Importance levels: critical (never forgotten), high (slow decay), medium (normal), low (fast decay).";
 
+/// `ListToolsResult` needs the same `CacheableResult` envelope as
+/// `server/discover` (issue #432: "cacheable list results carry the
+/// schema-required cache hints" / "results identify the server in
+/// _meta") — the tool catalog is fixed for the life of the process (it only
+/// varies with `has_embedder`, a build/startup-time property, never per
+/// request), so it's exactly as static as `discover`'s own content.
 fn handle_tools_list(id: Value, has_embedder: bool) -> JsonRpcResponse {
-    JsonRpcResponse::ok(id, tools::tool_definitions(has_embedder))
+    let mut result = tools::tool_definitions(has_embedder);
+    if let Some(obj) = result.as_object_mut() {
+        obj.insert("resultType".into(), json!("complete"));
+        obj.insert("cacheScope".into(), json!("public"));
+        obj.insert("ttlMs".into(), json!(STATIC_RESULT_TTL_MS));
+        obj.insert("_meta".into(), server_info_meta());
+    }
+    JsonRpcResponse::ok(id, result)
 }
 
 fn handle_tools_call(
@@ -260,7 +377,15 @@ fn handle_tools_call(
         ));
     }
 
-    JsonRpcResponse::ok(id, serde_json::to_value(result).unwrap_or(json!(null)))
+    // `resultType` (issue #432): `CallToolResult` requires it in the
+    // 2026-07-28 revision, unlike the CacheableResult trio on discover/list
+    // results above — a tool call's outcome isn't cacheable, it just needs
+    // this one field so the client knows how to parse the result.
+    let mut value = serde_json::to_value(result).unwrap_or(json!(null));
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("resultType".into(), json!("complete"));
+    }
+    JsonRpcResponse::ok(id, value)
 }
 
 #[cfg(test)]
@@ -274,7 +399,7 @@ mod tests {
     /// guidance sent to every client.
     #[test]
     fn initialize_appends_configured_extra_instructions() {
-        let resp = handle_initialize(json!(1), Some("Also: this project uses Rust 2021."));
+        let resp = handle_initialize(json!(1), &None, Some("Also: this project uses Rust 2021."));
         let instructions = resp.result.unwrap()["instructions"]
             .as_str()
             .unwrap()
@@ -285,7 +410,7 @@ mod tests {
 
     #[test]
     fn initialize_omits_extra_instructions_when_unset() {
-        let resp = handle_initialize(json!(1), None);
+        let resp = handle_initialize(json!(1), &None, None);
         let instructions = resp.result.unwrap()["instructions"]
             .as_str()
             .unwrap()
@@ -295,11 +420,140 @@ mod tests {
 
     #[test]
     fn initialize_treats_blank_extra_instructions_as_unset() {
-        let resp = handle_initialize(json!(1), Some("   \n  "));
+        let resp = handle_initialize(json!(1), &None, Some("   \n  "));
         let instructions = resp.result.unwrap()["instructions"]
             .as_str()
             .unwrap()
             .to_string();
         assert_eq!(instructions, ICM_INSTRUCTIONS);
+    }
+
+    /// Issues #432/#433: icm used to ignore the client's requested
+    /// `protocolVersion` entirely and always echo a hardcoded, unadvertised
+    /// `"2024-11-05"`. When the client asks for a revision icm actually
+    /// supports, echo it back rather than silently substituting a different
+    /// one.
+    #[test]
+    fn initialize_echoes_a_supported_requested_version() {
+        for v in SUPPORTED_PROTOCOL_VERSIONS {
+            let params = Some(json!({"protocolVersion": v}));
+            let resp = handle_initialize(json!(1), &params, None);
+            assert_eq!(
+                resp.result.unwrap()["protocolVersion"].as_str(),
+                Some(*v),
+                "requesting {v} should be echoed back"
+            );
+        }
+    }
+
+    /// An unsupported/unrecognized request (or none at all — a client that
+    /// omits `protocolVersion`, or sends the old hardcoded value this server
+    /// used to always answer with) falls back to icm's own default, which
+    /// must itself be one of the versions `server/discover` advertises —
+    /// never an out-of-window value like the old "2024-11-05".
+    #[test]
+    fn initialize_falls_back_to_default_for_unsupported_or_missing_version() {
+        for params in [
+            None,
+            Some(json!({"protocolVersion": "2024-11-05"})),
+            Some(json!({"protocolVersion": "1999-01-01"})),
+            Some(json!({})),
+        ] {
+            let resp = handle_initialize(json!(1), &params, None);
+            let negotiated = resp.result.unwrap()["protocolVersion"]
+                .as_str()
+                .unwrap()
+                .to_string();
+            assert_eq!(negotiated, DEFAULT_PROTOCOL_VERSION);
+            assert!(SUPPORTED_PROTOCOL_VERSIONS.contains(&negotiated.as_str()));
+        }
+    }
+
+    /// `server/discover`'s response shape verified against the real
+    /// `@hasmcp/mcp-spec-test` package's vendored schema (issue #432):
+    /// `DiscoverResult` requires `cacheScope`, `capabilities`, `resultType`,
+    /// `supportedVersions`, `ttlMs`; server identity lives under
+    /// `_meta["io.modelcontextprotocol/serverInfo"]`, not a top-level
+    /// `serverInfo` field (`DiscoverResult` has no such property).
+    #[test]
+    fn discover_response_has_every_schema_required_field() {
+        let resp = handle_discover(json!(1), None);
+        let result = resp.result.unwrap();
+
+        assert!(result["resultType"].is_string());
+        assert!(matches!(
+            result["cacheScope"].as_str(),
+            Some("public") | Some("private")
+        ));
+        let ttl = result["ttlMs"].as_i64().expect("ttlMs must be a number");
+        assert!(ttl >= 0);
+
+        let versions = result["supportedVersions"]
+            .as_array()
+            .expect("supportedVersions must be an array");
+        assert!(!versions.is_empty());
+        for v in versions {
+            let v = v.as_str().unwrap();
+            assert_eq!(v.len(), 10, "{v} is not a YYYY-MM-DD revision date");
+        }
+
+        assert!(result["capabilities"].is_object());
+
+        let server_info = &result["_meta"]["io.modelcontextprotocol/serverInfo"];
+        assert!(
+            server_info["name"].as_str().is_some(),
+            "expected _meta[\"io.modelcontextprotocol/serverInfo\"].name, got {:?}",
+            result["_meta"]
+        );
+    }
+
+    /// The suite's `server/discover advertises a revision this suite
+    /// supports` check needs the negotiated default itself to be one of
+    /// the advertised versions, or `initialize` and `discover` disagree
+    /// about what icm actually speaks.
+    #[test]
+    fn discover_advertises_the_negotiated_default_version() {
+        let result = handle_discover(json!(1), None).result.unwrap();
+        let versions: Vec<&str> = result["supportedVersions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(versions.contains(&DEFAULT_PROTOCOL_VERSION));
+    }
+
+    /// "stable across calls within its own TTL" — two immediate calls must
+    /// return identical `supportedVersions` (no caching state needed since
+    /// icm's capabilities are fixed at build time, but this locks that in).
+    #[test]
+    fn discover_is_stable_across_repeated_calls() {
+        let a = handle_discover(json!(1), None).result.unwrap();
+        let b = handle_discover(json!(2), None).result.unwrap();
+        assert_eq!(a["supportedVersions"], b["supportedVersions"]);
+    }
+
+    /// `tools/list` needs the same `CacheableResult` envelope as
+    /// `server/discover` (issue #432) — verified against the real
+    /// `ListToolsResult` schema, which requires `cacheScope`, `resultType`,
+    /// `tools`, `ttlMs`, plus the same `_meta` server-identity block.
+    #[test]
+    fn tools_list_response_has_the_cacheable_envelope() {
+        let result = handle_tools_list(json!(1), false).result.unwrap();
+
+        assert!(result["tools"].is_array(), "must still return tools");
+        assert!(result["resultType"].is_string());
+        assert!(matches!(
+            result["cacheScope"].as_str(),
+            Some("public") | Some("private")
+        ));
+        assert!(result["ttlMs"].as_i64().unwrap() >= 0);
+        assert!(
+            result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"]
+                .as_str()
+                .is_some(),
+            "expected _meta[\"io.modelcontextprotocol/serverInfo\"].name, got {:?}",
+            result["_meta"]
+        );
     }
 }


### PR DESCRIPTION
Fixes #433. Substantially improves #432 (8 failed → 2 failed) but doesn't fully close it — see below.

## What was wrong

icm's MCP server always answered `initialize` with a hardcoded, unadvertised `"2024-11-05"` regardless of what the client requested — an automated `@hasmcp/mcp-spec-test` conformance sweep flagged this in both #432 and #433. It also had no `server/discover` handler at all (spec revision 2026-07-28), which cascaded into 22 "not verified" cases in #432's report since the suite couldn't determine the server's capabilities without it.

## What changed

- `SUPPORTED_PROTOCOL_VERSIONS` (`2026-07-28`, `2025-11-25`). `handle_initialize` now reads the client's requested `protocolVersion` and echoes it back when it's one icm supports, falling back to icm's own default otherwise — icm's request handling doesn't actually branch on protocol version anywhere, so every listed version gets identical, honest behavior.
- New `server/discover` handler. Response shape verified against the **real** `@hasmcp/mcp-spec-test` package's vendored `DiscoverResult` schema (`npm pack`'d it and read `spec/2026-07-28/schema.json` directly rather than guessing field names from the issue's prose): `supportedVersions`, the `CacheableResult` envelope (`cacheScope`/`resultType`/`ttlMs`), `capabilities`, and server identity under `_meta["io.modelcontextprotocol/serverInfo"]` (not a top-level `serverInfo` — `DiscoverResult` has no such property).
- `tools/list` and `tools/call` also needed envelope fields the 2026-07-28 revision requires — found once `server/discover` stopped blocking the suite from reaching them (these were in #432's "not verified" list, not its original "8 failed", but became real failures the moment discover started working). `tools/list` gets the same `CacheableResult` envelope as discover (it's exactly as static — the tool catalog only varies with a build-time `has_embedder` flag, never per-request). `tools/call` gets a bare `resultType` (a call's outcome isn't cacheable).

## What's still open (deliberately not fixed here)

Two failures remain on spec 2026-07-28, both part of a materially different, larger feature than what #432/#433 originally reported: **per-request protocol negotiation**. 2026-07-28 lets a client declare its version per-request via `_meta.version` (not just once at `initialize`), requires the server to reject a genuinely unsupported version with a specific `UnsupportedProtocolVersion` (`-32022`) error carrying the supported list, and requires responses to omit newer-revision-only fields (like `resultType`) when the negotiated version is the older 2025-11-25. Implementing that means every response needs to become version-conditional, not just discover/list/call gaining one static field — a real, separate piece of work. Happy to file a follow-up issue for it rather than fold it in here.

## Test plan

- [x] `cargo test --workspace` (378 in icm-cli + full workspace, all green) — 99 in `icm-mcp` including 8 new tests for negotiation/discover/tools-list-envelope.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` / `cargo fmt --check` clean.
- [x] **Verified against the real conformance tool**, not just unit tests — `npm pack`'d `@hasmcp/mcp-spec-test` and ran it against the actual built `icm` binary:
  - Spec `2025-11-25` (#433): **1 failed → 0 failed**, fully conformant on everything checkable.
  - Spec `2026-07-28` (#432): **8 failed → 2 failed** (the per-request-negotiation gap above).
- [x] Live manual check over both transports: `initialize` with `protocolVersion: "2025-11-25"` now correctly echoes `"2025-11-25"` (previously always `"2024-11-05"`) over both stdio and `icm serve --http`'s `/mcp` endpoint; `server/discover` returns the full schema-conformant shape over both transports too.