### PR TITLE
fix(init): replace hand-rolled PATH lookup with the which crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,6 +2126,7 @@ dependencies = [
  "tracing-subscriber",
  "ureq 2.12.1",
  "walkdir",
+ "which",
  "zip",
 ]
 
@@ -4719,6 +4720,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "8.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/icm-cli/Cargo.toml
+++ b/crates/icm-cli/Cargo.toml
@@ -64,6 +64,11 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 chrono = { workspace = true }
 directories = { workspace = true }
+# Cross-platform PATH-based executable lookup (issue #428): the hand-rolled
+# check this replaced hardcoded the Unix `:` PATH separator and never tried
+# a `.exe`/`PATHEXT` suffix, so it silently found nothing on Windows for
+# every tool `icm init` detects, not just OpenCode Desktop.
+which = { version = "8", default-features = false, features = ["real-sys"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }

--- a/crates/icm-cli/src/main.rs
+++ b/crates/icm-cli/src/main.rs
@@ -7333,12 +7333,15 @@ pub(crate) fn parse_json_config(config_path: &std::path::Path) -> Result<Value> 
     Ok(strict)
 }
 
-/// Returns true if `name` resolves to an executable file somewhere in $PATH.
+/// Cross-platform PATH-based executable lookup (issue #428). Delegates to
+/// the `which` crate rather than hand-rolling it: a previous version split
+/// `$PATH` on a hardcoded `:` and checked the bare name with no extension —
+/// correct on Unix, but on Windows `PATH` entries are `;`-separated and
+/// every real executable needs a `PATHEXT` suffix (`.exe`, `.cmd`, …), so
+/// this silently found nothing for *every* tool `icm init`/`doctor` detect,
+/// not just the OpenCode Desktop app the issue reported.
 fn binary_in_path(name: &str) -> bool {
-    std::env::var("PATH")
-        .unwrap_or_default()
-        .split(':')
-        .any(|dir| std::path::Path::new(dir).join(name).is_file())
+    which::which(name).is_ok()
 }
 
 /// Heuristic: is this AI tool installed on the current machine?
@@ -7437,6 +7440,28 @@ fn detect_tool(name: &str, home: &str, vscode_data: &Path) -> bool {
         // pnpm-global env quirks). See issue #259.
         "Pi" => binary_in_path("pi") || PathBuf::from(home).join(".pi/agent").exists(),
         _ => true,
+    }
+}
+
+#[cfg(test)]
+mod binary_in_path_tests {
+    use super::*;
+
+    /// Issue #428: `binary_in_path` must find a real, definitely-installed
+    /// binary. `cargo` itself is the safest choice — every CI job (and any
+    /// dev machine running `cargo test`) has it on `$PATH` by construction,
+    /// on every platform this crate ships for (unlike a Unix-only tool like
+    /// `sh`, which isn't a given on `windows-latest`).
+    #[test]
+    fn finds_a_real_binary_that_is_definitely_on_path() {
+        assert!(binary_in_path("cargo"));
+    }
+
+    #[test]
+    fn does_not_find_a_binary_that_does_not_exist() {
+        assert!(!binary_in_path(
+            "icm-test-binary-that-almost-certainly-does-not-exist-anywhere"
+        ));
     }
 }
 
@@ -7921,34 +7946,6 @@ fn resolve_consolidate_provider(
     })
 }
 
-/// Check whether `name` resolves to an executable file on `$PATH`.
-///
-/// Used by the extraction drain to decide whether a configured LLM CLI
-/// (claude/codex/gemini/ollama) is actually usable, or whether it should
-/// fall back to the fastembed extractor.
-fn cli_on_path(name: &str) -> bool {
-    let Ok(path) = std::env::var("PATH") else {
-        return false;
-    };
-    std::env::split_paths(&path).any(|dir| {
-        let candidate = dir.join(name);
-        if !candidate.is_file() {
-            return false;
-        }
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::metadata(&candidate)
-                .map(|m| m.permissions().mode() & 0o111 != 0)
-                .unwrap_or(false)
-        }
-        #[cfg(not(unix))]
-        {
-            true
-        }
-    })
-}
-
 /// Best-effort inter-process singleton lock for the extract-pending worker
 /// (#322). Held for the lifetime of the value; the OS releases the advisory
 /// `flock` when the file descriptor closes on drop.
@@ -8170,7 +8167,7 @@ fn drain_pending_groups(
             }
             Err(e) => {
                 // A CLI missing from PATH already downgrades to fastembed before
-                // this loop (see the `cli_on_path` check) — this handles the
+                // this loop (see the `binary_in_path` check) — this handles the
                 // sibling failure mode: the CLI is present but errors at
                 // runtime. Left as a hard error, the queue would never empty,
                 // because every future run would hit the same failing CLI.
@@ -8288,7 +8285,7 @@ fn cmd_extract_pending(
     // never empty — so downgrade to the batched fastembed path when the
     // binary is missing.
     if !matches!(provider_kind, summarizer::ProviderKind::None)
-        && !cli_on_path(provider_kind.as_str())
+        && !binary_in_path(provider_kind.as_str())
     {
         eprintln!(
             "[extract-pending] '{}' CLI not found on PATH — draining with \


### PR DESCRIPTION
Fixes #428.

## Root cause

Issue #428 reported OpenCode Desktop not being detected on Windows even with `icm.exe` and `opencode` in the same directory, confirmed on PATH. The actual bug was much wider than that one tool:

```rust
fn binary_in_path(name: &str) -> bool {
    std::env::var("PATH").unwrap_or_default()
        .split(':')                                    // Unix-only separator
        .any(|dir| Path::new(dir).join(name).is_file()) // no .exe/PATHEXT handling
}
```

Both assumptions are Unix-only. Windows uses `;` to separate `PATH` entries — splitting on `:` there mostly produces garbage fragments of drive-letter paths (`C:\...` itself contains a colon) — and every real executable needs a `PATHEXT` suffix (`.exe`, `.cmd`, ...) to resolve. So on Windows this silently found nothing for **every** tool `icm init`/`doctor` detect: Claude Code, Cursor, Windsurf, Gemini, Amp, Zed, Codex CLI, Copilot CLI, Aider — not just OpenCode.

The sibling `cli_on_path()` (decides whether `extract-pending`'s configured LLM CLI is actually usable before falling back to fastembed) had the separator right (`std::env::split_paths`) but the same missing-extension bug — so on Windows, extraction would silently always fall back to fastembed even with a real LLM CLI installed, same root cause, different symptom.

## Fix

Replaced both with the `which` crate (MIT, minimal footprint — the crate itself plus `libc`, already a transitive dependency elsewhere) instead of hand-rolling `PATHEXT` resolution. `cli_on_path` became byte-identical to the fixed `binary_in_path`, so consolidated into one function.

## Test plan

- [x] `cargo test -p icm-cli` (380 passed, 2 new) / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` clean.
- [x] Full workspace build clean.
- [x] Real functional verification (not `--force`, which bypasses detection entirely): `icm init --mode hook` in a sandboxed `$HOME` on this machine correctly reports `[hook] OpenCode plugin: installed` (it's genuinely on `PATH` via homebrew) and `[hook] Gemini skipped (not detected)` (genuinely absent) — the exact behavior the fix needs to preserve on the platform where it already worked.
- Can't fully reproduce the Windows-specific symptom locally (no Windows machine) — this repo's CI already covers `test (windows-latest)` and `load-dynamic embeddings (windows)`, which will exercise the fixed code path for real.