### PR TITLE
fix(embeddings): use rustls instead of native-tls for hf-hub downloads

### DIFF
--- a/crates/icm-core/Cargo.toml
+++ b/crates/icm-core/Cargo.toml
@@ -8,7 +8,13 @@ default = []
 # `embeddings` = the embedder code + model download (hf-hub). It does NOT pick
 # an ort backend by itself; a consumer selects exactly one of the two below
 # (issue #345). This keeps every `#[cfg(feature = "embeddings")]` unchanged.
-embeddings = ["fastembed", "directories", "cachedir", "fastembed/hf-hub-native-tls"]
+# rustls-tls (not native-tls): native-tls pulls openssl-sys on Linux, which
+# needs a system OpenSSL + pkg-config at build time — breaks builds on
+# environments with no OpenSSL dev headers (e.g. homebrew-core's Linux
+# bottling CI, issue #345). rustls is vendored, so this removes the
+# dependency entirely rather than just working around it in one packaging
+# channel.
+embeddings = ["fastembed", "directories", "cachedir", "fastembed/hf-hub-rustls-tls"]
 # Static onnxruntime downloaded at build time (default; needs network at build).
 embeddings-static = ["embeddings", "fastembed/ort-download-binaries"]
 # onnxruntime loaded dynamically at runtime — builds with NO network, so the


### PR DESCRIPTION
## Summary
- Switch the `embeddings` feature's `hf-hub` TLS backend from `native-tls` to `rustls-tls`

## Why
Found while investigating a homebrew-core build failure for issue #345: `native-tls` pulls `openssl-sys` on Linux, which needs a system OpenSSL install + pkg-config to be found at build time. This broke the build on homebrew-core's Linux bottling CI (no OpenSSL dev headers). It went unnoticed locally because `native-tls` uses Secure Transport on macOS — no OpenSSL involved there at all.

`fastembed` ships a ready-made `hf-hub-rustls-tls` feature. Switching to it removes the OpenSSL dependency entirely, on every platform, rather than just working around it for one packaging channel (e.g. adding `depends_on "openssl@3"` to the Homebrew formula would have only fixed Homebrew).

Tradeoff: rustls uses a vendored/bundled root certificate store rather than the OS trust store, so it won't pick up a manually-installed corporate CA. Not expected to matter for HTTPS downloads from huggingface.co.

## Test plan
- [x] `cargo build --no-default-features -p icm-cli -F "embeddings-dynamic,backend-sqlite,tui,http-api"` — clean
- [x] `cargo tree -e features -i openssl-sys` (both native and `--target x86_64-unknown-linux-gnu`) — no longer resolves, confirming openssl-sys is gone from the graph
- [x] `cargo test --no-default-features -p icm-cli -p icm-core -F "embeddings-dynamic,backend-sqlite,tui,http-api"` — 62 passed, 0 failed
- [ ] CI (all platforms)