### PR TITLE
fix(release): document that Cargo.lock changes need a paired crate commit

### DIFF
--- a/crates/icm-cli/Cargo.toml
+++ b/crates/icm-cli/Cargo.toml
@@ -1,3 +1,9 @@
+# release-please only tracks commits touching crates/icm-cli (see
+# release-please-config.json): a workspace-root Cargo.lock change on its
+# own is invisible to it and will never trigger a release by itself
+# (issue #458). If you change a dependency that only touches Cargo.lock,
+# pair it with a real fix/feat commit under this crate's path, or the
+# lockfile update will silently sit unreleased on develop/main.
 [package]
 name = "icm-cli"
 version = "0.10.64"


### PR DESCRIPTION
## Summary
- Documents a release-please gotcha in `crates/icm-cli/Cargo.toml`, and doubles as the paired "fix under this crate's path" commit release-please needs to actually notice #456/#459's Cargo.lock fix and cut a new release.

## Why
release-please (see `release-please-config.json`) only watches commits touching `crates/icm-cli`. #456 changed `crates/icm-core/Cargo.toml`'s TLS feature, and #459 committed the resulting `Cargo.lock` regeneration — but neither touched `crates/icm-cli` itself, so release-please never saw a releasable commit for either (`Considering: 0 commits, skipping`). The fix shipped to `develop`/`main` but never went out in an actual release; today's v0.10.64 release predates it. #458 (the Nix build breakage this caused) had to be fixed by manually back-merging and is being tracked separately.

This commit is a genuine, real fix (a documentation note preventing the same mistake next time) placed under the crate path release-please actually watches, so merging it lets the normal `develop -> main -> release-please PR` flow produce a real v0.10.65 with the Cargo.lock fix included.

## Test plan
- [x] `cargo check -p icm-cli` — clean, TOML still parses correctly with the comment
- [ ] CI