### PR TITLE
chore: sync release icm-v0.10.65 into develop

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "crates/icm-cli": "0.10.64"
+  "crates/icm-cli": "0.10.65"
 }

--- a/crates/icm-cli/CHANGELOG.md
+++ b/crates/icm-cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.10.65](https://github.com/rtk-ai/icm/compare/icm-v0.10.64...icm-v0.10.65) (2026-09-08)
+
+
+### Bug Fixes
+
+* **release:** document that Cargo.lock changes need a paired crate commit ([#463](https://github.com/rtk-ai/icm/issues/463)) ([0a485c3](https://github.com/rtk-ai/icm/commit/0a485c3459c85439e1231f8e708973fa0726f4bd))
+
 ## [0.10.64](https://github.com/rtk-ai/icm/compare/icm-v0.10.63...icm-v0.10.64) (2026-09-08)
 
 

--- a/crates/icm-cli/Cargo.toml
+++ b/crates/icm-cli/Cargo.toml
@@ -6,7 +6,7 @@
 # lockfile update will silently sit unreleased on develop/main.
 [package]
 name = "icm-cli"
-version = "0.10.64"
+version = "0.10.65"
 edition = "2021"
 description = "Permanent memory for AI agents"
 license = "Apache-2.0"


### PR DESCRIPTION
Manual back-merge (same reason as #461): the automated job is gated on the full 9-target release build succeeding, and v0.10.65 partially failed the same way v0.10.64 did (unrelated upstream ort-sys/onnxruntime CDN issue). Fast-forward, no conflicts.