### PR TITLE
feat(mcp): document the memoir layer in the built-in agent instructions

### DIFF
--- a/crates/icm-mcp/src/server.rs
+++ b/crates/icm-mcp/src/server.rs
@@ -308,7 +308,15 @@ Do this BEFORE responding to the user. Not after. Not later. Immediately.\n\
 \n\
 Do NOT store: trivial details, information already in CLAUDE.md, ephemeral state.\n\
 \n\
-Importance levels: critical (never forgotten), high (slow decay), medium (normal), low (fast decay).";
+Importance levels: critical (never forgotten), high (slow decay), medium (normal), low (fast decay).\n\
+\n\
+MEMOIR (icm_memoir_create / icm_memoir_add_concept / icm_memoir_refine): a separate, permanent \
+knowledge layer — unlike memory_store, concepts here never decay or get pruned. Reach for it, not \
+memory_store, for durable foundational knowledge a project will keep relying on indefinitely: \
+canonical architecture decisions, stable domain/API definitions, core conventions — not day-to-day \
+context, which belongs in memory_store and is expected to fade. Create one memoir per project, then \
+icm_memoir_add_concept as durable facts emerge; use icm_memoir_refine to update an existing concept \
+rather than adding a duplicate.";
 
 /// `ListToolsResult` needs the same `CacheableResult` envelope as
 /// `server/discover` (issue #432: "cacheable list results carry the


### PR DESCRIPTION
## Summary
- `ICM_INSTRUCTIONS` (sent to every MCP client on `initialize`) covers `icm_memory_store`/`icm_memory_recall` in detail but never mentions the memoir tools (`icm_memoir_create`/`icm_memoir_add_concept`/`icm_memoir_refine`) at all.

## Why
The memoir layer (permanent, non-decaying concepts, distinct from regular decaying memories) is real, tested, and exposed via MCP — but nothing in the built-in instructions ever prompts an agent to use it. Found this while testing the new graph dashboard against a real production store: 3286 regular memories, 0 memoirs, because no agent had ever been told the feature exists. Adds a short section explaining what memoirs are for and when to reach for them instead of `memory_store`.

## Test plan
- [x] `cargo test -p icm-mcp` — 99 passed
- [x] `cargo clippy -p icm-mcp --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p icm-mcp -- --check` — clean
- [ ] CI